### PR TITLE
Rename Java package to org.apache.paimon.mosaic and update pom.xml

### DIFF
--- a/docs/java-api.html
+++ b/docs/java-api.html
@@ -75,7 +75,7 @@
         &lt;dependency&gt;
             &lt;groupId&gt;org.apache.arrow&lt;/groupId&gt;
             &lt;artifactId&gt;arrow-bom&lt;/artifactId&gt;
-            &lt;version&gt;18.1.0&lt;/version&gt;
+            &lt;version&gt;15.0.0&lt;/version&gt;
             &lt;type&gt;pom&lt;/type&gt;
             &lt;scope&gt;import&lt;/scope&gt;
         &lt;/dependency&gt;
@@ -299,7 +299,7 @@
             </p>
 
             <h2>Complete Example</h2>
-<pre><code><span class="kw">import</span> io.mosaic.*;
+<pre><code><span class="kw">import</span> org.apache.paimon.mosaic.*;
 <span class="kw">import</span> org.apache.arrow.memory.*;
 <span class="kw">import</span> org.apache.arrow.vector.*;
 <span class="kw">import</span> org.apache.arrow.vector.types.pojo.*;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -22,19 +22,50 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.mosaic</groupId>
+    <parent>
+        <groupId>org.apache</groupId>
+        <artifactId>apache</artifactId>
+        <version>23</version>
+    </parent>
+
+    <groupId>org.apache.paimon.mosaic</groupId>
     <artifactId>mosaic-writer</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mosaic Writer</name>
     <description>Mosaic file format writer for Java (backed by Rust via JNI)</description>
+    <url>https://paimon.apache.org</url>
+    <inceptionYear>2025</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <url>https://github.com/apache/paimon-mosaic</url>
+        <connection>git@github.com:apache/paimon-mosaic.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/paimon-mosaic.git</developerConnection>
+    </scm>
+
+    <developers>
+        <developer>
+            <name>Apache Paimon Contributors</name>
+            <email>dev@paimon.apache.org</email>
+            <organization>Apache Software Foundation</organization>
+            <organizationUrl>https://www.apache.org</organizationUrl>
+        </developer>
+    </developers>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>18.1.0</arrow.version>
+        <arrow.version>15.0.0</arrow.version>
     </properties>
 
     <dependencyManagement>
