### PR TITLE
[core] Add mosaic-core crate with format spec, reader, and writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --all-targets
+
+      - name: Test
+        run: cargo test
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Format check
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[workspace]
+members = ["core"]
+resolver = "2"
+
+[profile.release]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "mosaic-core"
+version = "0.1.0"
+edition = "2021"
+description = "Mosaic file format — core Rust library"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+zstd = "0.13"
+arrow-schema = "58"
+arrow-array = "58"
+arrow-buffer = "58"

--- a/core/src/bpe.rs
+++ b/core/src/bpe.rs
@@ -1,0 +1,136 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+
+const TOKEN_BASE: usize = 0x80;
+const MAX_RULES: usize = 128;
+
+pub fn is_ascii_only(names: &[&[u8]]) -> bool {
+    names.iter().all(|name| name.iter().all(|&b| b & 0x80 == 0))
+}
+
+pub fn build_vocabulary(names: &[&[u8]]) -> Vec<[u8; 2]> {
+    let mut tokens: Vec<Vec<u16>> = names
+        .iter()
+        .map(|name| name.iter().map(|&b| b as u16).collect())
+        .collect();
+
+    let mut rules = Vec::new();
+
+    for _ in 0..MAX_RULES {
+        let mut pair_counts: HashMap<u32, u32> = HashMap::new();
+        for seq in &tokens {
+            for w in seq.windows(2) {
+                let pair = (w[0] as u32) << 16 | w[1] as u32;
+                *pair_counts.entry(pair).or_default() += 1;
+            }
+        }
+
+        let best = pair_counts.iter().max_by_key(|&(_, &v)| v);
+        match best {
+            Some((&pair, &count)) if count > 1 => {
+                let left = (pair >> 16) as u16;
+                let right = (pair & 0xFFFF) as u16;
+                let new_token = (TOKEN_BASE + rules.len()) as u16;
+                rules.push([left as u8, right as u8]);
+
+                for seq in &mut tokens {
+                    replace_pair(seq, left, right, new_token);
+                }
+            }
+            _ => break,
+        }
+    }
+
+    rules
+}
+
+fn replace_pair(seq: &mut Vec<u16>, left: u16, right: u16, new_token: u16) {
+    let mut i = 0;
+    let mut out = 0;
+    while i < seq.len() {
+        if i + 1 < seq.len() && seq[i] == left && seq[i + 1] == right {
+            seq[out] = new_token;
+            i += 2;
+        } else {
+            seq[out] = seq[i];
+            i += 1;
+        }
+        out += 1;
+    }
+    seq.truncate(out);
+}
+
+pub fn encode(name: &[u8], rules: &[[u8; 2]]) -> Vec<u8> {
+    let mut tokens: Vec<u16> = name.iter().map(|&b| b as u16).collect();
+
+    for (r, rule) in rules.iter().enumerate() {
+        let left = rule[0] as u16;
+        let right = rule[1] as u16;
+        let new_token = (TOKEN_BASE + r) as u16;
+        replace_pair(&mut tokens, left, right, new_token);
+    }
+
+    tokens.iter().map(|&t| t as u8).collect()
+}
+
+pub fn decode(encoded: &[u8], rules: &[[u8; 2]]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(encoded.len() * 2);
+    for &b in encoded {
+        expand(b as usize, rules, &mut out);
+    }
+    out
+}
+
+fn expand(token: usize, rules: &[[u8; 2]], out: &mut Vec<u8>) {
+    if token < TOKEN_BASE {
+        out.push(token as u8);
+    } else {
+        let idx = token - TOKEN_BASE;
+        expand(rules[idx][0] as usize, rules, out);
+        expand(rules[idx][1] as usize, rules, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bpe_encode() {
+        let names: Vec<&[u8]> = vec![
+            b"engine_coolant_temp",
+            b"engine_coolant_pressure",
+            b"engine_oil_temp",
+            b"engine_oil_pressure",
+        ];
+        let rules = build_vocabulary(&names);
+        assert!(!rules.is_empty());
+
+        for &name in &names {
+            let encoded = encode(name, &rules);
+            assert!(encoded.len() <= name.len());
+        }
+    }
+
+    #[test]
+    fn test_ascii_only() {
+        assert!(is_ascii_only(&[b"hello", b"world"]));
+        assert!(!is_ascii_only(&[b"hello", &[0x80, 0x81]]));
+    }
+}

--- a/core/src/bucket_reader.rs
+++ b/core/src/bucket_reader.rs
@@ -1,0 +1,1319 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io;
+use std::sync::Arc;
+
+use arrow_array::*;
+use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field, TimeUnit};
+
+use crate::spec::*;
+use crate::types;
+use crate::values::Value;
+use crate::varint;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DataVariant {
+    Boolean,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    Binary,
+    TimestampNanos,
+}
+
+fn data_variant_for_type(dt: &DataType) -> DataVariant {
+    match dt {
+        DataType::Boolean => DataVariant::Boolean,
+        DataType::Int8 => DataVariant::Int8,
+        DataType::Int16 => DataVariant::Int16,
+        DataType::Int32 | DataType::Date32 | DataType::Time32(_) => DataVariant::Int32,
+        DataType::Float32 => DataVariant::Float32,
+        DataType::Int64 => DataVariant::Int64,
+        DataType::Float64 => DataVariant::Float64,
+        DataType::Decimal128(p, _) => {
+            if *p <= 18 {
+                DataVariant::Int64
+            } else {
+                DataVariant::Binary
+            }
+        }
+        DataType::Timestamp(_, _) => DataVariant::Int64,
+        DataType::Struct(fields) if types::is_timestamp_nanos_struct(fields) => {
+            DataVariant::TimestampNanos
+        }
+        _ => DataVariant::Binary,
+    }
+}
+
+#[derive(Debug, Clone)]
+enum RawColumnData {
+    Boolean(Vec<u8>),
+    Int8(Vec<i8>),
+    Int16(Vec<i16>),
+    Int32(Vec<i32>),
+    Int64(Vec<i64>),
+    Float32(Vec<f32>),
+    Float64(Vec<f64>),
+    Binary {
+        offsets: Vec<u32>,
+        data: Vec<u8>,
+    },
+    TimestampNanos {
+        millis: Vec<i64>,
+        nanos_of_milli: Vec<i32>,
+    },
+}
+
+fn empty_raw_data_for_type(dt: &DataType) -> RawColumnData {
+    match dt {
+        DataType::Boolean => RawColumnData::Boolean(Vec::new()),
+        DataType::Int8 => RawColumnData::Int8(Vec::new()),
+        DataType::Int16 => RawColumnData::Int16(Vec::new()),
+        DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
+            RawColumnData::Int32(Vec::new())
+        }
+        DataType::Float32 => RawColumnData::Float32(Vec::new()),
+        DataType::Int64 => RawColumnData::Int64(Vec::new()),
+        DataType::Float64 => RawColumnData::Float64(Vec::new()),
+        DataType::Decimal128(p, _) => {
+            if *p <= 18 {
+                RawColumnData::Int64(Vec::new())
+            } else {
+                RawColumnData::Binary {
+                    offsets: vec![0],
+                    data: Vec::new(),
+                }
+            }
+        }
+        DataType::Timestamp(_, _) => RawColumnData::Int64(Vec::new()),
+        DataType::Struct(fields) if types::is_timestamp_nanos_struct(fields) => {
+            RawColumnData::TimestampNanos {
+                millis: Vec::new(),
+                nanos_of_milli: Vec::new(),
+            }
+        }
+        _ => RawColumnData::Binary {
+            offsets: vec![0],
+            data: Vec::new(),
+        },
+    }
+}
+
+fn invert_bitmap(bitmap: &[u8]) -> Vec<u8> {
+    bitmap.iter().map(|b| !b).collect()
+}
+
+fn make_null_buffer(bitmap: Option<Vec<u8>>, num_rows: usize) -> Option<NullBuffer> {
+    bitmap.map(|bm| NullBuffer::new(BooleanBuffer::new(Buffer::from_vec(bm), 0, num_rows)))
+}
+
+fn scatter_fixed<T: Default + Copy>(
+    values: Vec<T>,
+    bitmap: &Option<Vec<u8>>,
+    num_rows: usize,
+) -> Vec<T> {
+    let bm = match bitmap {
+        None => return values,
+        Some(bm) => bm,
+    };
+    let mut out = vec![T::default(); num_rows];
+    let mut src = 0;
+    for i in 0..num_rows {
+        if (bm[i / 8] & (1 << (i % 8))) != 0 {
+            out[i] = values[src];
+            src += 1;
+        }
+    }
+    out
+}
+
+fn scatter_binary_offsets(
+    offsets: Vec<u32>,
+    data: Vec<u8>,
+    bitmap: &Option<Vec<u8>>,
+    num_rows: usize,
+) -> (Vec<i32>, Vec<u8>) {
+    let bm = match bitmap {
+        None => {
+            let i32_offsets: Vec<i32> = offsets.into_iter().map(|o| o as i32).collect();
+            return (i32_offsets, data);
+        }
+        Some(bm) => bm,
+    };
+    let mut out_offsets = Vec::with_capacity(num_rows + 1);
+    let mut out_data = Vec::with_capacity(data.len());
+    out_offsets.push(0i32);
+    let mut src = 0usize;
+    for i in 0..num_rows {
+        if (bm[i / 8] & (1 << (i % 8))) != 0 {
+            let start = offsets[src] as usize;
+            let end = offsets[src + 1] as usize;
+            assert!(
+                start <= end && end <= data.len(),
+                "binary offset out of bounds: start={}, end={}, data_len={}",
+                start,
+                end,
+                data.len()
+            );
+            out_data.extend_from_slice(&data[start..end]);
+            src += 1;
+        }
+        out_offsets.push(out_data.len() as i32);
+    }
+    (out_offsets, out_data)
+}
+
+fn build_all_null_array(dt: &DataType, num_rows: usize) -> ArrayRef {
+    arrow_array::new_null_array(dt, num_rows)
+}
+
+fn build_array(
+    data: RawColumnData,
+    dt: &DataType,
+    null_bitmap: Option<Vec<u8>>,
+    num_rows: usize,
+) -> ArrayRef {
+    let null_buf = make_null_buffer(null_bitmap.clone(), num_rows);
+
+    match data {
+        RawColumnData::Boolean(values) => {
+            let bool_buf = BooleanBuffer::new(Buffer::from_vec(values), 0, num_rows);
+            Arc::new(BooleanArray::new(bool_buf, null_buf))
+        }
+        RawColumnData::Int8(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            Arc::new(Int8Array::new(ScalarBuffer::from(scattered), null_buf))
+        }
+        RawColumnData::Int16(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            Arc::new(Int16Array::new(ScalarBuffer::from(scattered), null_buf))
+        }
+        RawColumnData::Int32(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            match dt {
+                DataType::Date32 => {
+                    Arc::new(Date32Array::new(ScalarBuffer::from(scattered), null_buf))
+                }
+                DataType::Time32(_) => Arc::new(Time32MillisecondArray::new(
+                    ScalarBuffer::from(scattered),
+                    null_buf,
+                )),
+                _ => Arc::new(Int32Array::new(ScalarBuffer::from(scattered), null_buf)),
+            }
+        }
+        RawColumnData::Int64(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            match dt {
+                DataType::Decimal128(p, s) => {
+                    let i128_values: Vec<i128> = scattered.iter().map(|&v| v as i128).collect();
+                    Arc::new(
+                        Decimal128Array::new(ScalarBuffer::from(i128_values), null_buf)
+                            .with_precision_and_scale(*p, *s)
+                            .unwrap(),
+                    )
+                }
+                DataType::Timestamp(TimeUnit::Millisecond, tz) => {
+                    let arr =
+                        TimestampMillisecondArray::new(ScalarBuffer::from(scattered), null_buf);
+                    Arc::new(if let Some(tz) = tz {
+                        arr.with_timezone(tz.clone())
+                    } else {
+                        arr
+                    })
+                }
+                DataType::Timestamp(TimeUnit::Microsecond, tz) => {
+                    let arr =
+                        TimestampMicrosecondArray::new(ScalarBuffer::from(scattered), null_buf);
+                    Arc::new(if let Some(tz) = tz {
+                        arr.with_timezone(tz.clone())
+                    } else {
+                        arr
+                    })
+                }
+                _ => Arc::new(Int64Array::new(ScalarBuffer::from(scattered), null_buf)),
+            }
+        }
+        RawColumnData::Float32(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            Arc::new(Float32Array::new(ScalarBuffer::from(scattered), null_buf))
+        }
+        RawColumnData::Float64(values) => {
+            let scattered = scatter_fixed(values, &null_bitmap, num_rows);
+            Arc::new(Float64Array::new(ScalarBuffer::from(scattered), null_buf))
+        }
+        RawColumnData::Binary { offsets, data } => {
+            let (i32_offsets, out_data) =
+                scatter_binary_offsets(offsets, data, &null_bitmap, num_rows);
+            let offset_buf = OffsetBuffer::new(ScalarBuffer::from(i32_offsets));
+            match dt {
+                DataType::Utf8 => Arc::new(StringArray::new(
+                    offset_buf,
+                    Buffer::from_vec(out_data),
+                    null_buf,
+                )),
+                DataType::Decimal128(p, s) => {
+                    let bin = BinaryArray::new(offset_buf, Buffer::from_vec(out_data), null_buf);
+                    let i128_values: Vec<i128> = (0..num_rows)
+                        .map(|i| {
+                            if bin.is_null(i) {
+                                0i128
+                            } else {
+                                let bytes = bin.value(i);
+                                let negative = !bytes.is_empty() && bytes[0] & 0x80 != 0;
+                                let pad = if negative { 0xFF } else { 0x00 };
+                                let mut buf = [pad; 16];
+                                let start = 16usize.saturating_sub(bytes.len());
+                                buf[start..].copy_from_slice(bytes);
+                                i128::from_be_bytes(buf)
+                            }
+                        })
+                        .collect();
+                    let null_buf2 = bin.nulls().cloned();
+                    Arc::new(
+                        Decimal128Array::new(ScalarBuffer::from(i128_values), null_buf2)
+                            .with_precision_and_scale(*p, *s)
+                            .unwrap(),
+                    )
+                }
+                _ => Arc::new(BinaryArray::new(
+                    offset_buf,
+                    Buffer::from_vec(out_data),
+                    null_buf,
+                )),
+            }
+        }
+        RawColumnData::TimestampNanos {
+            millis,
+            nanos_of_milli,
+        } => {
+            let millis_scattered = scatter_fixed(millis, &null_bitmap, num_rows);
+            let nanos_scattered = scatter_fixed(nanos_of_milli, &null_bitmap, num_rows);
+            let millis_array = Arc::new(Int64Array::from(millis_scattered)) as ArrayRef;
+            let nanos_array = Arc::new(Int32Array::from(nanos_scattered)) as ArrayRef;
+            let fields = vec![
+                Field::new("millis", DataType::Int64, false),
+                Field::new("nanos_of_milli", DataType::Int32, false),
+            ];
+            Arc::new(StructArray::new(
+                fields.into(),
+                vec![millis_array, nanos_array],
+                null_buf,
+            ))
+        }
+    }
+}
+
+pub struct BucketReader {
+    data: Vec<u8>,
+    num_columns: usize,
+    num_rows: usize,
+    col_types: Vec<DataType>,
+
+    encodings: Vec<u8>,
+    has_nulls: Vec<bool>,
+    null_bitmaps: Vec<Vec<u8>>,
+    const_values: Vec<Value>,
+    dict_values: Vec<Vec<Value>>,
+    dict_bit_widths: Vec<usize>,
+    data_cursors: Vec<usize>,
+}
+
+impl BucketReader {
+    pub fn new(col_types: Vec<DataType>, data: Vec<u8>, num_rows: usize) -> io::Result<Self> {
+        let num_columns = col_types.len();
+        let mut reader = BucketReader {
+            data,
+            num_columns,
+            num_rows,
+            col_types,
+            encodings: vec![0; num_columns],
+            has_nulls: vec![false; num_columns],
+            null_bitmaps: Vec::new(),
+            const_values: Vec::new(),
+            dict_values: Vec::new(),
+            dict_bit_widths: vec![0; num_columns],
+            data_cursors: vec![0; num_columns],
+        };
+        reader.init()?;
+        Ok(reader)
+    }
+
+    fn check_bounds(&self, pos: usize, need: usize) -> io::Result<()> {
+        if pos
+            .checked_add(need)
+            .is_none_or(|end| end > self.data.len())
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bucket data truncated",
+            ));
+        }
+        Ok(())
+    }
+
+    fn init(&mut self) -> io::Result<()> {
+        self.null_bitmaps = vec![Vec::new(); self.num_columns];
+        self.const_values = vec![Value::Null; self.num_columns];
+        self.dict_values = vec![Vec::new(); self.num_columns];
+
+        let mut pos = 0;
+
+        // 1. Encoding flags (2 bits per column)
+        let encoding_flags_bytes = (self.num_columns * 2).div_ceil(8);
+        self.check_bounds(pos, encoding_flags_bytes)?;
+        for i in 0..self.num_columns {
+            let byte_idx = (i * 2) / 8;
+            let bit_idx = (i * 2) % 8;
+            self.encodings[i] = (self.data[pos + byte_idx] >> bit_idx) & 0x03;
+        }
+        pos += encoding_flags_bytes;
+
+        // 2. Has-nulls flags (1 bit per column)
+        let has_nulls_bytes = self.num_columns.div_ceil(8);
+        self.check_bounds(pos, has_nulls_bytes)?;
+        for i in 0..self.num_columns {
+            self.has_nulls[i] = (self.data[pos + i / 8] & (1 << (i % 8))) != 0;
+        }
+        pos += has_nulls_bytes;
+
+        // 3. CONST metadata
+        for i in 0..self.num_columns {
+            if self.encodings[i] == ENCODING_CONST {
+                let (value, size) = self.read_value_at(&self.col_types[i], pos)?;
+                self.const_values[i] = value;
+                pos += size;
+            }
+        }
+
+        // 4. DICT metadata
+        for i in 0..self.num_columns {
+            if self.encodings[i] == ENCODING_DICT {
+                let num_entries = varint::decode(&self.data, &mut pos)? as usize;
+                self.dict_bit_widths[i] = bit_width(num_entries);
+                let mut entries = Vec::with_capacity(num_entries);
+                for _ in 0..num_entries {
+                    let (value, size) = self.read_value_at(&self.col_types[i], pos)?;
+                    entries.push(value);
+                    pos += size;
+                }
+                self.dict_values[i] = entries;
+            }
+        }
+
+        // 5. Null bitmaps
+        let null_bitmap_bytes = self.num_rows.div_ceil(8);
+        for i in 0..self.num_columns {
+            if self.has_nulls[i] && self.encodings[i] != ENCODING_ALL_NULL {
+                self.check_bounds(pos, null_bitmap_bytes)?;
+                self.null_bitmaps[i] = self.data[pos..pos + null_bitmap_bytes].to_vec();
+                pos += null_bitmap_bytes;
+            }
+        }
+
+        // 6. Record column data start offsets, skip past data
+        for i in 0..self.num_columns {
+            self.data_cursors[i] = pos;
+            if self.encodings[i] == ENCODING_PLAIN {
+                let w = types::fixed_width(&self.col_types[i]);
+                let non_null_count = self.count_non_null(i);
+                if w > 0 {
+                    let size = non_null_count * w as usize;
+                    self.check_bounds(pos, size)?;
+                    pos += size;
+                } else {
+                    for _ in 0..non_null_count {
+                        let len = varint::decode(&self.data, &mut pos)? as usize;
+                        self.check_bounds(pos, len)?;
+                        pos += len;
+                    }
+                }
+            } else if self.encodings[i] == ENCODING_DICT {
+                let non_null_count = self.count_non_null(i);
+                let size = (non_null_count * self.dict_bit_widths[i]).div_ceil(8);
+                self.check_bounds(pos, size)?;
+                pos += size;
+            }
+        }
+        Ok(())
+    }
+
+    fn read_value_at(&self, dt: &DataType, pos: usize) -> io::Result<(Value, usize)> {
+        let w = types::fixed_width(dt);
+        if w > 0 {
+            self.check_bounds(pos, w as usize)?;
+            Ok((read_typed_value(dt, &self.data, pos, w), w as usize))
+        } else {
+            read_variable_value(dt, &self.data, pos)
+        }
+    }
+
+    fn count_non_null(&self, col: usize) -> usize {
+        if !self.has_nulls[col] {
+            return self.num_rows;
+        }
+        if self.encodings[col] == ENCODING_ALL_NULL {
+            return 0;
+        }
+        let bitmap = &self.null_bitmaps[col];
+        let full_bytes = self.num_rows / 8;
+        let mut null_count = 0usize;
+        for byte in bitmap.iter().take(full_bytes) {
+            null_count += (*byte as u32).count_ones() as usize;
+        }
+        let remaining = self.num_rows % 8;
+        if remaining > 0 {
+            let mask = (1u8 << remaining) - 1;
+            null_count += (bitmap[full_bytes] & mask).count_ones() as usize;
+        }
+        self.num_rows - null_count
+    }
+
+    pub fn read_all_columns(&self) -> io::Result<Vec<ArrayRef>> {
+        let num_rows = self.num_rows;
+        let mut result = Vec::with_capacity(self.num_columns);
+
+        for i in 0..self.num_columns {
+            let variant = data_variant_for_type(&self.col_types[i]);
+
+            if self.encodings[i] == ENCODING_ALL_NULL {
+                result.push(build_all_null_array(&self.col_types[i], num_rows));
+                continue;
+            }
+
+            let has_nulls = self.has_nulls[i];
+            let null_bitmap = if has_nulls {
+                Some(invert_bitmap(&self.null_bitmaps[i]))
+            } else {
+                None
+            };
+
+            let data = match self.encodings[i] {
+                ENCODING_CONST => read_all_const(
+                    &self.const_values[i],
+                    num_rows,
+                    has_nulls,
+                    &self.null_bitmaps[i],
+                    variant,
+                )?,
+                ENCODING_DICT => read_all_dict(
+                    &self.data,
+                    self.data_cursors[i],
+                    &self.dict_values[i],
+                    self.dict_bit_widths[i],
+                    num_rows,
+                    has_nulls,
+                    &self.null_bitmaps[i],
+                    variant,
+                )?,
+                ENCODING_PLAIN => read_all_plain(
+                    &self.data,
+                    self.data_cursors[i],
+                    &self.col_types[i],
+                    num_rows,
+                    has_nulls,
+                    &self.null_bitmaps[i],
+                    variant,
+                )?,
+                _ => empty_raw_data_for_type(&self.col_types[i]),
+            };
+
+            result.push(build_array(data, &self.col_types[i], null_bitmap, num_rows));
+        }
+
+        Ok(result)
+    }
+}
+
+pub struct ColumnPageReader {
+    col_type: DataType,
+    encoding: u8,
+    has_nulls: bool,
+    const_value: Value,
+    dict_values: Vec<Value>,
+    dict_bit_width: usize,
+    null_bitmap: Vec<u8>,
+    data: Vec<u8>,
+    data_cursor: usize,
+    num_rows: usize,
+}
+
+impl ColumnPageReader {
+    pub fn new(
+        col_type: DataType,
+        encoding: u8,
+        has_nulls: bool,
+        const_value: Value,
+        page_data: Vec<u8>,
+        num_rows: usize,
+    ) -> io::Result<Self> {
+        let mut reader = ColumnPageReader {
+            col_type,
+            encoding,
+            has_nulls,
+            const_value,
+            dict_values: Vec::new(),
+            dict_bit_width: 0,
+            null_bitmap: Vec::new(),
+            data: page_data,
+            data_cursor: 0,
+            num_rows,
+        };
+        reader.init_page()?;
+        Ok(reader)
+    }
+
+    fn init_page(&mut self) -> io::Result<()> {
+        let null_bitmap_bytes = self.num_rows.div_ceil(8);
+        let mut pos = 0;
+
+        match self.encoding {
+            ENCODING_ALL_NULL => {}
+            ENCODING_CONST => {
+                if self.has_nulls {
+                    if pos + null_bitmap_bytes > self.data.len() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "column page truncated: null bitmap",
+                        ));
+                    }
+                    self.null_bitmap = self.data[pos..pos + null_bitmap_bytes].to_vec();
+                }
+            }
+            ENCODING_DICT => {
+                let num_entries = varint::decode(&self.data, &mut pos)? as usize;
+                self.dict_bit_width = bit_width(num_entries);
+                let mut entries = Vec::with_capacity(num_entries);
+                for _ in 0..num_entries {
+                    let (value, size) = self.read_value_at(pos)?;
+                    entries.push(value);
+                    pos += size;
+                }
+                self.dict_values = entries;
+                if self.has_nulls {
+                    if pos + null_bitmap_bytes > self.data.len() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "column page truncated: null bitmap",
+                        ));
+                    }
+                    self.null_bitmap = self.data[pos..pos + null_bitmap_bytes].to_vec();
+                    pos += null_bitmap_bytes;
+                }
+                self.data_cursor = pos;
+                let non_null_count = self.count_non_null();
+                let packed_bytes = (non_null_count * self.dict_bit_width).div_ceil(8);
+                if pos
+                    .checked_add(packed_bytes)
+                    .is_none_or(|end| end > self.data.len())
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "column page truncated: dict bit-packed data",
+                    ));
+                }
+            }
+            ENCODING_PLAIN => {
+                if self.has_nulls {
+                    if pos + null_bitmap_bytes > self.data.len() {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "column page truncated: null bitmap",
+                        ));
+                    }
+                    self.null_bitmap = self.data[pos..pos + null_bitmap_bytes].to_vec();
+                    pos += null_bitmap_bytes;
+                }
+                self.data_cursor = pos;
+                let non_null_count = self.count_non_null();
+                let w = types::fixed_width(&self.col_type);
+                if w > 0 {
+                    let size = non_null_count * w as usize;
+                    if pos
+                        .checked_add(size)
+                        .is_none_or(|end| end > self.data.len())
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "column page truncated: plain fixed-width data",
+                        ));
+                    }
+                } else {
+                    let mut scan = pos;
+                    for _ in 0..non_null_count {
+                        let len = varint::decode(&self.data, &mut scan)? as usize;
+                        if scan
+                            .checked_add(len)
+                            .is_none_or(|end| end > self.data.len())
+                        {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "column page truncated: plain variable-width data",
+                            ));
+                        }
+                        scan += len;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn count_non_null(&self) -> usize {
+        if !self.has_nulls {
+            return self.num_rows;
+        }
+        if self.encoding == ENCODING_ALL_NULL {
+            return 0;
+        }
+        let bitmap = &self.null_bitmap;
+        let full_bytes = self.num_rows / 8;
+        let mut null_count = 0usize;
+        for byte in bitmap.iter().take(full_bytes) {
+            null_count += (*byte as u32).count_ones() as usize;
+        }
+        let remaining = self.num_rows % 8;
+        if remaining > 0 {
+            let mask = (1u8 << remaining) - 1;
+            null_count += (bitmap[full_bytes] & mask).count_ones() as usize;
+        }
+        self.num_rows - null_count
+    }
+
+    fn read_value_at(&self, pos: usize) -> io::Result<(Value, usize)> {
+        let w = types::fixed_width(&self.col_type);
+        if w > 0 {
+            if pos + w as usize > self.data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "column page truncated",
+                ));
+            }
+            Ok((
+                read_typed_value(&self.col_type, &self.data, pos, w),
+                w as usize,
+            ))
+        } else {
+            read_variable_value(&self.col_type, &self.data, pos)
+        }
+    }
+
+    pub fn read_all(&self) -> io::Result<ArrayRef> {
+        let num_rows = self.num_rows;
+        let variant = data_variant_for_type(&self.col_type);
+
+        if self.encoding == ENCODING_ALL_NULL {
+            return Ok(build_all_null_array(&self.col_type, num_rows));
+        }
+
+        let has_nulls = self.has_nulls;
+        let null_bitmap = if has_nulls {
+            Some(invert_bitmap(&self.null_bitmap))
+        } else {
+            None
+        };
+
+        let data = match self.encoding {
+            ENCODING_CONST => read_all_const(
+                &self.const_value,
+                num_rows,
+                has_nulls,
+                &self.null_bitmap,
+                variant,
+            )?,
+            ENCODING_DICT => read_all_dict(
+                &self.data,
+                self.data_cursor,
+                &self.dict_values,
+                self.dict_bit_width,
+                num_rows,
+                has_nulls,
+                &self.null_bitmap,
+                variant,
+            )?,
+            ENCODING_PLAIN => read_all_plain(
+                &self.data,
+                self.data_cursor,
+                &self.col_type,
+                num_rows,
+                has_nulls,
+                &self.null_bitmap,
+                variant,
+            )?,
+            _ => empty_raw_data_for_type(&self.col_type),
+        };
+
+        Ok(build_array(data, &self.col_type, null_bitmap, num_rows))
+    }
+}
+
+pub(crate) fn read_typed_value(dt: &DataType, buf: &[u8], pos: usize, width: i32) -> Value {
+    match dt {
+        DataType::Boolean => Value::Boolean(buf[pos] != 0),
+        DataType::Int8 => Value::TinyInt(buf[pos] as i8),
+        DataType::Int16 => Value::SmallInt(i16::from_be_bytes([buf[pos], buf[pos + 1]])),
+        DataType::Int32 => Value::Integer(i32::from_be_bytes([
+            buf[pos],
+            buf[pos + 1],
+            buf[pos + 2],
+            buf[pos + 3],
+        ])),
+        DataType::Date32 => Value::Date(i32::from_be_bytes([
+            buf[pos],
+            buf[pos + 1],
+            buf[pos + 2],
+            buf[pos + 3],
+        ])),
+        DataType::Time32(_) => Value::Time(i32::from_be_bytes([
+            buf[pos],
+            buf[pos + 1],
+            buf[pos + 2],
+            buf[pos + 3],
+        ])),
+        DataType::Float32 => {
+            let bits = u32::from_be_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]]);
+            Value::Float(f32::from_bits(bits))
+        }
+        DataType::Int64 => Value::BigInt(read_i64(buf, pos)),
+        DataType::Float64 => Value::Double(f64::from_bits(read_u64(buf, pos))),
+        DataType::Decimal128(_, _) => Value::DecimalCompact(read_i64(buf, pos)),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => Value::TimestampMillis(read_i64(buf, pos)),
+        DataType::Timestamp(TimeUnit::Microsecond, _) => Value::TimestampMicros(read_i64(buf, pos)),
+        DataType::Struct(fields) if types::is_timestamp_nanos_struct(fields) => {
+            debug_assert_eq!(width, 12);
+            let millis = read_i64(buf, pos);
+            let nanos =
+                i32::from_be_bytes([buf[pos + 8], buf[pos + 9], buf[pos + 10], buf[pos + 11]]);
+            Value::TimestampNanos {
+                millis,
+                nanos_of_milli: nanos,
+            }
+        }
+        _ => Value::Null,
+    }
+}
+
+pub(crate) fn read_variable_value(
+    dt: &DataType,
+    buf: &[u8],
+    pos: usize,
+) -> io::Result<(Value, usize)> {
+    let mut p = pos;
+    let len = varint::decode(buf, &mut p).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "truncated varint in variable-length value",
+        )
+    })? as usize;
+    let header_size = p - pos;
+    if p + len > buf.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "buffer truncated in variable-length value",
+        ));
+    }
+    let bytes = buf[p..p + len].to_vec();
+    let total_size = header_size + len;
+
+    let value = match dt {
+        DataType::Utf8 => Value::String(bytes),
+        DataType::Binary => Value::Bytes(bytes),
+        DataType::Decimal128(_, _) => Value::DecimalLarge(bytes),
+        _ => Value::Null,
+    };
+    Ok((value, total_size))
+}
+
+// ======================== Columnar batch decode helpers ========================
+
+fn read_all_const(
+    const_value: &Value,
+    num_rows: usize,
+    has_nulls: bool,
+    null_bitmap: &[u8],
+    variant: DataVariant,
+) -> io::Result<RawColumnData> {
+    let non_null_count = if has_nulls {
+        count_non_null(null_bitmap, num_rows)
+    } else {
+        num_rows
+    };
+
+    match variant {
+        DataVariant::Boolean => {
+            let b = match const_value {
+                Value::Boolean(v) => *v,
+                _ => false,
+            };
+            let mut buf = vec![0u8; num_rows.div_ceil(8)];
+            if b {
+                for row in 0..num_rows {
+                    if !has_nulls || !is_null(null_bitmap, row) {
+                        buf[row / 8] |= 1 << (row % 8);
+                    }
+                }
+            }
+            Ok(RawColumnData::Boolean(buf))
+        }
+        DataVariant::Int8 => {
+            let v = match const_value {
+                Value::TinyInt(x) => *x,
+                _ => 0,
+            };
+            let mut out = vec![0i8; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Int8(out))
+        }
+        DataVariant::Int16 => {
+            let v = match const_value {
+                Value::SmallInt(x) => *x,
+                _ => 0,
+            };
+            let mut out = vec![0i16; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Int16(out))
+        }
+        DataVariant::Int32 => {
+            let v = match const_value {
+                Value::Integer(x) | Value::Date(x) | Value::Time(x) => *x,
+                _ => 0,
+            };
+            let mut out = vec![0i32; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Int32(out))
+        }
+        DataVariant::Int64 => {
+            let v = match const_value {
+                Value::BigInt(x)
+                | Value::DecimalCompact(x)
+                | Value::TimestampMillis(x)
+                | Value::TimestampMicros(x) => *x,
+                _ => 0,
+            };
+            let mut out = vec![0i64; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Int64(out))
+        }
+        DataVariant::Float32 => {
+            let v = match const_value {
+                Value::Float(x) => *x,
+                _ => 0.0,
+            };
+            let mut out = vec![0.0f32; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Float32(out))
+        }
+        DataVariant::Float64 => {
+            let v = match const_value {
+                Value::Double(x) => *x,
+                _ => 0.0,
+            };
+            let mut out = vec![0.0f64; non_null_count];
+            out.fill(v);
+            Ok(RawColumnData::Float64(out))
+        }
+        DataVariant::Binary => {
+            let bytes = match const_value {
+                Value::String(b) | Value::Bytes(b) | Value::DecimalLarge(b) => b.as_slice(),
+                _ => &[],
+            };
+            let mut offsets = Vec::with_capacity(non_null_count + 1);
+            let mut data = Vec::with_capacity(non_null_count * bytes.len());
+            offsets.push(0u32);
+            for _ in 0..non_null_count {
+                data.extend_from_slice(bytes);
+                offsets.push(data.len() as u32);
+            }
+            Ok(RawColumnData::Binary { offsets, data })
+        }
+        DataVariant::TimestampNanos => {
+            let (m, n) = match const_value {
+                Value::TimestampNanos {
+                    millis,
+                    nanos_of_milli,
+                } => (*millis, *nanos_of_milli),
+                _ => (0, 0),
+            };
+            let mut millis_out = vec![0i64; non_null_count];
+            let mut nanos_out = vec![0i32; non_null_count];
+            millis_out.fill(m);
+            nanos_out.fill(n);
+            Ok(RawColumnData::TimestampNanos {
+                millis: millis_out,
+                nanos_of_milli: nanos_out,
+            })
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn read_all_dict(
+    data: &[u8],
+    data_cursor: usize,
+    dict_values: &[Value],
+    dict_bit_width: usize,
+    num_rows: usize,
+    has_nulls: bool,
+    null_bitmap: &[u8],
+    variant: DataVariant,
+) -> io::Result<RawColumnData> {
+    let non_null_count = if has_nulls {
+        count_non_null(null_bitmap, num_rows)
+    } else {
+        num_rows
+    };
+
+    let mut indices = Vec::with_capacity(non_null_count);
+    let mut bit_offset = 0;
+    for row in 0..num_rows {
+        if has_nulls && is_null(null_bitmap, row) {
+            continue;
+        }
+        let idx = read_bit_packed(data, data_cursor, bit_offset, dict_bit_width);
+        bit_offset += dict_bit_width;
+        if idx >= dict_values.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "corrupt dict index",
+            ));
+        }
+        indices.push(idx);
+    }
+
+    match variant {
+        DataVariant::Boolean => {
+            let mut buf = vec![0u8; num_rows.div_ceil(8)];
+            let mut vi = 0;
+            for row in 0..num_rows {
+                if has_nulls && is_null(null_bitmap, row) {
+                    continue;
+                }
+                if let Value::Boolean(true) = &dict_values[indices[vi]] {
+                    buf[row / 8] |= 1 << (row % 8);
+                }
+                vi += 1;
+            }
+            Ok(RawColumnData::Boolean(buf))
+        }
+        DataVariant::Int8 => {
+            let out: Vec<i8> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::TinyInt(x) => *x,
+                    _ => 0,
+                })
+                .collect();
+            Ok(RawColumnData::Int8(out))
+        }
+        DataVariant::Int16 => {
+            let out: Vec<i16> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::SmallInt(x) => *x,
+                    _ => 0,
+                })
+                .collect();
+            Ok(RawColumnData::Int16(out))
+        }
+        DataVariant::Int32 => {
+            let out: Vec<i32> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::Integer(x) | Value::Date(x) | Value::Time(x) => *x,
+                    _ => 0,
+                })
+                .collect();
+            Ok(RawColumnData::Int32(out))
+        }
+        DataVariant::Int64 => {
+            let out: Vec<i64> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::BigInt(x)
+                    | Value::DecimalCompact(x)
+                    | Value::TimestampMillis(x)
+                    | Value::TimestampMicros(x) => *x,
+                    _ => 0,
+                })
+                .collect();
+            Ok(RawColumnData::Int64(out))
+        }
+        DataVariant::Float32 => {
+            let out: Vec<f32> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::Float(x) => *x,
+                    _ => 0.0,
+                })
+                .collect();
+            Ok(RawColumnData::Float32(out))
+        }
+        DataVariant::Float64 => {
+            let out: Vec<f64> = indices
+                .iter()
+                .map(|&i| match &dict_values[i] {
+                    Value::Double(x) => *x,
+                    _ => 0.0,
+                })
+                .collect();
+            Ok(RawColumnData::Float64(out))
+        }
+        DataVariant::Binary => {
+            let mut offsets = Vec::with_capacity(non_null_count + 1);
+            let mut out_data = Vec::new();
+            offsets.push(0u32);
+            for &idx in &indices {
+                let bytes = match &dict_values[idx] {
+                    Value::String(b) | Value::Bytes(b) | Value::DecimalLarge(b) => b.as_slice(),
+                    _ => &[],
+                };
+                out_data.extend_from_slice(bytes);
+                offsets.push(out_data.len() as u32);
+            }
+            Ok(RawColumnData::Binary {
+                offsets,
+                data: out_data,
+            })
+        }
+        DataVariant::TimestampNanos => {
+            let mut millis_out = Vec::with_capacity(non_null_count);
+            let mut nanos_out = Vec::with_capacity(non_null_count);
+            for &idx in &indices {
+                match &dict_values[idx] {
+                    Value::TimestampNanos {
+                        millis,
+                        nanos_of_milli,
+                    } => {
+                        millis_out.push(*millis);
+                        nanos_out.push(*nanos_of_milli);
+                    }
+                    _ => {
+                        millis_out.push(0);
+                        nanos_out.push(0);
+                    }
+                }
+            }
+            Ok(RawColumnData::TimestampNanos {
+                millis: millis_out,
+                nanos_of_milli: nanos_out,
+            })
+        }
+    }
+}
+
+fn read_all_plain(
+    data: &[u8],
+    data_cursor: usize,
+    col_type: &DataType,
+    num_rows: usize,
+    has_nulls: bool,
+    null_bitmap: &[u8],
+    variant: DataVariant,
+) -> io::Result<RawColumnData> {
+    let non_null_count = if has_nulls {
+        count_non_null(null_bitmap, num_rows)
+    } else {
+        num_rows
+    };
+    let w = types::fixed_width(col_type);
+
+    match variant {
+        DataVariant::Boolean => {
+            let mut buf = vec![0u8; num_rows.div_ceil(8)];
+            let mut cursor = data_cursor;
+            for row in 0..num_rows {
+                if has_nulls && is_null(null_bitmap, row) {
+                    continue;
+                }
+                if data[cursor] != 0 {
+                    buf[row / 8] |= 1 << (row % 8);
+                }
+                cursor += 1;
+            }
+            Ok(RawColumnData::Boolean(buf))
+        }
+        DataVariant::Int8 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                out.push(data[cursor] as i8);
+                cursor += 1;
+            }
+            Ok(RawColumnData::Int8(out))
+        }
+        DataVariant::Int16 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                out.push(i16::from_be_bytes([data[cursor], data[cursor + 1]]));
+                cursor += 2;
+            }
+            Ok(RawColumnData::Int16(out))
+        }
+        DataVariant::Int32 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                out.push(i32::from_be_bytes([
+                    data[cursor],
+                    data[cursor + 1],
+                    data[cursor + 2],
+                    data[cursor + 3],
+                ]));
+                cursor += 4;
+            }
+            Ok(RawColumnData::Int32(out))
+        }
+        DataVariant::Int64 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                out.push(read_i64(data, cursor));
+                cursor += 8;
+            }
+            Ok(RawColumnData::Int64(out))
+        }
+        DataVariant::Float32 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                let bits = u32::from_be_bytes([
+                    data[cursor],
+                    data[cursor + 1],
+                    data[cursor + 2],
+                    data[cursor + 3],
+                ]);
+                out.push(f32::from_bits(bits));
+                cursor += 4;
+            }
+            Ok(RawColumnData::Float32(out))
+        }
+        DataVariant::Float64 => {
+            let mut out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                let bits = read_u64(data, cursor);
+                out.push(f64::from_bits(bits));
+                cursor += 8;
+            }
+            Ok(RawColumnData::Float64(out))
+        }
+        DataVariant::Binary => {
+            let mut offsets = Vec::with_capacity(non_null_count + 1);
+            let mut out_data = Vec::new();
+            offsets.push(0u32);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                let len = varint::decode(data, &mut cursor)? as usize;
+                out_data.extend_from_slice(&data[cursor..cursor + len]);
+                cursor += len;
+                offsets.push(out_data.len() as u32);
+            }
+            Ok(RawColumnData::Binary {
+                offsets,
+                data: out_data,
+            })
+        }
+        DataVariant::TimestampNanos => {
+            debug_assert_eq!(w, 12);
+            let mut millis_out = Vec::with_capacity(non_null_count);
+            let mut nanos_out = Vec::with_capacity(non_null_count);
+            let mut cursor = data_cursor;
+            for _ in 0..non_null_count {
+                millis_out.push(read_i64(data, cursor));
+                nanos_out.push(i32::from_be_bytes([
+                    data[cursor + 8],
+                    data[cursor + 9],
+                    data[cursor + 10],
+                    data[cursor + 11],
+                ]));
+                cursor += 12;
+            }
+            Ok(RawColumnData::TimestampNanos {
+                millis: millis_out,
+                nanos_of_milli: nanos_out,
+            })
+        }
+    }
+}
+
+fn count_non_null(null_bitmap: &[u8], num_rows: usize) -> usize {
+    let full_bytes = num_rows / 8;
+    let mut null_count = 0usize;
+    for byte in null_bitmap.iter().take(full_bytes) {
+        null_count += (*byte as u32).count_ones() as usize;
+    }
+    let remaining = num_rows % 8;
+    if remaining > 0 {
+        let mask = (1u8 << remaining) - 1;
+        null_count += (null_bitmap[full_bytes] & mask).count_ones() as usize;
+    }
+    num_rows - null_count
+}
+
+fn is_null(null_bitmap: &[u8], row: usize) -> bool {
+    (null_bitmap[row / 8] & (1 << (row % 8))) != 0
+}
+
+fn read_bit_packed(buf: &[u8], byte_base: usize, bit_offset: usize, bit_width: usize) -> usize {
+    let mut value = 0;
+    for b in 0..bit_width {
+        let global_bit = bit_offset + b;
+        if (buf[byte_base + global_bit / 8] & (1 << (global_bit % 8))) != 0 {
+            value |= 1 << b;
+        }
+    }
+    value
+}
+
+fn bit_width(num_entries: usize) -> usize {
+    if num_entries <= 1 {
+        return 0;
+    }
+    usize::BITS as usize - (num_entries - 1).leading_zeros() as usize
+}
+
+fn read_i64(buf: &[u8], pos: usize) -> i64 {
+    i64::from_be_bytes([
+        buf[pos],
+        buf[pos + 1],
+        buf[pos + 2],
+        buf[pos + 3],
+        buf[pos + 4],
+        buf[pos + 5],
+        buf[pos + 6],
+        buf[pos + 7],
+    ])
+}
+
+fn read_u64(buf: &[u8], pos: usize) -> u64 {
+    u64::from_be_bytes([
+        buf[pos],
+        buf[pos + 1],
+        buf[pos + 2],
+        buf[pos + 3],
+        buf[pos + 4],
+        buf[pos + 5],
+        buf[pos + 6],
+        buf[pos + 7],
+    ])
+}

--- a/core/src/bucket_writer.rs
+++ b/core/src/bucket_writer.rs
@@ -1,0 +1,1080 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::io;
+
+use arrow_array::*;
+use arrow_schema::DataType;
+
+use crate::spec::*;
+use crate::types;
+use crate::values;
+use crate::varint;
+
+pub struct PagedBucketOutput {
+    pub encodings: Vec<u8>,
+    pub has_nulls: Vec<bool>,
+    pub const_data: Vec<Vec<u8>>,
+    pub column_pages: Vec<Option<Vec<u8>>>,
+}
+
+pub struct BucketWriter {
+    num_columns: usize,
+    fixed_widths: Vec<i32>,
+
+    null_bitmaps: Vec<Vec<u8>>,
+    value_buffers: Vec<Vec<u8>>,
+    non_null_counts: Vec<usize>,
+
+    // CONST tracking
+    const_tracking: Vec<bool>,
+    first_value_len: Vec<usize>,
+
+    // Dict tracking: fixed-width <=8 uses u64 keys, variable-width uses byte keys
+    long_dict_maps: Vec<Option<HashMap<u64, usize>>>,
+    byte_dict_maps: Vec<Option<HashMap<Vec<u8>, usize>>>,
+    dict_total_bytes: Vec<usize>,
+    max_dict_total_bytes: usize,
+    max_dict_entries: usize,
+
+    num_rows: usize,
+}
+
+impl BucketWriter {
+    pub fn new(
+        col_types: &[&DataType],
+        max_dict_total_bytes: usize,
+        max_dict_entries: usize,
+    ) -> Self {
+        let num_columns = col_types.len();
+        let fixed_widths: Vec<i32> = col_types.iter().map(|t| types::fixed_width(t)).collect();
+
+        let mut long_dict_maps = Vec::with_capacity(num_columns);
+        let mut byte_dict_maps = Vec::with_capacity(num_columns);
+
+        for fw in fixed_widths.iter().take(num_columns) {
+            if uses_long_dict(*fw) {
+                long_dict_maps.push(Some(HashMap::new()));
+                byte_dict_maps.push(None);
+            } else {
+                long_dict_maps.push(None);
+                byte_dict_maps.push(Some(HashMap::new()));
+            }
+        }
+
+        BucketWriter {
+            num_columns,
+            fixed_widths,
+            null_bitmaps: vec![vec![0u8; 128]; num_columns],
+            value_buffers: vec![Vec::with_capacity(1024); num_columns],
+            non_null_counts: vec![0; num_columns],
+            const_tracking: vec![true; num_columns],
+            first_value_len: vec![0; num_columns],
+            long_dict_maps,
+            byte_dict_maps,
+            dict_total_bytes: vec![0; num_columns],
+            max_dict_total_bytes,
+            max_dict_entries,
+            num_rows: 0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_rows == 0
+    }
+
+    pub fn estimated_raw_size(&self) -> usize {
+        if self.num_rows == 0 {
+            return 0;
+        }
+        let (encodings, has_nulls) = self.compute_encodings();
+        self.compute_out_size(&encodings, &has_nulls)
+    }
+
+    pub fn write_columns(
+        &mut self,
+        arrays: &[&dyn Array],
+        data_types: &[&DataType],
+    ) -> io::Result<usize> {
+        debug_assert_eq!(arrays.len(), self.num_columns);
+        let num_new_rows = arrays[0].len();
+        if num_new_rows == 0 {
+            return Ok(0);
+        }
+        let start_row = self.num_rows;
+        let mut total_size = 0;
+
+        for i in 0..self.num_columns {
+            total_size += self.append_array_column(i, arrays[i], data_types[i], start_row)?;
+        }
+
+        self.num_rows += num_new_rows;
+        total_size += num_new_rows * self.num_columns.div_ceil(8);
+        Ok(total_size)
+    }
+
+    fn append_array_column(
+        &mut self,
+        col: usize,
+        array: &dyn Array,
+        dt: &DataType,
+        start_row: usize,
+    ) -> io::Result<usize> {
+        let num_new_rows = array.len();
+        let needed_bytes = (start_row + num_new_rows).div_ceil(8);
+        if self.null_bitmaps[col].len() < needed_bytes {
+            self.null_bitmaps[col].resize(needed_bytes.next_power_of_two(), 0);
+        }
+
+        let typed = downcast_array(array, dt)?;
+
+        if array.null_count() == 0 {
+            if let Some(col_size) = self.append_no_null_batch(col, &typed, start_row, num_new_rows)
+            {
+                return Ok(col_size);
+            }
+        }
+
+        let mut col_size = 0usize;
+        for row in 0..num_new_rows {
+            let abs_row = start_row + row;
+            if array.is_null(row) {
+                self.null_bitmaps[col][abs_row / 8] |= 1 << (abs_row % 8);
+            } else {
+                self.non_null_counts[col] += 1;
+                let before = self.value_buffers[col].len();
+                write_typed_value(&mut self.value_buffers[col], &typed, row);
+                let written = self.value_buffers[col].len() - before;
+                col_size += written;
+
+                if self.const_tracking[col] {
+                    if self.non_null_counts[col] == 1 {
+                        self.first_value_len[col] = written;
+                    } else if written != self.first_value_len[col]
+                        || !equals_first_value(&self.value_buffers[col], before, written)
+                    {
+                        self.const_tracking[col] = false;
+                    }
+                }
+
+                if let Some(ref mut dict) = self.long_dict_maps[col] {
+                    let key = values::extract_fixed_key(
+                        &self.value_buffers[col],
+                        before,
+                        self.fixed_widths[col],
+                    );
+                    let len = dict.len();
+                    dict.entry(key).or_insert(len);
+                    if dict.len() > self.max_dict_entries {
+                        self.long_dict_maps[col] = None;
+                    }
+                } else if let Some(ref mut dict) = self.byte_dict_maps[col] {
+                    let slice = &self.value_buffers[col][before..before + written];
+                    if !dict.contains_key(slice) {
+                        let len = dict.len();
+                        dict.insert(slice.to_vec(), len);
+                        self.dict_total_bytes[col] += written;
+                    }
+                    if dict.len() > self.max_dict_entries
+                        || self.dict_total_bytes[col] > self.max_dict_total_bytes
+                    {
+                        self.byte_dict_maps[col] = None;
+                    }
+                }
+            }
+        }
+        Ok(col_size)
+    }
+
+    fn append_no_null_batch(
+        &mut self,
+        col: usize,
+        typed: &TypedArrayRef,
+        start_row: usize,
+        num_rows: usize,
+    ) -> Option<usize> {
+        let buf = &mut self.value_buffers[col];
+        let before_all = buf.len();
+
+        match typed {
+            TypedArrayRef::Boolean(a) => {
+                buf.reserve(num_rows);
+                for i in 0..num_rows {
+                    buf.push(if a.value(i) { 1 } else { 0 });
+                }
+            }
+            TypedArrayRef::Int8(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows);
+                for &v in vals.iter() {
+                    buf.push(v as u8);
+                }
+            }
+            TypedArrayRef::Int16(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 2);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::Int32(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 4);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::Int64(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 8);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::Float32(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 4);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_bits().to_be_bytes());
+                }
+            }
+            TypedArrayRef::Float64(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 8);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_bits().to_be_bytes());
+                }
+            }
+            TypedArrayRef::Date32(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 4);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::Time32(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 4);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::Decimal128Compact(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 8);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&(v as i64).to_be_bytes());
+                }
+            }
+            TypedArrayRef::TimestampMillis(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 8);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::TimestampMicros(a) => {
+                let vals = a.values();
+                buf.reserve(num_rows * 8);
+                for &v in vals.iter() {
+                    buf.extend_from_slice(&v.to_be_bytes());
+                }
+            }
+            TypedArrayRef::TimestampNanos { millis, nanos } => {
+                let m_vals = millis.values();
+                let n_vals = nanos.values();
+                buf.reserve(num_rows * 12);
+                for i in 0..num_rows {
+                    buf.extend_from_slice(&m_vals[i].to_be_bytes());
+                    buf.extend_from_slice(&n_vals[i].to_be_bytes());
+                }
+            }
+            _ => return None,
+        }
+
+        let col_size = buf.len() - before_all;
+        let fw = self.fixed_widths[col] as usize;
+        let prev_non_null = self.non_null_counts[col];
+        self.non_null_counts[col] += num_rows;
+
+        if self.const_tracking[col] {
+            if prev_non_null == 0 {
+                self.first_value_len[col] = fw;
+                for i in 1..num_rows {
+                    if !equals_first_value(buf, before_all + i * fw, fw) {
+                        self.const_tracking[col] = false;
+                        break;
+                    }
+                }
+            } else {
+                for i in 0..num_rows {
+                    if !equals_first_value(buf, before_all + i * fw, fw) {
+                        self.const_tracking[col] = false;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(ref mut dict) = self.long_dict_maps[col] {
+            for i in 0..num_rows {
+                let key =
+                    values::extract_fixed_key(buf, before_all + i * fw, self.fixed_widths[col]);
+                let len = dict.len();
+                dict.entry(key).or_insert(len);
+                if dict.len() > self.max_dict_entries {
+                    self.long_dict_maps[col] = None;
+                    break;
+                }
+            }
+        }
+
+        // null_bitmap stays all-zero (no nulls), start_row offsets are fine
+        let _ = start_row;
+
+        Some(col_size)
+    }
+
+    fn compute_encodings(&self) -> (Vec<u8>, Vec<bool>) {
+        let mut encodings = vec![0u8; self.num_columns];
+        let mut has_nulls = vec![false; self.num_columns];
+        for i in 0..self.num_columns {
+            if self.non_null_counts[i] == 0 {
+                encodings[i] = ENCODING_ALL_NULL;
+            } else if self.const_tracking[i] {
+                encodings[i] = ENCODING_CONST;
+                has_nulls[i] = self.non_null_counts[i] < self.num_rows;
+            } else {
+                let dict_size = self.get_dict_size(i);
+                if dict_size >= 2
+                    && dict_size <= self.max_dict_entries
+                    && self.dict_encoded_size(i) < self.value_buffers[i].len()
+                {
+                    encodings[i] = ENCODING_DICT;
+                } else {
+                    encodings[i] = ENCODING_PLAIN;
+                }
+                has_nulls[i] = self.non_null_counts[i] < self.num_rows;
+            }
+        }
+        (encodings, has_nulls)
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    pub fn finish(&self) -> Vec<u8> {
+        if self.num_rows == 0 {
+            return Vec::new();
+        }
+
+        let (encodings, has_nulls) = self.compute_encodings();
+
+        let out_size = self.compute_out_size(&encodings, &has_nulls);
+        let mut out = vec![0u8; out_size];
+        let mut pos = 0;
+
+        // Encoding flags: 2 bits per column
+        let encoding_flags_bytes = (self.num_columns * 2).div_ceil(8);
+        for i in 0..self.num_columns {
+            let byte_idx = (i * 2) / 8;
+            let bit_idx = (i * 2) % 8;
+            out[pos + byte_idx] |= encodings[i] << bit_idx;
+        }
+        pos += encoding_flags_bytes;
+
+        // Has-nulls flags: 1 bit per column
+        let has_nulls_bytes = self.num_columns.div_ceil(8);
+        for i in 0..self.num_columns {
+            if has_nulls[i] {
+                out[pos + i / 8] |= 1 << (i % 8);
+            }
+        }
+        pos += has_nulls_bytes;
+
+        // CONST metadata
+        for i in 0..self.num_columns {
+            if encodings[i] == ENCODING_CONST {
+                let len = self.first_value_len[i];
+                out[pos..pos + len].copy_from_slice(&self.value_buffers[i][..len]);
+                pos += len;
+            }
+        }
+
+        // Dict metadata
+        for i in 0..self.num_columns {
+            if encodings[i] == ENCODING_DICT {
+                if let Some(ref dict) = self.long_dict_maps[i] {
+                    let num_entries = dict.len();
+                    pos = varint::encode_to_slice(&mut out, pos, num_entries as u32);
+                    let w = self.fixed_widths[i];
+                    let mut keys = vec![0u64; num_entries];
+                    for (&key, &idx) in dict {
+                        keys[idx] = key;
+                    }
+                    for key in &keys {
+                        write_fixed_key_to_slice(&mut out, &mut pos, *key, w);
+                    }
+                } else if let Some(ref dict) = self.byte_dict_maps[i] {
+                    let num_entries = dict.len();
+                    pos = varint::encode_to_slice(&mut out, pos, num_entries as u32);
+                    let mut keys: Vec<(&Vec<u8>, &usize)> = dict.iter().collect();
+                    keys.sort_by_key(|&(_, idx)| *idx);
+                    for (key, _) in keys {
+                        out[pos..pos + key.len()].copy_from_slice(key);
+                        pos += key.len();
+                    }
+                }
+            }
+        }
+
+        // Null bitmaps
+        let null_bitmap_bytes = self.num_rows.div_ceil(8);
+        for i in 0..self.num_columns {
+            if has_nulls[i] && encodings[i] != ENCODING_ALL_NULL {
+                out[pos..pos + null_bitmap_bytes]
+                    .copy_from_slice(&self.null_bitmaps[i][..null_bitmap_bytes]);
+                pos += null_bitmap_bytes;
+            }
+        }
+
+        // Column data
+        for i in 0..self.num_columns {
+            if encodings[i] == ENCODING_PLAIN {
+                let len = self.value_buffers[i].len();
+                out[pos..pos + len].copy_from_slice(&self.value_buffers[i]);
+                pos += len;
+            } else if encodings[i] == ENCODING_DICT {
+                let data_start = pos;
+                let bit_offset = self.write_dict_bit_packed(i, &mut out, data_start);
+                pos += bit_offset.div_ceil(8);
+            }
+        }
+
+        debug_assert_eq!(pos, out.len());
+        out
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    pub fn finish_paged(&self) -> PagedBucketOutput {
+        if self.num_rows == 0 {
+            return PagedBucketOutput {
+                encodings: Vec::new(),
+                has_nulls: Vec::new(),
+                const_data: Vec::new(),
+                column_pages: Vec::new(),
+            };
+        }
+
+        let (encodings, has_nulls) = self.compute_encodings();
+        let null_bitmap_bytes = self.num_rows.div_ceil(8);
+
+        let mut const_data = vec![Vec::new(); self.num_columns];
+        let mut column_pages: Vec<Option<Vec<u8>>> = vec![None; self.num_columns];
+
+        for i in 0..self.num_columns {
+            match encodings[i] {
+                ENCODING_ALL_NULL => {}
+                ENCODING_CONST => {
+                    let len = self.first_value_len[i];
+                    const_data[i] = self.value_buffers[i][..len].to_vec();
+                    if has_nulls[i] {
+                        column_pages[i] = Some(self.null_bitmaps[i][..null_bitmap_bytes].to_vec());
+                    }
+                }
+                ENCODING_DICT => {
+                    let mut page = Vec::new();
+                    // Dict table
+                    if let Some(ref dict) = self.long_dict_maps[i] {
+                        let num_entries = dict.len();
+                        varint::encode(&mut page, num_entries as u32);
+                        let w = self.fixed_widths[i];
+                        let mut keys = vec![0u64; num_entries];
+                        for (&key, &idx) in dict {
+                            keys[idx] = key;
+                        }
+                        for key in &keys {
+                            write_fixed_key_to_vec(&mut page, *key, w);
+                        }
+                    } else if let Some(ref dict) = self.byte_dict_maps[i] {
+                        let num_entries = dict.len();
+                        varint::encode(&mut page, num_entries as u32);
+                        let mut keys: Vec<(&Vec<u8>, &usize)> = dict.iter().collect();
+                        keys.sort_by_key(|&(_, idx)| *idx);
+                        for (key, _) in keys {
+                            page.extend_from_slice(key);
+                        }
+                    }
+                    // Null bitmap
+                    if has_nulls[i] {
+                        page.extend_from_slice(&self.null_bitmaps[i][..null_bitmap_bytes]);
+                    }
+                    // Bit-packed indices
+                    let dict_size = self.get_dict_size(i);
+                    let bw = bit_width(dict_size);
+                    let packed_bytes = (self.non_null_counts[i] * bw).div_ceil(8);
+                    let data_start = page.len();
+                    page.resize(data_start + packed_bytes, 0);
+                    self.write_dict_bit_packed(i, &mut page, data_start);
+                    column_pages[i] = Some(page);
+                }
+                ENCODING_PLAIN => {
+                    let mut page = Vec::new();
+                    if has_nulls[i] {
+                        page.extend_from_slice(&self.null_bitmaps[i][..null_bitmap_bytes]);
+                    }
+                    page.extend_from_slice(&self.value_buffers[i]);
+                    column_pages[i] = Some(page);
+                }
+                _ => {}
+            }
+        }
+
+        PagedBucketOutput {
+            encodings,
+            has_nulls,
+            const_data,
+            column_pages,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for i in 0..self.num_columns {
+            for b in &mut self.null_bitmaps[i] {
+                *b = 0;
+            }
+            self.value_buffers[i].clear();
+            self.non_null_counts[i] = 0;
+            self.const_tracking[i] = true;
+            self.first_value_len[i] = 0;
+            self.dict_total_bytes[i] = 0;
+            if uses_long_dict(self.fixed_widths[i]) {
+                if let Some(ref mut dict) = self.long_dict_maps[i] {
+                    dict.clear();
+                } else {
+                    self.long_dict_maps[i] = Some(HashMap::new());
+                }
+            } else if let Some(ref mut dict) = self.byte_dict_maps[i] {
+                dict.clear();
+            } else {
+                self.byte_dict_maps[i] = Some(HashMap::new());
+            }
+        }
+        self.num_rows = 0;
+    }
+
+    fn get_dict_size(&self, col: usize) -> usize {
+        if let Some(ref dict) = self.long_dict_maps[col] {
+            return dict.len();
+        }
+        if let Some(ref dict) = self.byte_dict_maps[col] {
+            return dict.len();
+        }
+        0
+    }
+
+    fn write_dict_bit_packed(&self, col: usize, buf: &mut [u8], data_start: usize) -> usize {
+        let dict_size = self.get_dict_size(col);
+        let bw = bit_width(dict_size);
+        let w = self.fixed_widths[col];
+        let mut bit_offset = 0usize;
+        let mut val_pos = 0usize;
+
+        for r in 0..self.num_rows {
+            let is_null = (self.null_bitmaps[col][r / 8] & (1 << (r % 8))) != 0;
+            if !is_null {
+                let idx = if let Some(ref dict) = self.long_dict_maps[col] {
+                    let key = values::extract_fixed_key(&self.value_buffers[col], val_pos, w);
+                    val_pos += w as usize;
+                    *dict.get(&key).unwrap()
+                } else if let Some(ref dict) = self.byte_dict_maps[col] {
+                    let value_len = if w > 0 {
+                        w as usize
+                    } else {
+                        let var_len =
+                            varint::decode(&self.value_buffers[col], &mut val_pos.clone())
+                                .expect("internal varint in value buffer");
+                        varint::encoded_size(var_len) + var_len as usize
+                    };
+                    let slice = &self.value_buffers[col][val_pos..val_pos + value_len];
+                    val_pos += value_len;
+                    *dict.get(slice).unwrap()
+                } else {
+                    unreachable!()
+                };
+                write_bit_packed(buf, data_start, bit_offset, idx, bw);
+                bit_offset += bw;
+            }
+        }
+        bit_offset
+    }
+
+    fn dict_encoded_size(&self, col: usize) -> usize {
+        let (num_entries, entry_bytes) = if let Some(ref dict) = self.long_dict_maps[col] {
+            (dict.len(), dict.len() * self.fixed_widths[col] as usize)
+        } else if let Some(ref dict) = self.byte_dict_maps[col] {
+            let bytes: usize = dict.keys().map(|k| k.len()).sum();
+            (dict.len(), bytes)
+        } else {
+            return usize::MAX;
+        };
+        let index_bytes = (self.non_null_counts[col] * bit_width(num_entries)).div_ceil(8);
+        varint::encoded_size(num_entries as u32) + entry_bytes + index_bytes
+    }
+
+    fn compute_out_size(&self, encodings: &[u8], has_nulls: &[bool]) -> usize {
+        let null_bitmap_bytes = self.num_rows.div_ceil(8);
+        let mut size = (self.num_columns * 2).div_ceil(8) + self.num_columns.div_ceil(8);
+
+        for i in 0..self.num_columns {
+            if encodings[i] == ENCODING_ALL_NULL {
+                continue;
+            }
+            if has_nulls[i] {
+                size += null_bitmap_bytes;
+            }
+            match encodings[i] {
+                ENCODING_CONST => {
+                    size += self.first_value_len[i];
+                }
+                ENCODING_DICT => {
+                    if let Some(ref dict) = self.long_dict_maps[i] {
+                        let n = dict.len();
+                        size += varint::encoded_size(n as u32) + n * self.fixed_widths[i] as usize;
+                        size += (self.non_null_counts[i] * bit_width(n)).div_ceil(8);
+                    } else if let Some(ref dict) = self.byte_dict_maps[i] {
+                        let n = dict.len();
+                        size += varint::encoded_size(n as u32);
+                        size += dict.keys().map(|k| k.len()).sum::<usize>();
+                        size += (self.non_null_counts[i] * bit_width(n)).div_ceil(8);
+                    }
+                }
+                ENCODING_PLAIN => {
+                    size += self.value_buffers[i].len();
+                }
+                _ => {}
+            }
+        }
+        size
+    }
+}
+
+enum TypedArrayRef<'a> {
+    Boolean(&'a BooleanArray),
+    Int8(&'a Int8Array),
+    Int16(&'a Int16Array),
+    Int32(&'a Int32Array),
+    Int64(&'a Int64Array),
+    Float32(&'a Float32Array),
+    Float64(&'a Float64Array),
+    Date32(&'a Date32Array),
+    Time32(&'a Time32MillisecondArray),
+    Utf8(&'a StringArray),
+    Binary(&'a BinaryArray),
+    Decimal128Compact(&'a Decimal128Array),
+    Decimal128Large(&'a Decimal128Array),
+    TimestampMillis(&'a TimestampMillisecondArray),
+    TimestampMicros(&'a TimestampMicrosecondArray),
+    TimestampNanos {
+        millis: &'a Int64Array,
+        nanos: &'a Int32Array,
+    },
+}
+
+fn cast_err(dt: &DataType) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("array downcast failed for DataType: {:?}", dt),
+    )
+}
+
+fn downcast_array<'a>(array: &'a dyn Array, dt: &DataType) -> io::Result<TypedArrayRef<'a>> {
+    let any = array.as_any();
+    match dt {
+        DataType::Boolean => Ok(TypedArrayRef::Boolean(
+            any.downcast_ref::<BooleanArray>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Int8 => Ok(TypedArrayRef::Int8(
+            any.downcast_ref::<Int8Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Int16 => Ok(TypedArrayRef::Int16(
+            any.downcast_ref::<Int16Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Int32 => Ok(TypedArrayRef::Int32(
+            any.downcast_ref::<Int32Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Int64 => Ok(TypedArrayRef::Int64(
+            any.downcast_ref::<Int64Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Float32 => Ok(TypedArrayRef::Float32(
+            any.downcast_ref::<Float32Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Float64 => Ok(TypedArrayRef::Float64(
+            any.downcast_ref::<Float64Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Date32 => Ok(TypedArrayRef::Date32(
+            any.downcast_ref::<Date32Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Time32(_) => Ok(TypedArrayRef::Time32(
+            any.downcast_ref::<Time32MillisecondArray>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Utf8 => Ok(TypedArrayRef::Utf8(
+            any.downcast_ref::<StringArray>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Binary => Ok(TypedArrayRef::Binary(
+            any.downcast_ref::<BinaryArray>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Decimal128(p, _) if *p <= 18 => Ok(TypedArrayRef::Decimal128Compact(
+            any.downcast_ref::<Decimal128Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Decimal128(_, _) => Ok(TypedArrayRef::Decimal128Large(
+            any.downcast_ref::<Decimal128Array>()
+                .ok_or_else(|| cast_err(dt))?,
+        )),
+        DataType::Timestamp(arrow_schema::TimeUnit::Millisecond, _) => {
+            Ok(TypedArrayRef::TimestampMillis(
+                any.downcast_ref::<TimestampMillisecondArray>()
+                    .ok_or_else(|| cast_err(dt))?,
+            ))
+        }
+        DataType::Timestamp(arrow_schema::TimeUnit::Microsecond, _) => {
+            Ok(TypedArrayRef::TimestampMicros(
+                any.downcast_ref::<TimestampMicrosecondArray>()
+                    .ok_or_else(|| cast_err(dt))?,
+            ))
+        }
+        DataType::Struct(fields) if types::is_timestamp_nanos_struct(fields) => {
+            let s = any
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| cast_err(dt))?;
+            let ts_dt = DataType::Int64;
+            let ns_dt = DataType::Int32;
+            Ok(TypedArrayRef::TimestampNanos {
+                millis: s
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .ok_or_else(|| cast_err(&ts_dt))?,
+                nanos: s
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .ok_or_else(|| cast_err(&ns_dt))?,
+            })
+        }
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsupported DataType: {:?}", dt),
+        )),
+    }
+}
+
+#[inline]
+fn write_typed_value(buf: &mut Vec<u8>, typed: &TypedArrayRef, row: usize) {
+    match typed {
+        TypedArrayRef::Boolean(a) => buf.push(if a.value(row) { 1 } else { 0 }),
+        TypedArrayRef::Int8(a) => buf.push(a.value(row) as u8),
+        TypedArrayRef::Int16(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::Int32(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::Int64(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::Float32(a) => buf.extend_from_slice(&a.value(row).to_bits().to_be_bytes()),
+        TypedArrayRef::Float64(a) => buf.extend_from_slice(&a.value(row).to_bits().to_be_bytes()),
+        TypedArrayRef::Date32(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::Time32(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::Utf8(a) => {
+            let bytes = a.value(row).as_bytes();
+            varint::encode(buf, bytes.len() as u32);
+            buf.extend_from_slice(bytes);
+        }
+        TypedArrayRef::Binary(a) => {
+            let bytes = a.value(row);
+            varint::encode(buf, bytes.len() as u32);
+            buf.extend_from_slice(bytes);
+        }
+        TypedArrayRef::Decimal128Compact(a) => {
+            buf.extend_from_slice(&(a.value(row) as i64).to_be_bytes())
+        }
+        TypedArrayRef::Decimal128Large(a) => {
+            let bytes = i128_to_biginteger_bytes(a.value(row));
+            varint::encode(buf, bytes.len() as u32);
+            buf.extend_from_slice(&bytes);
+        }
+        TypedArrayRef::TimestampMillis(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::TimestampMicros(a) => buf.extend_from_slice(&a.value(row).to_be_bytes()),
+        TypedArrayRef::TimestampNanos { millis, nanos } => {
+            buf.extend_from_slice(&millis.value(row).to_be_bytes());
+            buf.extend_from_slice(&nanos.value(row).to_be_bytes());
+        }
+    }
+}
+
+fn i128_to_biginteger_bytes(val: i128) -> Vec<u8> {
+    let bytes = val.to_be_bytes();
+    let negative = val < 0;
+    let pad = if negative { 0xFF } else { 0x00 };
+    let mut start = 0;
+    while start < 15 {
+        if bytes[start] != pad {
+            break;
+        }
+        if (bytes[start + 1] & 0x80 != 0) != negative {
+            break;
+        }
+        start += 1;
+    }
+    bytes[start..].to_vec()
+}
+
+fn uses_long_dict(fixed_width: i32) -> bool {
+    fixed_width > 0 && fixed_width <= 8
+}
+
+fn bit_width(num_entries: usize) -> usize {
+    if num_entries <= 1 {
+        return 0;
+    }
+    usize::BITS as usize - (num_entries - 1).leading_zeros() as usize
+}
+
+fn write_bit_packed(buf: &mut [u8], byte_base: usize, bit_offset: usize, value: usize, bw: usize) {
+    if bw == 0 {
+        return;
+    }
+    let start_byte = byte_base + bit_offset / 8;
+    let bit_shift = bit_offset % 8;
+    let mut bits = (value as u64) << bit_shift;
+    let total_bits = bit_shift + bw;
+    let num_bytes = total_bits.div_ceil(8);
+    for i in 0..num_bytes {
+        buf[start_byte + i] |= (bits & 0xFF) as u8;
+        bits >>= 8;
+    }
+}
+
+fn equals_first_value(buf: &[u8], offset: usize, len: usize) -> bool {
+    buf[..len] == buf[offset..offset + len]
+}
+
+fn write_fixed_key_to_vec(buf: &mut Vec<u8>, key: u64, width: i32) {
+    match width {
+        1 => buf.push(key as u8),
+        2 => buf.extend_from_slice(&(key as u16).to_be_bytes()),
+        4 => buf.extend_from_slice(&(key as u32).to_be_bytes()),
+        8 => buf.extend_from_slice(&key.to_be_bytes()),
+        _ => {}
+    }
+}
+
+fn write_fixed_key_to_slice(buf: &mut [u8], pos: &mut usize, key: u64, width: i32) {
+    match width {
+        1 => {
+            buf[*pos] = key as u8;
+            *pos += 1;
+        }
+        2 => {
+            let bytes = (key as u16).to_be_bytes();
+            buf[*pos..*pos + 2].copy_from_slice(&bytes);
+            *pos += 2;
+        }
+        4 => {
+            let bytes = (key as u32).to_be_bytes();
+            buf[*pos..*pos + 4].copy_from_slice(&bytes);
+            *pos += 4;
+        }
+        8 => {
+            let bytes = key.to_be_bytes();
+            buf[*pos..*pos + 8].copy_from_slice(&bytes);
+            *pos += 8;
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_null_encoding() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let arr = Int32Array::new_null(10);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert!(!data.is_empty());
+        assert_eq!(data[0] & 0x03, ENCODING_ALL_NULL);
+    }
+
+    #[test]
+    fn test_const_encoding() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let arr = Int32Array::from(vec![42; 10]);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_CONST);
+    }
+
+    #[test]
+    fn test_dict_encoding() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let vals: Vec<i32> = (0..100).map(|i| i % 3).collect();
+        let arr = Int32Array::from(vals);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+    }
+
+    #[test]
+    fn test_plain_encoding() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let vals: Vec<i32> = (0..1000).collect();
+        let arr = Int32Array::from(vals);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_PLAIN);
+    }
+
+    #[test]
+    fn test_const_string_encoding() {
+        let types = [DataType::Utf8];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let arr = StringArray::from(vec!["same"; 50]);
+        writer.write_columns(&[&arr], &[&DataType::Utf8]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_CONST);
+    }
+
+    #[test]
+    fn test_dict_string_encoding() {
+        let types = [DataType::Utf8];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let vals: Vec<&str> = (0..60).map(|i| ["aa", "bb", "cc"][i % 3]).collect();
+        let arr = StringArray::from(vals);
+        writer.write_columns(&[&arr], &[&DataType::Utf8]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+    }
+
+    #[test]
+    fn test_const_with_nulls() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let vals: Vec<Option<i32>> = (0..20)
+            .map(|i| if i % 3 == 0 { None } else { Some(42) })
+            .collect();
+        let arr = Int32Array::from(vals);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_CONST);
+    }
+
+    #[test]
+    fn test_dict_with_nulls() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let vals: Vec<Option<i32>> = (0..100)
+            .map(|i| if i % 5 == 0 { None } else { Some(i % 3) })
+            .collect();
+        let arr = Int32Array::from(vals);
+        writer.write_columns(&[&arr], &[&DataType::Int32]).unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+    }
+
+    #[test]
+    fn test_multi_column_mixed_encodings() {
+        let types = [DataType::Int32, DataType::Utf8, DataType::Int64];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let col0 = Int32Array::new_null(100);
+        let col1 = StringArray::from(vec!["same"; 100]);
+        let col2_vals: Vec<i64> = (0..100).map(|i| i % 4).collect();
+        let col2 = Int64Array::from(col2_vals);
+
+        writer
+            .write_columns(
+                &[&col0, &col1, &col2],
+                &[&DataType::Int32, &DataType::Utf8, &DataType::Int64],
+            )
+            .unwrap();
+
+        let data = writer.finish();
+        assert_eq!(data[0] & 0x03, ENCODING_ALL_NULL);
+        assert_eq!((data[0] >> 2) & 0x03, ENCODING_CONST);
+        assert_eq!((data[0] >> 4) & 0x03, ENCODING_DICT);
+    }
+
+    #[test]
+    fn test_reset_and_reuse() {
+        let types = [DataType::Int32];
+        let type_refs: Vec<&DataType> = types.iter().collect();
+        let mut writer = BucketWriter::new(&type_refs, 32768, 255);
+
+        let arr1 = Int32Array::from(vec![42; 10]);
+        writer.write_columns(&[&arr1], &[&DataType::Int32]).unwrap();
+        let data1 = writer.finish();
+        assert_eq!(data1[0] & 0x03, ENCODING_CONST);
+
+        writer.reset();
+        assert!(writer.is_empty());
+
+        let vals: Vec<i32> = (0..1000).collect();
+        let arr2 = Int32Array::from(vals);
+        writer.write_columns(&[&arr2], &[&DataType::Int32]).unwrap();
+        let data2 = writer.finish();
+        assert_eq!(data2[0] & 0x03, ENCODING_PLAIN);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub mod bpe;
+pub mod bucket_reader;
+pub mod bucket_writer;
+pub mod reader;
+pub mod schema;
+pub mod spec;
+pub mod types;
+pub mod values;
+pub mod varint;
+pub mod writer;

--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -1,0 +1,819 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io;
+
+use arrow_array::ArrayRef;
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema};
+
+use crate::bucket_reader::{read_typed_value, read_variable_value, BucketReader, ColumnPageReader};
+use crate::schema::MosaicSchema;
+use crate::spec::*;
+use crate::types;
+use crate::values::Value;
+use crate::varint;
+
+const COALESCE_GAP: u64 = 1024 * 1024;
+const COALESCE_MAX_RANGE: u64 = 32 * 1024 * 1024;
+
+/// A random-access file abstraction for reading Mosaic files.
+///
+/// The `Sync` bound is required because the reader may call `read_at` from
+/// multiple threads in parallel (e.g. when coalescing IO ranges).
+/// Implementations must ensure that concurrent `read_at` calls are safe.
+pub trait InputFile: Sync {
+    /// Read `buf.len()` bytes starting at `offset`.
+    ///
+    /// # Thread safety
+    /// This method must be safe to call concurrently from multiple threads.
+    fn read_at(&self, offset: u64, buf: &mut [u8]) -> io::Result<()>;
+
+    fn read_ranges(&self, ranges: &[(u64, usize)]) -> io::Result<Vec<Vec<u8>>> {
+        if ranges.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build sorted index
+        let mut indices: Vec<usize> = (0..ranges.len()).collect();
+        indices.sort_unstable_by_key(|&i| ranges[i].0);
+
+        // Merge ranges with gap <= COALESCE_GAP and total size <= COALESCE_MAX_RANGE
+        struct MergedRange {
+            start: u64,
+            end: u64,
+            members: Vec<usize>, // original indices
+        }
+
+        let mut merged: Vec<MergedRange> = Vec::new();
+        for &idx in &indices {
+            let (offset, len) = ranges[idx];
+            let range_end = offset + len as u64;
+
+            let should_merge = if let Some(last) = merged.last() {
+                offset >= last.start
+                    && offset.saturating_sub(last.end) <= COALESCE_GAP
+                    && (range_end - last.start) <= COALESCE_MAX_RANGE
+            } else {
+                false
+            };
+
+            if should_merge {
+                let last = merged.last_mut().unwrap();
+                last.end = last.end.max(range_end);
+                last.members.push(idx);
+            } else {
+                merged.push(MergedRange {
+                    start: offset,
+                    end: range_end,
+                    members: vec![idx],
+                });
+            }
+        }
+
+        // Fetch merged ranges in parallel
+        let fetched: Vec<io::Result<Vec<u8>>> = std::thread::scope(|s| {
+            let handles: Vec<_> = merged
+                .iter()
+                .map(|mr| {
+                    s.spawn(|| {
+                        let len = (mr.end - mr.start) as usize;
+                        let mut buf = vec![0u8; len];
+                        self.read_at(mr.start, &mut buf)?;
+                        Ok(buf)
+                    })
+                })
+                .collect();
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+        let fetched: Vec<Vec<u8>> = fetched.into_iter().collect::<io::Result<_>>()?;
+
+        // Distribute slices back to original order
+        let mut results: Vec<Vec<u8>> = Vec::with_capacity(ranges.len());
+        results.resize_with(ranges.len(), Vec::new);
+        for (mi, mr) in merged.iter().enumerate() {
+            let buf = &fetched[mi];
+            for &idx in &mr.members {
+                let (offset, len) = ranges[idx];
+                let rel_start = (offset - mr.start) as usize;
+                results[idx] = buf[rel_start..rel_start + len].to_vec();
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+pub struct RowGroupMeta {
+    pub num_rows: usize,
+    pub bucket_offsets: Vec<u64>,
+    pub bucket_layouts: Vec<BucketLayout>,
+}
+
+pub trait ReaderAccess {
+    fn schema(&self) -> &MosaicSchema;
+    fn num_row_groups(&self) -> usize;
+    fn row_group_reader(&self, rg_index: usize) -> io::Result<RowGroupReader>;
+    fn row_group_reader_projected(
+        &self,
+        rg_index: usize,
+        columns: &[usize],
+    ) -> io::Result<RowGroupReader>;
+}
+
+pub struct MosaicReader<I: InputFile> {
+    input: I,
+    schema: MosaicSchema,
+    row_group_metas: Vec<RowGroupMeta>,
+    compression: u8,
+    num_buckets: usize,
+}
+
+fn read_range(input: &dyn InputFile, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0u8; len];
+    input.read_at(offset, &mut buf)?;
+    Ok(buf)
+}
+
+const TAIL_PREFETCH_SIZE: u64 = 64 * 1024;
+
+impl<I: InputFile> MosaicReader<I> {
+    pub fn new(input: I, file_len: u64) -> io::Result<Self> {
+        if (file_len as usize) < FOOTER_SIZE {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "file too small"));
+        }
+
+        // Read a tail chunk that likely covers all metadata in one IO
+        let tail_size = file_len.min(TAIL_PREFETCH_SIZE) as usize;
+        let tail_offset = file_len - tail_size as u64;
+        let tail = read_range(&input, tail_offset, tail_size)?;
+
+        let footer = &tail[tail_size - FOOTER_SIZE..];
+
+        if footer[28] != MAGIC[0]
+            || footer[29] != MAGIC[1]
+            || footer[30] != MAGIC[2]
+            || footer[31] != MAGIC[3]
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bad magic bytes",
+            ));
+        }
+
+        let version = footer[25];
+        if version != VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported version: {}", version),
+            ));
+        }
+
+        let index_offset = u64::from_be_bytes(footer[0..8].try_into().unwrap());
+        let schema_block_offset = u64::from_be_bytes(footer[8..16].try_into().unwrap());
+        let num_buckets = u32::from_be_bytes(footer[16..20].try_into().unwrap()) as usize;
+        let num_row_groups = u32::from_be_bytes(footer[20..24].try_into().unwrap()) as usize;
+        let compression = footer[24];
+
+        let schema_data_start = schema_block_offset.checked_add(4).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "corrupted footer offsets")
+        })?;
+        let footer_start = file_len - FOOTER_SIZE as u64;
+        if !(schema_data_start <= index_offset
+            && index_offset <= footer_start
+            && footer_start <= file_len)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "corrupted footer offsets",
+            ));
+        }
+
+        // All metadata starts at schema_block_offset. Check if our tail covers it.
+        let meta_buf = if schema_block_offset >= tail_offset {
+            // Tail covers all metadata — zero additional IO
+            let local_start = (schema_block_offset - tail_offset) as usize;
+            let local_end = tail_size - FOOTER_SIZE;
+            tail[local_start..local_end].to_vec()
+        } else {
+            // Metadata is larger than our tail prefetch — one more IO
+            let meta_len = (footer_start - schema_block_offset) as usize;
+            read_range(&input, schema_block_offset, meta_len)?
+        };
+
+        // Parse schema block from meta_buf
+        let schema_uncompressed_size =
+            u32::from_be_bytes(meta_buf[0..4].try_into().unwrap()) as usize;
+        let schema_compressed_len = (index_offset - schema_block_offset - 4) as usize;
+        let schema_compressed = &meta_buf[4..4 + schema_compressed_len];
+
+        let schema_raw = match compression {
+            COMPRESSION_NONE => schema_compressed.to_vec(),
+            COMPRESSION_ZSTD => zstd::bulk::decompress(schema_compressed, schema_uncompressed_size)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unsupported compression: {}", compression),
+                ))
+            }
+        };
+
+        let schema = MosaicSchema::deserialize(&schema_raw)?;
+
+        if schema.num_buckets != num_buckets {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "footer num_buckets does not match schema",
+            ));
+        }
+
+        if num_buckets == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "num_buckets must be > 0",
+            ));
+        }
+
+        // Parse row group index from meta_buf
+        let index_local_start = (index_offset - schema_block_offset) as usize;
+        let index_data = &meta_buf[index_local_start..];
+        let mut pos = 0usize;
+        let mut row_group_metas = Vec::with_capacity(num_row_groups);
+
+        for _ in 0..num_row_groups {
+            let num_rows = varint::decode(index_data, &mut pos)? as usize;
+            let non_empty = varint::decode(index_data, &mut pos)? as usize;
+
+            if non_empty > num_buckets {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "non_empty count exceeds num_buckets",
+                ));
+            }
+
+            let mut bucket_offsets = vec![0u64; num_buckets];
+            let mut bucket_layouts = vec![BucketLayout::Empty; num_buckets];
+            let mut seen_buckets = vec![false; num_buckets];
+
+            for _ in 0..non_empty {
+                let bucket_id = varint::decode(index_data, &mut pos)? as usize;
+                if bucket_id >= num_buckets || pos + 8 > index_data.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "corrupted row group index",
+                    ));
+                }
+                if seen_buckets[bucket_id] {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "duplicate bucket_id in row group index",
+                    ));
+                }
+                seen_buckets[bucket_id] = true;
+                bucket_offsets[bucket_id] =
+                    u64::from_be_bytes(index_data[pos..pos + 8].try_into().unwrap());
+                pos += 8;
+                let compressed_size = varint::decode(index_data, &mut pos)? as usize;
+                let bulk_decompress_size = varint::decode(index_data, &mut pos)? as usize;
+                bucket_layouts[bucket_id] =
+                    BucketLayout::decode(compressed_size, bulk_decompress_size)
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+                let end = bucket_offsets[bucket_id]
+                    .checked_add(compressed_size as u64)
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "bucket offset overflow")
+                    })?;
+                if end > schema_block_offset {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "bucket data extends past schema block",
+                    ));
+                }
+            }
+
+            row_group_metas.push(RowGroupMeta {
+                num_rows,
+                bucket_offsets,
+                bucket_layouts,
+            });
+        }
+
+        if pos != index_data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "trailing bytes in row group index",
+            ));
+        }
+
+        Ok(MosaicReader {
+            input,
+            schema,
+            row_group_metas,
+            compression,
+            num_buckets,
+        })
+    }
+
+    pub fn input(&self) -> &I {
+        &self.input
+    }
+
+    fn parse_column_slot(
+        slot_data: &[u8],
+        col_type: &DataType,
+        num_rows: usize,
+    ) -> io::Result<ColumnPageReader> {
+        let mut spos = 0usize;
+        let uncompressed_size = varint::decode(slot_data, &mut spos)? as usize;
+        let compressed_data = &slot_data[spos..];
+        let page_content = zstd::bulk::decompress(compressed_data, uncompressed_size)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        if page_content.len() < 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "paged bucket: page_content too short",
+            ));
+        }
+        let encoding = page_content[0];
+        let flags = page_content[1];
+        let has_nulls = (flags & 1) != 0;
+        let mut ppos = 2usize;
+
+        let mut const_value = Value::Null;
+        if encoding == ENCODING_CONST {
+            let w = types::fixed_width(col_type);
+            if w > 0 {
+                if ppos + w as usize > page_content.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "paged bucket: page_content truncated at const value",
+                    ));
+                }
+                const_value = read_typed_value(col_type, &page_content, ppos, w);
+                ppos += w as usize;
+            } else {
+                let (value, size) = read_variable_value(col_type, &page_content, ppos)?;
+                const_value = value;
+                ppos += size;
+            }
+        }
+
+        let page_data = page_content[ppos..].to_vec();
+
+        ColumnPageReader::new(
+            col_type.clone(),
+            encoding,
+            has_nulls,
+            const_value,
+            page_data,
+            num_rows,
+        )
+    }
+}
+
+impl<I: InputFile> ReaderAccess for MosaicReader<I> {
+    fn schema(&self) -> &MosaicSchema {
+        &self.schema
+    }
+
+    fn num_row_groups(&self) -> usize {
+        self.row_group_metas.len()
+    }
+
+    fn row_group_reader(&self, rg_index: usize) -> io::Result<RowGroupReader> {
+        let all_columns: Vec<usize> = (0..self.schema.columns.len()).collect();
+        self.row_group_reader_projected(rg_index, &all_columns)
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn row_group_reader_projected(
+        &self,
+        rg_index: usize,
+        columns: &[usize],
+    ) -> io::Result<RowGroupReader> {
+        if rg_index >= self.row_group_metas.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "row group index out of range",
+            ));
+        }
+
+        let meta = &self.row_group_metas[rg_index];
+        let num_cols = self.schema.columns.len();
+
+        let mut projected = vec![false; num_cols];
+        for &c in columns {
+            if c >= num_cols {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "projected column index {} out of range (num_columns={})",
+                        c, num_cols
+                    ),
+                ));
+            }
+            projected[c] = true;
+        }
+
+        let mut needed_buckets = vec![false; self.num_buckets];
+        let mut all_projected_in_bucket = vec![false; self.num_buckets];
+        for b in 0..self.num_buckets {
+            let mut any = false;
+            let mut all = true;
+            for &gi in &self.schema.bucket_to_global[b] {
+                if projected[gi] {
+                    any = true;
+                } else {
+                    all = false;
+                }
+            }
+            needed_buckets[b] = any;
+            all_projected_in_bucket[b] = any && all;
+        }
+
+        // Classify buckets and collect Round 1 ranges:
+        // - Monolithic buckets: read entire compressed blob
+        // - Paged buckets with all columns projected: read entire bucket (skip round 2)
+        // - Paged buckets with partial projection: read directory only (round 2 fetches slots)
+        let mut bucket_kinds = Vec::with_capacity(self.num_buckets);
+        let mut r1_ranges: Vec<(u64, usize)> = Vec::new();
+        let mut r1_bucket_ids: Vec<usize> = Vec::new();
+
+        for b in 0..self.num_buckets {
+            let layout = if needed_buckets[b] {
+                meta.bucket_layouts[b]
+            } else {
+                BucketLayout::Empty
+            };
+            match layout {
+                BucketLayout::Empty => {
+                    bucket_kinds.push(BucketLayout::Empty);
+                }
+                BucketLayout::Paged { total_size } => {
+                    if self.compression != COMPRESSION_ZSTD {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "paged bucket requires ZSTD compression",
+                        ));
+                    }
+                    let dir_size = self.schema.bucket_to_global[b].len() * 4;
+                    if dir_size > total_size {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "paged bucket {}: directory size {} exceeds total size {}",
+                                b, dir_size, total_size
+                            ),
+                        ));
+                    }
+                    if all_projected_in_bucket[b] {
+                        r1_ranges.push((meta.bucket_offsets[b], total_size));
+                    } else {
+                        r1_ranges.push((meta.bucket_offsets[b], dir_size));
+                    }
+                    r1_bucket_ids.push(b);
+                    bucket_kinds.push(layout);
+                }
+                BucketLayout::Monolithic {
+                    compressed_size, ..
+                } => {
+                    r1_ranges.push((meta.bucket_offsets[b], compressed_size));
+                    r1_bucket_ids.push(b);
+                    bucket_kinds.push(layout);
+                }
+            }
+        }
+
+        // Round 1: batch read all directories + monolithic blobs
+        let r1_buffers = self.input.read_ranges(&r1_ranges)?;
+
+        // Process Round 1 results, build Round 2 ranges for paged bucket slots
+        let mut bucket_states: Vec<Option<BucketState>> =
+            (0..self.num_buckets).map(|_| None).collect();
+        let mut r2_ranges: Vec<(u64, usize)> = Vec::new();
+        // Track which paged bucket each merged range group belongs to,
+        // and which columns within that bucket
+        struct PagedSlotInfo {
+            bucket_id: usize,
+            col_idx: usize,
+        }
+        let mut r2_group_infos: Vec<Vec<PagedSlotInfo>> = Vec::new();
+
+        // Per-bucket directory parse results (slot_sizes, slot_file_offsets) for paged buckets
+        let mut paged_dir_info: Vec<Option<(Vec<usize>, Vec<u64>)>> = vec![None; self.num_buckets];
+
+        for (ri, &b) in r1_bucket_ids.iter().enumerate() {
+            let buf = &r1_buffers[ri];
+            match bucket_kinds[b] {
+                BucketLayout::Monolithic {
+                    uncompressed_size, ..
+                } => {
+                    let global_indices = &self.schema.bucket_to_global[b];
+                    let bucket_data = match self.compression {
+                        COMPRESSION_NONE => buf.clone(),
+                        COMPRESSION_ZSTD => zstd::bulk::decompress(buf, uncompressed_size)
+                            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                        _ => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "unsupported compression",
+                            ))
+                        }
+                    };
+                    let col_types: Vec<DataType> = global_indices
+                        .iter()
+                        .map(|&gi| self.schema.columns[gi].data_type.clone())
+                        .collect();
+                    let reader =
+                        Box::new(BucketReader::new(col_types, bucket_data, meta.num_rows)?);
+                    bucket_states[b] = Some(BucketState::Monolithic { reader });
+                }
+                BucketLayout::Paged { total_size } => {
+                    let global_indices = &self.schema.bucket_to_global[b];
+                    let num_columns = global_indices.len();
+
+                    // Parse directory
+                    let mut slot_sizes = Vec::with_capacity(num_columns);
+                    for i in 0..num_columns {
+                        let off = i * 4;
+                        let size =
+                            u32::from_le_bytes(buf[off..off + 4].try_into().unwrap()) as usize;
+                        slot_sizes.push(size);
+                    }
+
+                    // Validate: directory + slots must exactly equal total_size
+                    let dir_size = num_columns * 4;
+                    let slot_total: usize = slot_sizes.iter().sum();
+                    if dir_size + slot_total != total_size {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "paged bucket {}: directory ({}) + slots ({}) != total size ({})",
+                                b, dir_size, slot_total, total_size
+                            ),
+                        ));
+                    }
+
+                    if all_projected_in_bucket[b] {
+                        // All columns projected — we already read the full bucket in round 1,
+                        // parse all slots directly without a second read_ranges call.
+                        let mut column_readers: Vec<Option<ColumnPageReader>> =
+                            Vec::with_capacity(num_columns);
+                        let mut data_offset = dir_size;
+                        for i in 0..num_columns {
+                            let gi = global_indices[i];
+                            let col_type = self.schema.columns[gi].data_type.clone();
+
+                            if slot_sizes[i] == 0 {
+                                column_readers.push(Some(ColumnPageReader::new(
+                                    col_type,
+                                    ENCODING_ALL_NULL,
+                                    false,
+                                    Value::Null,
+                                    Vec::new(),
+                                    meta.num_rows,
+                                )?));
+                            } else {
+                                let slot_data = &buf[data_offset..data_offset + slot_sizes[i]];
+                                let column_reader =
+                                    Self::parse_column_slot(slot_data, &col_type, meta.num_rows)?;
+                                column_readers.push(Some(column_reader));
+                            }
+                            data_offset += slot_sizes[i];
+                        }
+                        bucket_states[b] = Some(BucketState::Paged { column_readers });
+                    } else {
+                        // Partial projection — only directory was read in round 1,
+                        // collect ranges for round 2.
+                        let bucket_offset = meta.bucket_offsets[b];
+                        let mut slot_file_offsets = Vec::with_capacity(num_columns);
+                        let mut foff = bucket_offset + dir_size as u64;
+                        for &size in &slot_sizes {
+                            slot_file_offsets.push(foff);
+                            foff += size as u64;
+                        }
+
+                        let mut projected_cols: Vec<usize> = Vec::new();
+                        for i in 0..num_columns {
+                            let gi = global_indices[i];
+                            if projected[gi] && slot_sizes[i] > 0 {
+                                projected_cols.push(i);
+                            }
+                        }
+
+                        for &col_idx in &projected_cols {
+                            let col_offset = slot_file_offsets[col_idx];
+                            let col_size = slot_sizes[col_idx];
+
+                            if let Some(last_range) = r2_ranges.last_mut() {
+                                let last_end = last_range.0 + last_range.1 as u64;
+                                if col_offset == last_end {
+                                    last_range.1 += col_size;
+                                    r2_group_infos.last_mut().unwrap().push(PagedSlotInfo {
+                                        bucket_id: b,
+                                        col_idx,
+                                    });
+                                    continue;
+                                }
+                            }
+                            r2_ranges.push((col_offset, col_size));
+                            r2_group_infos.push(vec![PagedSlotInfo {
+                                bucket_id: b,
+                                col_idx,
+                            }]);
+                        }
+
+                        paged_dir_info[b] = Some((slot_sizes, slot_file_offsets));
+                    }
+                }
+                BucketLayout::Empty => {}
+            }
+        }
+
+        // Round 2: batch read all paged column slots
+        if !r2_ranges.is_empty() {
+            let r2_buffers = self.input.read_ranges(&r2_ranges)?;
+
+            // Distribute slot data to per-bucket column readers
+            // First, build a per-bucket map of col_idx -> slot_data
+            let mut paged_slot_data: Vec<Vec<Option<Vec<u8>>>> =
+                Vec::with_capacity(self.num_buckets);
+            for b in 0..self.num_buckets {
+                let n = self.schema.bucket_to_global[b].len();
+                paged_slot_data.push(vec![None; n]);
+            }
+
+            for (group_idx, group) in r2_group_infos.iter().enumerate() {
+                let buf = &r2_buffers[group_idx];
+                let group_base = r2_ranges[group_idx].0;
+                for info in group {
+                    let (_, ref slot_file_offsets) =
+                        paged_dir_info[info.bucket_id].as_ref().unwrap();
+                    let (ref slot_sizes, _) = paged_dir_info[info.bucket_id].as_ref().unwrap();
+                    let rel_start = (slot_file_offsets[info.col_idx] - group_base) as usize;
+                    let rel_end = rel_start + slot_sizes[info.col_idx];
+                    paged_slot_data[info.bucket_id][info.col_idx] =
+                        Some(buf[rel_start..rel_end].to_vec());
+                }
+            }
+
+            // Build ColumnPageReaders for each paged bucket
+            for b in 0..self.num_buckets {
+                if !matches!(bucket_kinds[b], BucketLayout::Paged { .. }) {
+                    continue;
+                }
+                let global_indices = &self.schema.bucket_to_global[b];
+                let num_columns = global_indices.len();
+                let (ref slot_sizes, _) = paged_dir_info[b].as_ref().unwrap();
+
+                let mut column_readers: Vec<Option<ColumnPageReader>> =
+                    Vec::with_capacity(num_columns);
+                for i in 0..num_columns {
+                    let gi = global_indices[i];
+                    if !projected[gi] {
+                        column_readers.push(None);
+                        continue;
+                    }
+
+                    let col_type = self.schema.columns[gi].data_type.clone();
+
+                    if slot_sizes[i] == 0 {
+                        column_readers.push(Some(ColumnPageReader::new(
+                            col_type,
+                            ENCODING_ALL_NULL,
+                            false,
+                            Value::Null,
+                            Vec::new(),
+                            meta.num_rows,
+                        )?));
+                        continue;
+                    }
+
+                    let slot_data = paged_slot_data[b][i].as_ref().unwrap();
+                    let column_reader =
+                        Self::parse_column_slot(slot_data, &col_type, meta.num_rows)?;
+                    column_readers.push(Some(column_reader));
+                }
+                bucket_states[b] = Some(BucketState::Paged { column_readers });
+            }
+        }
+
+        Ok(RowGroupReader::new(
+            bucket_states,
+            self.schema.bucket_to_global.clone(),
+            self.schema.clone(),
+            num_cols,
+            meta.num_rows,
+        ))
+    }
+}
+
+enum BucketState {
+    Monolithic {
+        reader: Box<BucketReader>,
+    },
+    Paged {
+        column_readers: Vec<Option<ColumnPageReader>>,
+    },
+}
+
+pub struct RowGroupReader {
+    bucket_states: Vec<Option<BucketState>>,
+    bucket_to_global: Vec<Vec<usize>>,
+    active_buckets: Vec<usize>,
+    schema: MosaicSchema,
+    num_rows: usize,
+    num_columns: usize,
+}
+
+impl RowGroupReader {
+    fn new(
+        bucket_states: Vec<Option<BucketState>>,
+        bucket_to_global: Vec<Vec<usize>>,
+        schema: MosaicSchema,
+        num_columns: usize,
+        num_rows: usize,
+    ) -> Self {
+        let active_buckets: Vec<usize> = bucket_states
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| if s.is_some() { Some(i) } else { None })
+            .collect();
+        RowGroupReader {
+            bucket_states,
+            bucket_to_global,
+            active_buckets,
+            schema,
+            num_rows,
+            num_columns,
+        }
+    }
+
+    pub fn num_rows(&self) -> usize {
+        self.num_rows
+    }
+
+    pub fn read_columns(&mut self) -> io::Result<RecordBatch> {
+        let num_cols = self.num_columns;
+        let mut arrays: Vec<Option<ArrayRef>> = vec![None; num_cols];
+
+        for &bucket_id in &self.active_buckets {
+            let global_indices = &self.bucket_to_global[bucket_id];
+            let state = self.bucket_states[bucket_id].as_ref().unwrap();
+
+            match state {
+                BucketState::Paged { column_readers } => {
+                    for (local_idx, &global_idx) in global_indices.iter().enumerate() {
+                        if let Some(ref cr) = column_readers[local_idx] {
+                            arrays[global_idx] = Some(cr.read_all()?);
+                        }
+                    }
+                }
+                BucketState::Monolithic { reader, .. } => {
+                    let columns = reader.read_all_columns()?;
+                    for (local_idx, &global_idx) in global_indices.iter().enumerate() {
+                        if local_idx < columns.len() {
+                            arrays[global_idx] = Some(columns[local_idx].clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut fields = Vec::new();
+        let mut batch_arrays = Vec::new();
+        for (i, arr_opt) in arrays.into_iter().enumerate() {
+            if let Some(arr) = arr_opt {
+                let col_meta = &self.schema.columns[i];
+                fields.push(Field::new(
+                    &col_meta.name,
+                    col_meta.data_type.clone(),
+                    col_meta.nullable,
+                ));
+                batch_arrays.push(arr);
+            }
+        }
+
+        let arrow_schema = std::sync::Arc::new(Schema::new(fields));
+        RecordBatch::try_new(arrow_schema, batch_arrays)
+            .map_err(|e| io::Error::other(e.to_string()))
+    }
+}
+

--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -816,4 +816,3 @@ impl RowGroupReader {
             .map_err(|e| io::Error::other(e.to_string()))
     }
 }
-

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -1,0 +1,394 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashSet;
+use std::io;
+
+use arrow_schema::{DataType, Field, Schema};
+
+use crate::bpe;
+use crate::spec;
+use crate::types;
+use crate::varint;
+
+#[derive(Debug, Clone)]
+pub struct ColumnMeta {
+    pub name: String,
+    pub data_type: DataType,
+    pub nullable: bool,
+    pub bucket_id: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MosaicSchema {
+    pub num_buckets: usize,
+    pub columns: Vec<ColumnMeta>,
+    /// bucket_to_global[bucket_id] = [global_col_indices...] in name-sorted order
+    pub bucket_to_global: Vec<Vec<usize>>,
+}
+
+impl MosaicSchema {
+    pub fn validate(columns: &[(String, DataType, bool)]) -> Result<(), String> {
+        let mut seen = HashSet::new();
+        for (name, data_type, _nullable) in columns {
+            if !seen.insert(name.as_str()) {
+                return Err(format!("duplicate column name: {}", name));
+            }
+            types::validate_data_type(data_type)?;
+        }
+        Ok(())
+    }
+
+    pub fn from_arrow(schema: &Schema, num_buckets: usize) -> Result<Self, String> {
+        let columns: Vec<(String, DataType, bool)> = schema
+            .fields()
+            .iter()
+            .map(|f| (f.name().clone(), f.data_type().clone(), f.is_nullable()))
+            .collect();
+        Self::validate(&columns)?;
+        Ok(Self::new(columns, num_buckets))
+    }
+
+    pub fn new(columns: Vec<(String, DataType, bool)>, num_buckets: usize) -> Self {
+        let num_columns = columns.len();
+        let actual_buckets = num_buckets.min(num_columns).max(1);
+
+        let mut sorted_indices: Vec<usize> = (0..num_columns).collect();
+        sorted_indices.sort_by(|&a, &b| columns[a].0.cmp(&columns[b].0));
+
+        let mut bucket_to_global = vec![Vec::new(); actual_buckets];
+        let mut cols: Vec<ColumnMeta> = columns
+            .into_iter()
+            .map(|(name, data_type, nullable)| ColumnMeta {
+                name,
+                data_type,
+                nullable,
+                bucket_id: 0,
+            })
+            .collect();
+
+        for (sorted_pos, &global_idx) in sorted_indices.iter().enumerate() {
+            let bucket_id = spec::assign_bucket(sorted_pos, num_columns, actual_buckets);
+            cols[global_idx].bucket_id = bucket_id;
+            bucket_to_global[bucket_id].push(global_idx);
+        }
+
+        MosaicSchema {
+            num_buckets: actual_buckets,
+            columns: cols,
+            bucket_to_global,
+        }
+    }
+
+    pub fn deserialize(data: &[u8]) -> io::Result<Self> {
+        let mut pos = 0;
+        let num_columns = varint::decode(data, &mut pos)? as usize;
+        let num_buckets = varint::decode(data, &mut pos)? as usize;
+
+        if num_buckets == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: num_buckets must be > 0",
+            ));
+        }
+
+        if pos >= data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "schema: missing name encoding byte",
+            ));
+        }
+        let name_encoding = data[pos];
+        pos += 1;
+
+        let bpe_rules: Option<Vec<[u8; 2]>> = if name_encoding == 1 {
+            let num_rules = varint::decode(data, &mut pos)? as usize;
+            let mut rules = Vec::with_capacity(num_rules);
+            for _ in 0..num_rules {
+                if pos + 2 > data.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "schema: truncated BPE rules",
+                    ));
+                }
+                let left = data[pos];
+                let right = data[pos + 1];
+                pos += 2;
+                rules.push([left, right]);
+            }
+            Some(rules)
+        } else {
+            None
+        };
+
+        struct SortedEntry {
+            logical_index: usize,
+            name: String,
+            data_type: DataType,
+            nullable: bool,
+            sorted_pos: usize,
+        }
+
+        let mut entries = Vec::with_capacity(num_columns);
+        let mut prev_encoded: Vec<u8> = Vec::new();
+
+        for sorted_pos in 0..num_columns {
+            let shared = varint::decode(data, &mut pos)? as usize;
+            let suffix_len = varint::decode(data, &mut pos)? as usize;
+
+            if shared > prev_encoded.len() || pos + suffix_len > data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: corrupted column name encoding",
+                ));
+            }
+            let mut encoded = Vec::with_capacity(shared + suffix_len);
+            encoded.extend_from_slice(&prev_encoded[..shared]);
+            encoded.extend_from_slice(&data[pos..pos + suffix_len]);
+            pos += suffix_len;
+            prev_encoded = encoded.clone();
+
+            let name_bytes = match &bpe_rules {
+                Some(rules) => bpe::decode(&encoded, rules),
+                None => encoded,
+            };
+            let name = String::from_utf8(name_bytes).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: invalid UTF-8 column name",
+                )
+            })?;
+
+            let logical_index = varint::decode(data, &mut pos)? as usize;
+
+            let field = types::deserialize_field(&name, data, &mut pos)?;
+
+            entries.push(SortedEntry {
+                logical_index,
+                name,
+                data_type: field.data_type().clone(),
+                nullable: field.is_nullable(),
+                sorted_pos,
+            });
+        }
+
+        let mut columns = Vec::with_capacity(num_columns);
+        columns.resize_with(num_columns, || ColumnMeta {
+            name: String::new(),
+            data_type: DataType::Int32,
+            nullable: false,
+            bucket_id: 0,
+        });
+        let mut bucket_to_global = vec![Vec::new(); num_buckets];
+        let mut seen = vec![false; num_columns];
+
+        for entry in entries {
+            if entry.logical_index >= num_columns {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: logical_index out of range",
+                ));
+            }
+            if seen[entry.logical_index] {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: duplicate logical_index",
+                ));
+            }
+            seen[entry.logical_index] = true;
+            let bucket_id = spec::assign_bucket(entry.sorted_pos, num_columns, num_buckets);
+            columns[entry.logical_index] = ColumnMeta {
+                name: entry.name,
+                data_type: entry.data_type,
+                nullable: entry.nullable,
+                bucket_id,
+            };
+            bucket_to_global[bucket_id].push(entry.logical_index);
+        }
+
+        let mut seen_names = std::collections::HashSet::with_capacity(num_columns);
+        for col in &columns {
+            if col.name.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: empty column name",
+                ));
+            }
+            if !seen_names.insert(&col.name) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("schema: duplicate column name '{}'", col.name),
+                ));
+            }
+        }
+
+        Ok(MosaicSchema {
+            num_buckets,
+            columns,
+            bucket_to_global,
+        })
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let num_columns = self.columns.len();
+
+        let mut sorted_indices: Vec<usize> = (0..num_columns).collect();
+        sorted_indices.sort_by(|&a, &b| self.columns[a].name.cmp(&self.columns[b].name));
+
+        let raw_names: Vec<Vec<u8>> = sorted_indices
+            .iter()
+            .map(|&i| self.columns[i].name.as_bytes().to_vec())
+            .collect();
+        let raw_refs: Vec<&[u8]> = raw_names.iter().map(|v| v.as_slice()).collect();
+
+        let plain_size = front_coded_size(&raw_refs, &sorted_indices);
+
+        let mut bpe_rules = Vec::new();
+        let mut bpe_names = Vec::new();
+        let mut bpe_size = usize::MAX;
+
+        if bpe::is_ascii_only(&raw_refs) {
+            let rules = bpe::build_vocabulary(&raw_refs);
+            if !rules.is_empty() {
+                let names: Vec<Vec<u8>> = raw_refs
+                    .iter()
+                    .map(|name| bpe::encode(name, &rules))
+                    .collect();
+                let name_refs: Vec<&[u8]> = names.iter().map(|v| v.as_slice()).collect();
+                bpe_size = 1 + rules.len() * 2 + front_coded_size(&name_refs, &sorted_indices);
+                bpe_rules = rules;
+                bpe_names = names;
+            }
+        }
+
+        let mut buf = Vec::new();
+        varint::encode(&mut buf, num_columns as u32);
+        varint::encode(&mut buf, self.num_buckets as u32);
+
+        if bpe_size < plain_size {
+            buf.push(1); // NAME_ENCODING_BPE
+            varint::encode(&mut buf, bpe_rules.len() as u32);
+            for rule in &bpe_rules {
+                buf.push(rule[0]);
+                buf.push(rule[1]);
+            }
+            let bpe_refs: Vec<&[u8]> = bpe_names.iter().map(|v| v.as_slice()).collect();
+            write_front_coded(&mut buf, &bpe_refs, &sorted_indices, &self.columns);
+        } else {
+            buf.push(0); // NAME_ENCODING_FRONT_CODE
+            write_front_coded(&mut buf, &raw_refs, &sorted_indices, &self.columns);
+        }
+
+        buf
+    }
+}
+
+fn write_front_coded(
+    buf: &mut Vec<u8>,
+    name_bytes: &[&[u8]],
+    sorted_indices: &[usize],
+    columns: &[ColumnMeta],
+) {
+    let mut prev: &[u8] = &[];
+    for (i, &global_idx) in sorted_indices.iter().enumerate() {
+        let col = &columns[global_idx];
+
+        let cur = name_bytes[i];
+        let shared = common_prefix_length(prev, cur);
+        varint::encode(buf, shared as u32);
+        varint::encode(buf, (cur.len() - shared) as u32);
+        buf.extend_from_slice(&cur[shared..]);
+        prev = cur;
+
+        varint::encode(buf, global_idx as u32);
+        let field = Field::new(&col.name, col.data_type.clone(), col.nullable);
+        types::serialize_field(&field, buf);
+    }
+}
+
+fn front_coded_size(names: &[&[u8]], sorted_indices: &[usize]) -> usize {
+    let mut size = 0;
+    let mut prev: &[u8] = &[];
+    for (i, name) in names.iter().enumerate() {
+        let shared = common_prefix_length(prev, name);
+        let suffix_len = name.len() - shared;
+        size += varint::encoded_size(shared as u32)
+            + varint::encoded_size(suffix_len as u32)
+            + suffix_len
+            + varint::encoded_size(sorted_indices[i] as u32);
+        prev = name;
+    }
+    size
+}
+
+fn common_prefix_length(a: &[u8], b: &[u8]) -> usize {
+    a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bucket_assignment() {
+        let columns: Vec<(String, DataType, bool)> = (0..1000)
+            .map(|i| (format!("col_{:04}", i), DataType::Int32, true))
+            .collect();
+        let schema = MosaicSchema::new(columns, 10);
+        assert_eq!(schema.num_buckets, 10);
+        let total: usize = schema.bucket_to_global.iter().map(|b| b.len()).sum();
+        assert_eq!(total, 1000);
+    }
+
+    #[test]
+    fn test_serialize() {
+        let columns = vec![
+            ("b_col".to_string(), DataType::Int32, true),
+            ("a_col".to_string(), DataType::Float64, false),
+        ];
+        let schema = MosaicSchema::new(columns, 2);
+        let data = schema.serialize();
+        assert!(!data.is_empty());
+    }
+
+    #[test]
+    fn test_serialize_deserialize_preserves_column_order() {
+        let columns = vec![
+            ("name".to_string(), DataType::Utf8, true),
+            ("age".to_string(), DataType::Int32, true),
+            ("score".to_string(), DataType::Float64, true),
+        ];
+        let schema = MosaicSchema::new(columns, 2);
+        assert_eq!(schema.columns[0].name, "name");
+        assert_eq!(schema.columns[1].name, "age");
+        assert_eq!(schema.columns[2].name, "score");
+
+        let data = schema.serialize();
+        let restored = MosaicSchema::deserialize(&data).unwrap();
+
+        assert_eq!(restored.columns.len(), 3);
+        assert_eq!(restored.columns[0].name, "name");
+        assert_eq!(restored.columns[1].name, "age");
+        assert_eq!(restored.columns[2].name, "score");
+        assert_eq!(restored.num_buckets, schema.num_buckets);
+
+        for i in 0..3 {
+            assert_eq!(restored.columns[i].bucket_id, schema.columns[i].bucket_id);
+        }
+        assert_eq!(restored.bucket_to_global, schema.bucket_to_global);
+    }
+}

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub const MAGIC: [u8; 4] = [b'M', b'O', b'S', b'A'];
+pub const VERSION: u8 = 1;
+pub const FOOTER_SIZE: usize = 32;
+
+pub const COMPRESSION_NONE: u8 = 0;
+pub const COMPRESSION_ZSTD: u8 = 1;
+
+pub const ENCODING_PLAIN: u8 = 0;
+pub const ENCODING_CONST: u8 = 1;
+pub const ENCODING_DICT: u8 = 2;
+pub const ENCODING_ALL_NULL: u8 = 3;
+
+pub const DEFAULT_NUM_BUCKETS: usize = 100;
+pub const DEFAULT_ROW_GROUP_MAX_SIZE: u64 = 256 * 1024 * 1024;
+pub const DEFAULT_ZSTD_LEVEL: i32 = 1;
+pub const DEFAULT_DICT_MAX_TOTAL_BYTES: usize = 32 * 1024;
+pub const DEFAULT_DICT_MAX_ENTRIES: usize = 255;
+pub const DEFAULT_PAGE_SIZE_THRESHOLD: usize = 32 * 1024;
+
+// ======================== Bucket Layout Sentinel ========================
+//
+// Each bucket in the row group index is described by (compressed_size, bulk_decompress_size):
+//
+//   compressed_size == 0                            → Empty bucket. No data on disk; skip.
+//   compressed_size > 0 && bulk_decompress_size > 0 → Monolithic bucket. The on-disk blob
+//                                                     is a single compressed block;
+//                                                     bulk_decompress_size is the decompressed size.
+//   compressed_size > 0 && bulk_decompress_size == 0 → Paged bucket. The on-disk content is
+//                                                     [directory (num_cols × u32le slot sizes)]
+//                                                     followed by per-column compressed slots.
+//
+// This encoding is unambiguous: a non-empty monolithic bucket always has
+// bulk_decompress_size > 0 (decompressed payload cannot be zero bytes).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BucketLayout {
+    Empty,
+    Monolithic {
+        compressed_size: usize,
+        uncompressed_size: usize,
+    },
+    Paged {
+        total_size: usize,
+    },
+}
+
+impl BucketLayout {
+    pub fn decode(
+        compressed_size: usize,
+        bulk_decompress_size: usize,
+    ) -> Result<Self, &'static str> {
+        match (compressed_size, bulk_decompress_size) {
+            (0, 0) => Ok(BucketLayout::Empty),
+            (0, _) => {
+                Err("invalid bucket layout: compressed_size == 0 but bulk_decompress_size != 0")
+            }
+            (cs, 0) => Ok(BucketLayout::Paged { total_size: cs }),
+            (cs, us) => Ok(BucketLayout::Monolithic {
+                compressed_size: cs,
+                uncompressed_size: us,
+            }),
+        }
+    }
+
+    pub fn encode(&self) -> (usize, usize) {
+        match *self {
+            BucketLayout::Empty => (0, 0),
+            BucketLayout::Monolithic {
+                compressed_size,
+                uncompressed_size,
+            } => (compressed_size, uncompressed_size),
+            BucketLayout::Paged { total_size } => (total_size, 0),
+        }
+    }
+}
+
+pub fn assign_bucket(sorted_position: usize, num_columns: usize, num_buckets: usize) -> usize {
+    sorted_position * num_buckets / num_columns
+}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,0 +1,242 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_schema::{DataType, Field, Fields, TimeUnit};
+
+use crate::varint;
+
+pub fn fixed_width(dt: &DataType) -> i32 {
+    match dt {
+        DataType::Boolean | DataType::Int8 => 1,
+        DataType::Int16 => 2,
+        DataType::Int32 | DataType::Date32 | DataType::Time32(_) | DataType::Float32 => 4,
+        DataType::Int64 | DataType::Float64 => 8,
+        DataType::Decimal128(p, _) if *p <= 18 => 8,
+        DataType::Timestamp(_, _) => 8,
+        DataType::Struct(fields) if is_timestamp_nanos_struct(fields) => 12,
+        _ => -1,
+    }
+}
+
+pub fn is_timestamp_nanos_struct(fields: &Fields) -> bool {
+    fields.len() == 2
+        && fields[0].name() == "millis"
+        && *fields[0].data_type() == DataType::Int64
+        && fields[1].name() == "nanos_of_milli"
+        && *fields[1].data_type() == DataType::Int32
+}
+
+pub fn validate_data_type(dt: &DataType) -> Result<(), String> {
+    match dt {
+        DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Date32
+        | DataType::Utf8
+        | DataType::Binary => Ok(()),
+        DataType::Time32(TimeUnit::Millisecond) => Ok(()),
+        DataType::Decimal128(p, _s) => {
+            if *p == 0 || *p > 38 {
+                Err(format!("DECIMAL precision must be 1..38, got {}", p))
+            } else {
+                Ok(())
+            }
+        }
+        DataType::Timestamp(unit, _) => match unit {
+            TimeUnit::Millisecond | TimeUnit::Microsecond => Ok(()),
+            _ => Err(format!("unsupported Timestamp unit: {:?}", unit)),
+        },
+        DataType::Struct(fields) if is_timestamp_nanos_struct(fields) => Ok(()),
+        _ => Err(format!("unsupported DataType: {:?}", dt)),
+    }
+}
+
+pub fn data_type_to_type_byte(dt: &DataType) -> u8 {
+    match dt {
+        DataType::Boolean => 0,
+        DataType::Int8 => 1,
+        DataType::Int16 => 2,
+        DataType::Int32 => 3,
+        DataType::Int64 => 4,
+        DataType::Float32 => 5,
+        DataType::Float64 => 6,
+        DataType::Date32 => 7,
+        DataType::Utf8 => 10,
+        DataType::Binary => 13,
+        DataType::Decimal128(_, _) => 14,
+        DataType::Time32(_) => 15,
+        DataType::Timestamp(_, None) => 16,
+        DataType::Timestamp(_, Some(_)) => 17,
+        DataType::Struct(fields) if is_timestamp_nanos_struct(fields) => 16,
+        _ => panic!("unsupported DataType for serialization: {:?}", dt),
+    }
+}
+
+pub fn precision_of(dt: &DataType) -> u32 {
+    match dt {
+        DataType::Decimal128(p, _) => *p as u32,
+        DataType::Timestamp(TimeUnit::Millisecond, _) => 3,
+        DataType::Timestamp(TimeUnit::Microsecond, _) => 6,
+        DataType::Struct(fields) if is_timestamp_nanos_struct(fields) => 9,
+        DataType::Time32(TimeUnit::Millisecond) => 3,
+        _ => 0,
+    }
+}
+
+pub fn scale_of(dt: &DataType) -> u32 {
+    match dt {
+        DataType::Decimal128(_, s) => *s as u32,
+        _ => 0,
+    }
+}
+
+pub fn serialize_field(field: &Field, buf: &mut Vec<u8>) {
+    let dt = field.data_type();
+    let type_byte = data_type_to_type_byte(dt);
+    buf.push(type_byte);
+    buf.push(if field.is_nullable() { 1 } else { 0 });
+    match dt {
+        DataType::Decimal128(p, s) => {
+            varint::encode(buf, *p as u32);
+            varint::encode(buf, *s as u32);
+        }
+        DataType::Time32(_) => {
+            varint::encode(buf, precision_of(dt));
+        }
+        DataType::Timestamp(unit, tz) => {
+            let p = match unit {
+                TimeUnit::Millisecond => 3u32,
+                TimeUnit::Microsecond => 6u32,
+                _ => 0,
+            };
+            varint::encode(buf, p);
+            if let Some(tz) = tz {
+                let tz_bytes = tz.as_bytes();
+                varint::encode(buf, tz_bytes.len() as u32);
+                buf.extend_from_slice(tz_bytes);
+            }
+        }
+        DataType::Struct(fields) if is_timestamp_nanos_struct(fields) => {
+            varint::encode(buf, 9u32);
+        }
+        _ => {}
+    }
+}
+
+pub fn deserialize_field(name: &str, buf: &[u8], pos: &mut usize) -> Result<Field, std::io::Error> {
+    if *pos + 1 >= buf.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "type: not enough bytes for type header",
+        ));
+    }
+    let type_byte = buf[*pos];
+    *pos += 1;
+    let nullable = buf[*pos] != 0;
+    *pos += 1;
+
+    let dt = match type_byte {
+        0 => DataType::Boolean,
+        1 => DataType::Int8,
+        2 => DataType::Int16,
+        3 => DataType::Int32,
+        4 => DataType::Int64,
+        5 => DataType::Float32,
+        6 => DataType::Float64,
+        7 => DataType::Date32,
+        8 | 9 => {
+            // Char/VarChar — skip length, map to Utf8
+            let _length = varint::decode(buf, pos)?;
+            DataType::Utf8
+        }
+        10 => DataType::Utf8,
+        11 | 12 => {
+            // Binary/VarBinary — skip length, map to Binary
+            let _length = varint::decode(buf, pos)?;
+            DataType::Binary
+        }
+        13 => DataType::Binary,
+        14 => {
+            let precision = varint::decode(buf, pos)?;
+            let scale = varint::decode(buf, pos)?;
+            DataType::Decimal128(precision as u8, scale as i8)
+        }
+        15 => {
+            let _precision = varint::decode(buf, pos)?;
+            DataType::Time32(TimeUnit::Millisecond)
+        }
+        16 => {
+            let precision = varint::decode(buf, pos)?;
+            if precision <= 3 {
+                DataType::Timestamp(TimeUnit::Millisecond, None)
+            } else if precision <= 6 {
+                DataType::Timestamp(TimeUnit::Microsecond, None)
+            } else {
+                DataType::Struct(
+                    vec![
+                        Field::new("millis", DataType::Int64, false),
+                        Field::new("nanos_of_milli", DataType::Int32, false),
+                    ]
+                    .into(),
+                )
+            }
+        }
+        17 => {
+            let precision = varint::decode(buf, pos)?;
+            let tz_len = varint::decode(buf, pos)? as usize;
+            if *pos + tz_len > buf.len() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "type: not enough bytes for timezone string",
+                ));
+            }
+            let tz_str = std::str::from_utf8(&buf[*pos..*pos + tz_len]).map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "type: invalid UTF-8 timezone",
+                )
+            })?;
+            *pos += tz_len;
+            let tz: std::sync::Arc<str> = std::sync::Arc::from(tz_str);
+            if precision <= 3 {
+                DataType::Timestamp(TimeUnit::Millisecond, Some(tz))
+            } else if precision <= 6 {
+                DataType::Timestamp(TimeUnit::Microsecond, Some(tz))
+            } else {
+                DataType::Struct(
+                    vec![
+                        Field::new("millis", DataType::Int64, false),
+                        Field::new("nanos_of_milli", DataType::Int32, false),
+                    ]
+                    .into(),
+                )
+            }
+        }
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown type tag: {}", type_byte),
+            ));
+        }
+    };
+
+    Ok(Field::new(name, dt, nullable))
+}