@@ -70,4 +101,50 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-maven</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>1.8.0</version>
+                                        </requireJavaVersion>
+                                        <requireMavenVersion>
+                                            <version>[3.1.1,)</version>
+                                        </requireMavenVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/java/src/main/java/org/apache/paimon/mosaic/ColumnStatistics.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/ColumnStatistics.java
@@ -17,17 +17,39 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
-import java.io.IOException;
+public class ColumnStatistics {
 
-public interface InputFile {
+    private final int columnIndex;
+    private final long nullCount;
+    private final byte[] min;
+    private final byte[] max;
 
-    /**
-     * Read {@code length} bytes starting at {@code position} into {@code buffer}.
-     *
-     * <p>This method must be thread-safe: the reader may call it concurrently
-     * from multiple threads to perform parallel IO.
-     */
-    void readFully(long position, byte[] buffer, int offset, int length) throws IOException;
+    ColumnStatistics(int columnIndex, long nullCount, byte[] min, byte[] max) {
+        this.columnIndex = columnIndex;
+        this.nullCount = nullCount;
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+    public long getNullCount() {
+        return nullCount;
+    }
+
+    public boolean hasMinMax() {
+        return min != null;
+    }
+
+    public byte[] getMin() {
+        return min;
+    }
+
+    public byte[] getMax() {
+        return max;
+    }
 }

--- a/java/src/main/java/org/apache/paimon/mosaic/InputFile.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/InputFile.java
@@ -17,39 +17,17 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
-public class ColumnStatistics {
+import java.io.IOException;
 
-    private final int columnIndex;
-    private final long nullCount;
-    private final byte[] min;
-    private final byte[] max;
+public interface InputFile {
 
-    ColumnStatistics(int columnIndex, long nullCount, byte[] min, byte[] max) {
-        this.columnIndex = columnIndex;
-        this.nullCount = nullCount;
-        this.min = min;
-        this.max = max;
-    }
-
-    public int getColumnIndex() {
-        return columnIndex;
-    }
-
-    public long getNullCount() {
-        return nullCount;
-    }
-
-    public boolean hasMinMax() {
-        return min != null;
-    }
-
-    public byte[] getMin() {
-        return min;
-    }
-
-    public byte[] getMax() {
-        return max;
-    }
+    /**
+     * Read {@code length} bytes starting at {@code position} into {@code buffer}.
+     *
+     * <p>This method must be thread-safe: the reader may call it concurrently
+     * from multiple threads to perform parallel IO.
+     */
+    void readFully(long position, byte[] buffer, int offset, int length) throws IOException;
 }

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicWriter.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicWriter.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
 import java.io.OutputStream;
 

--- a/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
@@ -17,17 +17,88 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 final class NativeLib {
 
+    private static final String LIB_NAME = "mosaic_jni";
+
     static {
-        System.loadLibrary("mosaic_jni");
+        loadNativeLibrary();
     }
 
     private NativeLib() {}
+
+    private static void loadNativeLibrary() {
+        // First try java.library.path (for development / manual override)
+        try {
+            System.loadLibrary(LIB_NAME);
+            return;
+        } catch (UnsatisfiedLinkError ignored) {
+        }
+
+        // Extract from JAR resources
+        String os = normalizeOs(System.getProperty("os.name", ""));
+        String arch = normalizeArch(System.getProperty("os.arch", ""));
+        String libFileName = mapLibraryName(os);
+        String resourcePath = "/native/" + os + "/" + arch + "/" + libFileName;
+
+        try (InputStream in = NativeLib.class.getResourceAsStream(resourcePath)) {
+            if (in == null) {
+                throw new UnsatisfiedLinkError(
+                        "Native library not found in JAR: " + resourcePath);
+            }
+            File tempFile = File.createTempFile("mosaic_jni", libFileName);
+            tempFile.deleteOnExit();
+            Files.copy(in, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            System.load(tempFile.getAbsolutePath());
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError(
+                    "Failed to extract native library: " + e.getMessage());
+        }
+    }
+
+    private static String normalizeOs(String osName) {
+        String lower = osName.toLowerCase();
+        if (lower.contains("linux")) {
+            return "linux";
+        } else if (lower.contains("mac") || lower.contains("darwin")) {
+            return "macos";
+        } else if (lower.contains("win")) {
+            return "windows";
+        }
+        throw new UnsatisfiedLinkError("Unsupported OS: " + osName);
+    }
+
+    private static String normalizeArch(String archName) {
+        String lower = archName.toLowerCase();
+        if (lower.equals("amd64") || lower.equals("x86_64")) {
+            return "x86_64";
+        } else if (lower.equals("aarch64") || lower.equals("arm64")) {
+            return "aarch64";
+        }
+        throw new UnsatisfiedLinkError("Unsupported architecture: " + archName);
+    }
+
+    private static String mapLibraryName(String os) {
+        switch (os) {
+            case "linux":
+                return "libmosaic_jni.so";
+            case "macos":
+                return "libmosaic_jni.dylib";
+            case "windows":
+                return "mosaic_jni.dll";
+            default:
+                throw new UnsatisfiedLinkError("Unsupported OS: " + os);
+        }
+    }
 
     // Writer
     static native long nativeWriterOpen(OutputStream stream, long arrowSchemaAddr,

--- a/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
 public class WriterOptions {
 

--- a/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
+++ b/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package io.mosaic;
+package org.apache.paimon.mosaic;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -194,7 +194,7 @@ struct WriterHandle {
 // ======================== Writer ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterOpen(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterOpen(
     mut env: JNIEnv,
     _class: JClass,
     stream: JObject,
@@ -321,7 +321,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterOpen(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterClose(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterClose(
     mut env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -343,7 +343,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterClose(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterFree(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterFree(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -356,7 +356,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterFree(
 // ======================== Writer.estimatedSize ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterEstimatedSize(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterEstimatedSize(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -371,7 +371,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterEstimatedSize(
 // ======================== Writer.writeBatch (Arrow C Data Interface) ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeWriterWriteBatch(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterWriteBatch(
     mut env: JNIEnv,
     _class: JClass,
     writer_handle: jlong,
@@ -427,7 +427,7 @@ struct RowGroupReaderHandle {
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpen(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpen(
     mut env: JNIEnv,
     _class: JClass,
     input_file: JObject,
@@ -483,7 +483,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpen(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderFree(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderFree(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -494,7 +494,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderFree(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderExportSchema(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderExportSchema(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -527,7 +527,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderExportSchema(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderNumRowGroups(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderNumRowGroups(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -541,7 +541,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderNumRowGroups(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpenRowGroup(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpenRowGroup(
     mut env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -576,7 +576,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpenRowGroup(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpenRowGroupProjected(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpenRowGroupProjected(
     mut env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -629,7 +629,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderOpenRowGroupProjecte
 // ======================== RowGroupReader ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeRowGroupReaderNumRows(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderNumRows(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -642,7 +642,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeRowGroupReaderNumRows(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeRowGroupReaderFree(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderFree(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -655,7 +655,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeRowGroupReaderFree(
 // ======================== Row Group Stats ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupNumStats(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupNumStats(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -672,7 +672,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupNumStats(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatColumnIndex(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatColumnIndex(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -695,7 +695,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatColumnIn
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatNullCount(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatNullCount(
     _env: JNIEnv,
     _class: JClass,
     handle: jlong,
@@ -718,7 +718,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatNullCoun
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatMin<'a>(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMin<'a>(
     env: JNIEnv<'a>,
     _class: JClass<'a>,
     handle: jlong,
@@ -748,7 +748,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatMin<'a>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatMax<'a>(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMax<'a>(
     env: JNIEnv<'a>,
     _class: JClass<'a>,
     handle: jlong,
@@ -780,7 +780,7 @@ pub extern "system" fn Java_io_mosaic_NativeLib_nativeReaderRowGroupStatMax<'a>(
 // ======================== Columnar Read (Arrow C Data Interface) ========================
 
 #[no_mangle]
-pub extern "system" fn Java_io_mosaic_NativeLib_nativeRowGroupReaderReadColumns(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderReadColumns(
     mut env: JNIEnv,
     _class: JClass,
     handle: jlong,


### PR DESCRIPTION
- Rename package from io.mosaic to org.apache.paimon.mosaic
- Update groupId to org.apache.paimon.mosaic with Apache parent pom
- Downgrade to Java 1.8 source/target and Arrow 15.0.0
- Add enhanced NativeLib with JAR-embedded native library loading
- Add release profile with GPG signing and enforcer plugin
- Update JNI function names to match new package path