--- a/core/src/values.rs
+++ b/core/src/values.rs
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io;
+
+use crate::varint;
+
+#[derive(Debug, Clone)]
+pub enum Value {
+    Null,
+    Boolean(bool),
+    TinyInt(i8),
+    SmallInt(i16),
+    Integer(i32),
+    BigInt(i64),
+    Float(f32),
+    Double(f64),
+    Date(i32),
+    Time(i32),
+    String(Vec<u8>),
+    Bytes(Vec<u8>),
+    DecimalCompact(i64),
+    DecimalLarge(Vec<u8>),
+    TimestampMillis(i64),
+    TimestampMicros(i64),
+    TimestampNanos { millis: i64, nanos_of_milli: i32 },
+}
+
+impl Value {
+    pub fn is_null(&self) -> bool {
+        matches!(self, Value::Null)
+    }
+
+    pub fn to_be_bytes(&self) -> Vec<u8> {
+        match self {
+            Value::Null => Vec::new(),
+            Value::Boolean(v) => vec![if *v { 1 } else { 0 }],
+            Value::TinyInt(v) => vec![*v as u8],
+            Value::SmallInt(v) => v.to_be_bytes().to_vec(),
+            Value::Integer(v) | Value::Date(v) | Value::Time(v) => v.to_be_bytes().to_vec(),
+            Value::BigInt(v)
+            | Value::DecimalCompact(v)
+            | Value::TimestampMillis(v)
+            | Value::TimestampMicros(v) => v.to_be_bytes().to_vec(),
+            Value::Float(v) => v.to_bits().to_be_bytes().to_vec(),
+            Value::Double(v) => v.to_bits().to_be_bytes().to_vec(),
+            Value::TimestampNanos {
+                millis,
+                nanos_of_milli,
+            } => {
+                let mut buf = millis.to_be_bytes().to_vec();
+                buf.extend_from_slice(&nanos_of_milli.to_be_bytes());
+                buf
+            }
+            Value::String(b) | Value::Bytes(b) | Value::DecimalLarge(b) => b.clone(),
+        }
+    }
+}
+
+fn type_mismatch(expected: &str, value: &Value) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("type mismatch: expected {}, got {:?}", expected, value),
+    )
+}
+
+pub fn write_fixed(buf: &mut Vec<u8>, value: &Value, width: i32) -> io::Result<()> {
+    match width {
+        1 => match value {
+            Value::Boolean(v) => buf.push(if *v { 1 } else { 0 }),
+            Value::TinyInt(v) => buf.push(*v as u8),
+            _ => return Err(type_mismatch("Boolean or TinyInt", value)),
+        },
+        2 => match value {
+            Value::SmallInt(v) => buf.extend_from_slice(&v.to_be_bytes()),
+            _ => return Err(type_mismatch("SmallInt", value)),
+        },
+        4 => match value {
+            Value::Integer(v) | Value::Date(v) | Value::Time(v) => {
+                buf.extend_from_slice(&v.to_be_bytes());
+            }
+            Value::Float(v) => {
+                buf.extend_from_slice(&v.to_bits().to_be_bytes());
+            }
+            _ => return Err(type_mismatch("Integer/Date/Time/Float", value)),
+        },
+        8 => match value {
+            Value::BigInt(v)
+            | Value::DecimalCompact(v)
+            | Value::TimestampMillis(v)
+            | Value::TimestampMicros(v) => {
+                buf.extend_from_slice(&v.to_be_bytes());
+            }
+            Value::Double(v) => {
+                buf.extend_from_slice(&v.to_bits().to_be_bytes());
+            }
+            _ => return Err(type_mismatch("BigInt/Decimal/Timestamp/Double", value)),
+        },
+        12 => match value {
+            Value::TimestampNanos {
+                millis,
+                nanos_of_milli,
+            } => {
+                buf.extend_from_slice(&millis.to_be_bytes());
+                buf.extend_from_slice(&nanos_of_milli.to_be_bytes());
+            }
+            _ => return Err(type_mismatch("TimestampNanos", value)),
+        },
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported fixed width {}", width),
+            ))
+        }
+    }
+    Ok(())
+}
+
+pub fn write_variable(buf: &mut Vec<u8>, value: &Value) -> io::Result<()> {
+    match value {
+        Value::String(bytes) | Value::Bytes(bytes) | Value::DecimalLarge(bytes) => {
+            varint::encode(buf, bytes.len() as u32);
+            buf.extend_from_slice(bytes);
+            Ok(())
+        }
+        _ => Err(type_mismatch("String/Bytes/DecimalLarge", value)),
+    }
+}
+
+pub fn extract_fixed_key(buf: &[u8], pos: usize, width: i32) -> u64 {
+    match width {
+        1 => buf[pos] as u64,
+        2 => u16::from_be_bytes([buf[pos], buf[pos + 1]]) as u64,
+        4 => u32::from_be_bytes([buf[pos], buf[pos + 1], buf[pos + 2], buf[pos + 3]]) as u64,
+        8 => u64::from_be_bytes([
+            buf[pos],
+            buf[pos + 1],
+            buf[pos + 2],
+            buf[pos + 3],
+            buf[pos + 4],
+            buf[pos + 5],
+            buf[pos + 6],
+            buf[pos + 7],
+        ]),
+        _ => 0,
+    }
+}

--- a/core/src/varint.rs
+++ b/core/src/varint.rs
@@ -1,0 +1,160 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub fn encode(buf: &mut Vec<u8>, mut value: u32) {
+    loop {
+        if (value & !0x7F) == 0 {
+            buf.push(value as u8);
+            return;
+        }
+        buf.push(((value & 0x7F) | 0x80) as u8);
+        value >>= 7;
+    }
+}
+
+pub fn encode_to_slice(buf: &mut [u8], pos: usize, mut value: u32) -> usize {
+    let mut p = pos;
+    loop {
+        if (value & !0x7F) == 0 {
+            buf[p] = value as u8;
+            p += 1;
+            return p;
+        }
+        buf[p] = ((value & 0x7F) | 0x80) as u8;
+        p += 1;
+        value >>= 7;
+    }
+}
+
+pub fn encoded_size(mut value: u32) -> usize {
+    let mut size = 1;
+    while (value & !0x7F) != 0 {
+        size += 1;
+        value >>= 7;
+    }
+    size
+}
+
+pub fn decode(buf: &[u8], pos: &mut usize) -> Result<u32, std::io::Error> {
+    let mut value: u32 = 0;
+    let mut shift = 0;
+    loop {
+        if *pos >= buf.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "varint: unexpected end of data",
+            ));
+        }
+        let b = buf[*pos] as u32;
+        *pos += 1;
+        value |= (b & 0x7F) << shift;
+        if (b & 0x80) == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 35 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "varint: overflow (>5 bytes for u32)",
+            ));
+        }
+    }
+}
+
+pub fn encode_u64(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        if (value & !0x7F) == 0 {
+            buf.push(value as u8);
+            return;
+        }
+        buf.push(((value & 0x7F) | 0x80) as u8);
+        value >>= 7;
+    }
+}
+
+pub fn decode_u64(buf: &[u8], pos: &mut usize) -> Result<u64, std::io::Error> {
+    let mut value: u64 = 0;
+    let mut shift = 0;
+    loop {
+        if *pos >= buf.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "varint: unexpected end of data",
+            ));
+        }
+        let b = buf[*pos] as u64;
+        *pos += 1;
+        value |= (b & 0x7F) << shift;
+        if (b & 0x80) == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 70 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "varint: overflow (>10 bytes for u64)",
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip() {
+        for &v in &[0u32, 1, 127, 128, 255, 16383, 16384, 2097151, u32::MAX] {
+            let mut buf = Vec::new();
+            encode(&mut buf, v);
+            assert_eq!(buf.len(), encoded_size(v));
+            let mut pos = 0;
+            assert_eq!(decode(&buf, &mut pos).unwrap(), v);
+            assert_eq!(pos, buf.len());
+        }
+    }
+
+    #[test]
+    fn test_u64_roundtrip() {
+        for &v in &[
+            0u64,
+            1,
+            127,
+            128,
+            255,
+            16383,
+            16384,
+            u32::MAX as u64,
+            u64::MAX,
+        ] {
+            let mut buf = Vec::new();
+            encode_u64(&mut buf, v);
+            let mut pos = 0;
+            assert_eq!(decode_u64(&buf, &mut pos).unwrap(), v);
+            assert_eq!(pos, buf.len());
+        }
+    }
+
+    #[test]
+    fn test_decode_eof() {
+        let mut pos = 0;
+        assert!(decode(&[], &mut pos).is_err());
+        let truncated = vec![0x80];
+        pos = 0;
+        assert!(decode(&truncated, &mut pos).is_err());
+    }
+}

--- a/core/src/writer.rs
+++ b/core/src/writer.rs
@@ -1,0 +1,708 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io;
+
+use arrow_array::*;
+use arrow_schema::Schema;
+
+use crate::bucket_writer::{BucketWriter, PagedBucketOutput};
+use crate::schema::MosaicSchema;
+use crate::spec::*;
+use crate::varint;
+
+fn to_u32(val: usize, field: &str) -> io::Result<u32> {
+    u32::try_from(val).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{} ({}) exceeds u32::MAX", field, val),
+        )
+    })
+}
+
+pub trait OutputFile {
+    fn write(&mut self, data: &[u8]) -> io::Result<()>;
+    fn flush(&mut self) -> io::Result<()>;
+    fn pos(&self) -> u64;
+}
+
+pub struct WriterOptions {
+    pub compression: u8,
+    pub zstd_level: i32,
+    pub num_buckets: usize,
+    pub row_group_max_size: u64,
+    pub max_dict_total_bytes: usize,
+    pub max_dict_entries: usize,
+    pub page_size_threshold: usize,
+}
+
+impl Default for WriterOptions {
+    fn default() -> Self {
+        Self {
+            compression: COMPRESSION_ZSTD,
+            zstd_level: DEFAULT_ZSTD_LEVEL,
+            num_buckets: DEFAULT_NUM_BUCKETS,
+            row_group_max_size: DEFAULT_ROW_GROUP_MAX_SIZE,
+            max_dict_total_bytes: DEFAULT_DICT_MAX_TOTAL_BYTES,
+            max_dict_entries: DEFAULT_DICT_MAX_ENTRIES,
+            page_size_threshold: DEFAULT_PAGE_SIZE_THRESHOLD,
+        }
+    }
+}
+
+struct RowGroupMeta {
+    num_rows: usize,
+    bucket_offsets: Vec<u64>,
+    bucket_layouts: Vec<BucketLayout>,
+}
+
+pub struct MosaicWriter<S: OutputFile> {
+    out: S,
+    schema: MosaicSchema,
+    bucket_writers: Vec<Option<BucketWriter>>,
+    active_buckets: Vec<usize>,
+    num_buckets: usize,
+    compression: u8,
+    zstd_level: i32,
+    row_group_max_size: u64,
+    page_size_threshold: usize,
+
+    row_group_metas: Vec<RowGroupMeta>,
+    current_row_group_rows: usize,
+    current_buffered_size: u64,
+    compression_ratio: f64,
+    total_uncompressed: u64,
+    total_compressed: u64,
+    closed: bool,
+}
+
+impl<S: OutputFile> MosaicWriter<S> {
+    pub fn new(out: S, schema: &Schema, options: WriterOptions) -> io::Result<Self> {
+        let mosaic_schema = MosaicSchema::from_arrow(schema, options.num_buckets)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        Ok(Self::from_mosaic_schema(out, mosaic_schema, options))
+    }
+
+    pub fn from_mosaic_schema(out: S, schema: MosaicSchema, options: WriterOptions) -> Self {
+        let num_buckets = schema.num_buckets;
+        let mut bucket_writers = Vec::with_capacity(num_buckets);
+
+        for b in 0..num_buckets {
+            let global_indices = &schema.bucket_to_global[b];
+            if global_indices.is_empty() {
+                bucket_writers.push(None);
+            } else {
+                let col_types: Vec<&arrow_schema::DataType> = global_indices
+                    .iter()
+                    .map(|&gi| &schema.columns[gi].data_type)
+                    .collect();
+                bucket_writers.push(Some(BucketWriter::new(
+                    &col_types,
+                    options.max_dict_total_bytes,
+                    options.max_dict_entries,
+                )));
+            }
+        }
+
+        let active_buckets: Vec<usize> = bucket_writers
+            .iter()
+            .enumerate()
+            .filter_map(|(i, bw)| if bw.is_some() { Some(i) } else { None })
+            .collect();
+
+        let compression_ratio = if options.compression == COMPRESSION_NONE {
+            1.0
+        } else {
+            0.3
+        };
+
+        MosaicWriter {
+            out,
+            schema,
+            bucket_writers,
+            active_buckets,
+            num_buckets,
+            compression: options.compression,
+            zstd_level: options.zstd_level,
+            row_group_max_size: options.row_group_max_size,
+            page_size_threshold: options.page_size_threshold,
+            row_group_metas: Vec::new(),
+            current_row_group_rows: 0,
+            current_buffered_size: 0,
+            compression_ratio,
+            total_uncompressed: 0,
+            total_compressed: 0,
+            closed: false,
+        }
+    }
+
+    pub fn schema(&self) -> &MosaicSchema {
+        &self.schema
+    }
+
+    pub fn output(&self) -> &S {
+        &self.out
+    }
+
+    pub fn output_mut(&mut self) -> &mut S {
+        &mut self.out
+    }
+
+    pub fn estimated_file_size(&self) -> u64 {
+        let written = self.out.pos();
+        let buffered_estimate = (self.current_buffered_size as f64 * self.compression_ratio) as u64;
+        written + buffered_estimate + 1024
+    }
+
+    pub fn write_batch(&mut self, batch: &RecordBatch) -> io::Result<()> {
+        if self.closed {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "writer is already closed",
+            ));
+        }
+        let num_cols = self.schema.columns.len();
+        if batch.num_columns() != num_cols {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "column count mismatch: schema has {} but batch has {}",
+                    num_cols,
+                    batch.num_columns()
+                ),
+            ));
+        }
+
+        for (i, col) in self.schema.columns.iter().enumerate() {
+            if !col.nullable && batch.column(i).null_count() > 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "non-nullable column '{}' has {} nulls in batch",
+                        col.name,
+                        batch.column(i).null_count()
+                    ),
+                ));
+            }
+        }
+
+        let mut size = 0u64;
+        for &b in &self.active_buckets {
+            let global_indices = &self.schema.bucket_to_global[b];
+            let arrays: Vec<&dyn Array> = global_indices
+                .iter()
+                .map(|&gi| batch.column(gi).as_ref())
+                .collect();
+            let data_types: Vec<&arrow_schema::DataType> = global_indices
+                .iter()
+                .map(|&gi| &self.schema.columns[gi].data_type)
+                .collect();
+            let bw = self.bucket_writers[b].as_mut().unwrap();
+            size += bw.write_columns(&arrays, &data_types)? as u64;
+        }
+
+        self.current_row_group_rows += batch.num_rows();
+        self.current_buffered_size += size;
+
+        if self.current_buffered_size >= self.row_group_max_size {
+            self.flush_row_group()?;
+        }
+        Ok(())
+    }
+
+    fn flush_row_group(&mut self) -> io::Result<()> {
+        if self.current_row_group_rows == 0 {
+            return Ok(());
+        }
+
+        let mut bucket_offsets = vec![0u64; self.num_buckets];
+        let mut bucket_layouts = vec![BucketLayout::Empty; self.num_buckets];
+
+        let num_active = self.active_buckets.len();
+        let mut actual_uncompressed_sizes = vec![0usize; self.num_buckets];
+        for ai in 0..num_active {
+            let b = self.active_buckets[ai];
+            let bw = self.bucket_writers[b].as_ref().unwrap();
+            if bw.is_empty() {
+                continue;
+            }
+            let est_size = bw.estimated_raw_size();
+            let try_paged =
+                self.compression == COMPRESSION_ZSTD && est_size >= self.page_size_threshold;
+
+            let paged_output = if try_paged {
+                let paged = bw.finish_paged();
+                let num_pages = paged.column_pages.iter().filter(|p| p.is_some()).count();
+                let avg_ok = if num_pages > 0 {
+                    let total: usize = paged
+                        .column_pages
+                        .iter()
+                        .filter_map(|p| p.as_ref())
+                        .map(|p| p.len())
+                        .sum();
+                    total / num_pages >= self.page_size_threshold
+                } else {
+                    false
+                };
+                if avg_ok {
+                    Some(paged)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            if let Some(paged) = paged_output {
+                let paged_raw_size: usize = paged
+                    .column_pages
+                    .iter()
+                    .filter_map(|p| p.as_ref())
+                    .map(|p| p.len())
+                    .sum();
+                let total_size = self.write_paged_bucket(&paged)?;
+                bucket_layouts[b] = BucketLayout::Paged { total_size };
+                actual_uncompressed_sizes[b] = paged_raw_size;
+                bucket_offsets[b] = self.out.pos() - total_size as u64;
+            } else {
+                let raw = self.bucket_writers[b].as_ref().unwrap().finish();
+                let comp_size = self.write_compressed(&raw)?;
+                bucket_layouts[b] = BucketLayout::Monolithic {
+                    compressed_size: comp_size,
+                    uncompressed_size: raw.len(),
+                };
+                actual_uncompressed_sizes[b] = raw.len();
+                bucket_offsets[b] = self.out.pos() - comp_size as u64;
+            }
+        }
+
+        let rg_uncompressed: u64 = actual_uncompressed_sizes.iter().map(|&s| s as u64).sum();
+        let rg_compressed: u64 = bucket_layouts
+            .iter()
+            .map(|l| {
+                let (cs, _) = l.encode();
+                cs as u64
+            })
+            .sum();
+        self.total_uncompressed += rg_uncompressed;
+        self.total_compressed += rg_compressed;
+        if self.total_uncompressed > 0 {
+            self.compression_ratio = self.total_compressed as f64 / self.total_uncompressed as f64;
+        }
+
+        for ai in 0..num_active {
+            let b = self.active_buckets[ai];
+            self.bucket_writers[b].as_mut().unwrap().reset();
+        }
+
+        self.row_group_metas.push(RowGroupMeta {
+            num_rows: self.current_row_group_rows,
+            bucket_offsets,
+            bucket_layouts,
+        });
+
+        self.current_row_group_rows = 0;
+        self.current_buffered_size = 0;
+        Ok(())
+    }
+
+    fn write_compressed(&mut self, raw: &[u8]) -> io::Result<usize> {
+        match self.compression {
+            COMPRESSION_NONE => {
+                self.out.write(raw)?;
+                Ok(raw.len())
+            }
+            COMPRESSION_ZSTD => {
+                let compressed =
+                    zstd::bulk::compress(raw, self.zstd_level).map_err(io::Error::other)?;
+                self.out.write(&compressed)?;
+                Ok(compressed.len())
+            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Unsupported compression: {}", self.compression),
+            )),
+        }
+    }
+
+    fn write_paged_bucket(&mut self, paged: &PagedBucketOutput) -> io::Result<usize> {
+        let num_columns = paged.encodings.len();
+
+        // Build and compress each column's page_content independently.
+        // page_content = [encoding(1B) | flags(1B) | meta | data]
+        // On-disk slot = [uncompressed_size (varint) | zstd(page_content)]
+        // ALL_NULL columns have no slot (directory entry = 0).
+        let mut column_slots: Vec<Vec<u8>> = Vec::with_capacity(num_columns);
+        for i in 0..num_columns {
+            if paged.encodings[i] == ENCODING_ALL_NULL {
+                column_slots.push(Vec::new());
+                continue;
+            }
+
+            // Build page_content
+            let mut page_content = Vec::new();
+            page_content.push(paged.encodings[i]);
+            let flags: u8 = if paged.has_nulls[i] { 1 } else { 0 };
+            page_content.push(flags);
+
+            // Meta + data depend on encoding
+            match paged.encodings[i] {
+                ENCODING_CONST => {
+                    page_content.extend_from_slice(&paged.const_data[i]);
+                    if let Some(ref page_data) = paged.column_pages[i] {
+                        page_content.extend_from_slice(page_data);
+                    }
+                }
+                _ => {
+                    if let Some(ref page_data) = paged.column_pages[i] {
+                        page_content.extend_from_slice(page_data);
+                    }
+                }
+            }
+
+            // Compress and build on-disk slot: uncompressed_size varint + compressed data
+            let uncompressed_size = page_content.len();
+            let compressed =
+                zstd::bulk::compress(&page_content, self.zstd_level).map_err(io::Error::other)?;
+            let mut slot = Vec::new();
+            varint::encode(
+                &mut slot,
+                to_u32(uncompressed_size, "page uncompressed size")?,
+            );
+            slot.extend_from_slice(&compressed);
+            column_slots.push(slot);
+        }
+
+        // Write fixed-length directory: num_columns * 4 bytes (u32 LE per column = slot size)
+        let dir_size = num_columns * 4;
+        let mut total_size = dir_size;
+        for slot in &column_slots {
+            let slot_size = to_u32(slot.len(), "paged slot size")?;
+            self.out.write(&slot_size.to_le_bytes())?;
+        }
+
+        // Write column slots sequentially
+        for slot in &column_slots {
+            if !slot.is_empty() {
+                self.out.write(slot)?;
+                total_size += slot.len();
+            }
+        }
+
+        Ok(total_size)
+    }
+
+    pub fn close(&mut self) -> io::Result<()> {
+        if self.closed {
+            return Ok(());
+        }
+        self.closed = true;
+
+        self.flush_row_group()?;
+
+        // Write schema block
+        let schema_raw = self.schema.serialize();
+        let schema_block_offset = self.out.pos();
+
+        let uncomp_size = to_u32(schema_raw.len(), "schema uncompressed size")?;
+        self.out.write(&uncomp_size.to_be_bytes())?;
+
+        match self.compression {
+            COMPRESSION_NONE => {
+                self.out.write(&schema_raw)?;
+            }
+            COMPRESSION_ZSTD => {
+                let compressed =
+                    zstd::bulk::compress(&schema_raw, self.zstd_level).map_err(io::Error::other)?;
+                self.out.write(&compressed)?;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Unsupported compression",
+                ));
+            }
+        }
+
+        // Write row group index (varint encoded, only non-empty buckets)
+        let index_offset = self.out.pos();
+        let num_row_groups = self.row_group_metas.len();
+
+        let mut index_buf = Vec::with_capacity(num_row_groups * (5 + self.num_buckets * 25));
+        for meta in &self.row_group_metas {
+            varint::encode(&mut index_buf, to_u32(meta.num_rows, "row group num_rows")?);
+            let non_empty = meta
+                .bucket_layouts
+                .iter()
+                .filter(|l| !matches!(l, BucketLayout::Empty))
+                .count();
+            varint::encode(&mut index_buf, to_u32(non_empty, "non_empty bucket count")?);
+            for b in 0..self.num_buckets {
+                let (compressed_size, bulk_decompress_size) = meta.bucket_layouts[b].encode();
+                if compressed_size > 0 {
+                    varint::encode(&mut index_buf, to_u32(b, "bucket index")?);
+                    index_buf.extend_from_slice(&meta.bucket_offsets[b].to_be_bytes());
+                    varint::encode(
+                        &mut index_buf,
+                        to_u32(compressed_size, "bucket compressed_size")?,
+                    );
+                    varint::encode(
+                        &mut index_buf,
+                        to_u32(bulk_decompress_size, "bucket bulk_decompress_size")?,
+                    );
+                }
+            }
+        }
+        self.out.write(&index_buf)?;
+
+        // Write footer (32 bytes, big-endian)
+        let mut footer = [0u8; FOOTER_SIZE];
+        footer[0..8].copy_from_slice(&index_offset.to_be_bytes());
+        footer[8..16].copy_from_slice(&schema_block_offset.to_be_bytes());
+        footer[16..20].copy_from_slice(&to_u32(self.num_buckets, "num_buckets")?.to_be_bytes());
+        footer[20..24].copy_from_slice(&to_u32(num_row_groups, "num_row_groups")?.to_be_bytes());
+        footer[24] = self.compression;
+        footer[25] = VERSION;
+        footer[26..28].copy_from_slice(&[0, 0]);
+        footer[28..32].copy_from_slice(&MAGIC);
+
+        self.out.write(&footer)?;
+        self.out.flush()?;
+        Ok(())
+    }
+}
+
+impl<S: OutputFile> Drop for MosaicWriter<S> {
+    fn drop(&mut self) {
+        if !self.closed {
+            if let Err(e) = self.close() {
+                eprintln!("MosaicWriter::drop: close failed: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    struct MemOutputFile {
+        buf: Vec<u8>,
+    }
+
+    impl MemOutputFile {
+        fn new() -> Self {
+            Self { buf: Vec::new() }
+        }
+    }
+
+    impl OutputFile for MemOutputFile {
+        fn write(&mut self, data: &[u8]) -> io::Result<()> {
+            self.buf.extend_from_slice(data);
+            Ok(())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+        fn pos(&self) -> u64 {
+            self.buf.len() as u64
+        }
+    }
+
+    #[test]
+    fn test_write_simple_file() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("name", DataType::Utf8, true),
+            Field::new("age", DataType::Int32, true),
+            Field::new("score", DataType::Float64, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(
+            out,
+            &arrow_schema,
+            WriterOptions {
+                num_buckets: 2,
+                compression: COMPRESSION_NONE,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let names: Vec<String> = (0..100).map(|i| format!("user_{}", i)).collect();
+        let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        let ages: Vec<i32> = (0..100).map(|i| 20 + (i % 50)).collect();
+        let scores: Vec<f64> = (0..100).map(|i| i as f64 * 1.5).collect();
+
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(StringArray::from(name_refs)),
+                Arc::new(Int32Array::from(ages)),
+                Arc::new(Float64Array::from(scores)),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+
+        writer.close().unwrap();
+        let data = &writer.out.buf;
+
+        assert!(data.len() >= FOOTER_SIZE);
+        let magic = &data[data.len() - 4..];
+        assert_eq!(magic, &MAGIC);
+        assert_eq!(data[data.len() - 7], VERSION);
+    }
+
+    #[test]
+    fn test_write_with_zstd() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(
+            out,
+            &arrow_schema,
+            WriterOptions {
+                num_buckets: 1,
+                compression: COMPRESSION_ZSTD,
+                zstd_level: 3,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let a_vals: Vec<i64> = (0..1000).collect();
+        let b_vals: Vec<i64> = (0..1000).map(|i| i * 2).collect();
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(Int64Array::from(a_vals)),
+                Arc::new(Int64Array::from(b_vals)),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+
+        writer.close().unwrap();
+        let magic = &writer.out.buf[writer.out.buf.len() - 4..];
+        assert_eq!(magic, &MAGIC);
+    }
+
+    #[test]
+    fn test_estimated_file_size() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(
+            out,
+            &arrow_schema,
+            WriterOptions {
+                num_buckets: 1,
+                compression: COMPRESSION_ZSTD,
+                zstd_level: 3,
+                row_group_max_size: 4096,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(writer.estimated_file_size(), 1024);
+
+        let arrow_schema = Arc::new(arrow_schema);
+
+        let a_vals: Vec<i64> = (0..10).collect();
+        let b_vals: Vec<String> = (0..10).map(|i| format!("val_{}", i)).collect();
+        let b_refs: Vec<&str> = b_vals.iter().map(|s| s.as_str()).collect();
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(a_vals)),
+                Arc::new(StringArray::from(b_refs)),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        let est_before_flush = writer.estimated_file_size();
+        assert!(est_before_flush > 1024);
+
+        let a_vals: Vec<i64> = (10..500).collect();
+        let b_vals: Vec<String> = (10..500).map(|i| format!("val_{}", i)).collect();
+        let b_refs: Vec<&str> = b_vals.iter().map(|s| s.as_str()).collect();
+        let batch = RecordBatch::try_new(
+            arrow_schema,
+            vec![
+                Arc::new(Int64Array::from(a_vals)),
+                Arc::new(StringArray::from(b_refs)),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        assert!(!writer.row_group_metas.is_empty());
+        assert!(writer.compression_ratio < 1.0);
+
+        let est_after_flush = writer.estimated_file_size();
+        assert!(est_after_flush > 0);
+
+        writer.close().unwrap();
+        let actual = writer.out.buf.len() as u64;
+        assert!(actual > 0);
+    }
+
+    #[test]
+    fn test_non_nullable_rejects_null() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(out, &arrow_schema, WriterOptions::default()).unwrap();
+
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, true),
+                Field::new("name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(Int32Array::from(vec![None, Some(1)])),
+                Arc::new(StringArray::from(vec![Some("hello"), Some("world")])),
+            ],
+        )
+        .unwrap();
+        let result = writer.write_batch(&batch);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+
+        let batch2 = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("id", DataType::Int32, false),
+                Field::new("name", DataType::Utf8, true),
+            ])),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec![None, Some("world")])),
+            ],
+        )
+        .unwrap();
+        let result = writer.write_batch(&batch2);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
Initial contribution of the Mosaic file format core library:
- Format specification (spec.rs): magic bytes, version, footer layout, bucket layouts (monolithic and paged), encoding types
- Schema (schema.rs): column metadata, bucket assignment, serialization
- Writer (writer.rs, bucket_writer.rs): row-group-based writer with automatic encoding selection (const, dict, plain), zstd compression, and paged bucket support for wide tables
- Reader (reader.rs, bucket_reader.rs): two-round IO strategy with range coalescing, column projection, paged bucket optimization
- Types (types.rs, values.rs): type system mapping to Arrow types
- Utilities (varint.rs, bpe.rs): variable-length integer encoding, byte-pair encoding for string compression