### PR TITLE
Remove logical index, add name-based project() and batch stats API

### DIFF
--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -195,16 +195,42 @@ pub trait ReaderAccess {
         rg_index: usize,
         columns: &[usize],
     ) -> io::Result<RowGroupReader>;
+    fn row_group_reader_by_names(
+        &self,
+        rg_index: usize,
+        column_names: &[&str],
+    ) -> io::Result<RowGroupReader> {
+        let schema = self.schema();
+        let mut indices = Vec::with_capacity(column_names.len());
+        for name in column_names {
+            let idx = schema
+                .columns
+                .iter()
+                .position(|c| c.name == *name)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("column '{}' not found in schema", name),
+                    )
+                })?;
+            indices.push(idx);
+        }
+        self.row_group_reader_projected(rg_index, &indices)
+    }
+    fn project(&mut self, column_names: &[&str]) -> io::Result<()>;
     fn row_group_stats(&self, rg_index: usize) -> io::Result<&[ColumnStats]>;
     fn row_group_num_rows(&self, rg_index: usize) -> io::Result<usize>;
 }
 
+/// Schema and output columns are in storage order (name-sorted).
+/// Use `project()` to select and reorder output columns.
 pub struct MosaicReader<I: InputFile> {
     input: I,
     schema: MosaicSchema,
     row_group_metas: Vec<RowGroupMeta>,
     compression: u8,
     num_buckets: usize,
+    projected_columns: Option<Vec<usize>>,
 }
 
 fn read_range(input: &dyn InputFile, offset: u64, len: usize) -> io::Result<Vec<u8>> {
@@ -395,7 +421,28 @@ impl<I: InputFile> MosaicReader<I> {
             row_group_metas,
             compression,
             num_buckets,
+            projected_columns: None,
         })
+    }
+
+    pub fn project(&mut self, column_names: &[&str]) -> io::Result<()> {
+        let mut indices = Vec::with_capacity(column_names.len());
+        for name in column_names {
+            let idx = self
+                .schema
+                .columns
+                .iter()
+                .position(|c| c.name == *name)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("column '{}' not found in schema", name),
+                    )
+                })?;
+            indices.push(idx);
+        }
+        self.projected_columns = Some(indices);
+        Ok(())
     }
 
     pub fn input(&self) -> &I {
@@ -493,8 +540,13 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
     }
 
     fn row_group_reader(&self, rg_index: usize) -> io::Result<RowGroupReader> {
-        let all_columns: Vec<usize> = (0..self.schema.columns.len()).collect();
-        self.row_group_reader_projected(rg_index, &all_columns)
+        match &self.projected_columns {
+            Some(cols) => self.row_group_reader_projected(rg_index, cols),
+            None => {
+                let all_columns: Vec<usize> = (0..self.schema.columns.len()).collect();
+                self.row_group_reader_projected(rg_index, &all_columns)
+            }
+        }
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -846,7 +898,28 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
             num_cols,
             meta.num_rows,
             projected,
+            columns.to_vec(),
         ))
+    }
+
+    fn project(&mut self, column_names: &[&str]) -> io::Result<()> {
+        let mut indices = Vec::with_capacity(column_names.len());
+        for name in column_names {
+            let idx = self
+                .schema
+                .columns
+                .iter()
+                .position(|c| c.name == *name)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("column '{}' not found in schema", name),
+                    )
+                })?;
+            indices.push(idx);
+        }
+        self.projected_columns = Some(indices);
+        Ok(())
     }
 }
 
@@ -867,6 +940,7 @@ pub struct RowGroupReader {
     num_rows: usize,
     num_columns: usize,
     projected_columns: Vec<bool>,
+    output_order: Vec<usize>,
 }
 
 impl RowGroupReader {
@@ -877,6 +951,7 @@ impl RowGroupReader {
         num_columns: usize,
         num_rows: usize,
         projected_columns: Vec<bool>,
+        output_order: Vec<usize>,
     ) -> Self {
         let active_buckets: Vec<usize> = bucket_states
             .iter()
@@ -891,6 +966,7 @@ impl RowGroupReader {
             num_rows,
             num_columns,
             projected_columns,
+            output_order,
         }
     }
 
@@ -933,8 +1009,8 @@ impl RowGroupReader {
 
         let mut fields = Vec::new();
         let mut batch_arrays = Vec::new();
-        for (i, arr_opt) in arrays.into_iter().enumerate() {
-            if let Some(arr) = arr_opt {
+        for &i in &self.output_order {
+            if let Some(arr) = arrays[i].take() {
                 let col_meta = &self.schema.columns[i];
                 fields.push(Field::new(
                     &col_meta.name,

--- a/core/src/reader_tests.rs
+++ b/core/src/reader_tests.rs
@@ -869,7 +869,7 @@ fn test_stats_roundtrip() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0, 2],
+            stats_columns: vec!["id".to_string(), "score".to_string()],
             num_buckets: 2,
             ..Default::default()
         },
@@ -924,7 +924,7 @@ fn test_stats_with_nulls() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0, 1],
+            stats_columns: vec!["a".to_string(), "b".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -965,7 +965,7 @@ fn test_stats_all_null_column() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0],
+            stats_columns: vec!["x".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -1013,14 +1013,14 @@ fn test_no_stats_minimal_overhead() {
     writer.close().unwrap();
     let no_stats_size = writer.output().buf.len();
 
-    // Write with stats on column 0
+    // Write with stats on column "a"
     let out2 = MemOutputFile::new();
     let mut writer2 = MosaicWriter::new(
         out2,
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0],
+            stats_columns: vec!["a".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -1061,7 +1061,7 @@ fn test_stats_string_column() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0],
+            stats_columns: vec!["s".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -1307,6 +1307,113 @@ fn test_projection_single_column() {
     for i in 0..20usize {
         assert_eq!(cy.value(i), i as i32 * 10);
     }
+}
+
+#[test]
+fn test_projection_preserves_requested_order() {
+    let columns = vec![
+        ("a".to_string(), DataType::Int32, true),
+        ("b".to_string(), DataType::Utf8, true),
+        ("c".to_string(), DataType::Float64, true),
+    ];
+    let out = MemOutputFile::new();
+    let mut writer = MosaicWriter::new(
+        out,
+        &columns_to_arrow_schema(&columns),
+        WriterOptions {
+            compression: COMPRESSION_ZSTD,
+            num_buckets: 2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let rows: Vec<Vec<Value>> = (0..10)
+        .map(|i| {
+            vec![
+                Value::Integer(i),
+                Value::String(format!("s{}", i).into_bytes()),
+                Value::Double(i as f64 * 0.5),
+            ]
+        })
+        .collect();
+    write_values(&mut writer, &columns, &rows);
+    writer.close().unwrap();
+    let data = writer.output().buf.clone();
+    let len = data.len() as u64;
+    let mut reader = MosaicReader::new(ByteArrayInputFile::new(data), len).unwrap();
+
+    reader.project(&["c", "a", "b"]).unwrap();
+    let mut rg = reader.row_group_reader(0).unwrap();
+    let batch = rg.read_columns().unwrap();
+
+    assert_eq!(batch.num_columns(), 3);
+    let schema = batch.schema();
+    let fields: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(fields, vec!["c", "a", "b"]);
+
+    let col_c = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    let col_a = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<Int32Array>()
+        .unwrap();
+    let col_b = batch
+        .column(2)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    for i in 0..10usize {
+        assert_eq!(col_a.value(i), i as i32);
+        assert_eq!(col_b.value(i), format!("s{}", i));
+        assert!((col_c.value(i) - i as f64 * 0.5).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn test_projection_empty_via_project_method() {
+    let columns = vec![
+        ("a".to_string(), DataType::Int32, true),
+        ("b".to_string(), DataType::Utf8, true),
+        ("c".to_string(), DataType::Float64, true),
+    ];
+    let out = MemOutputFile::new();
+    let mut writer = MosaicWriter::new(
+        out,
+        &columns_to_arrow_schema(&columns),
+        WriterOptions {
+            compression: COMPRESSION_ZSTD,
+            num_buckets: 2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let rows: Vec<Vec<Value>> = (0..5)
+        .map(|i| {
+            vec![
+                Value::Integer(i),
+                Value::String(format!("v{}", i).into_bytes()),
+                Value::Double(i as f64),
+            ]
+        })
+        .collect();
+    write_values(&mut writer, &columns, &rows);
+    writer.close().unwrap();
+    let data = writer.output().buf.clone();
+    let len = data.len() as u64;
+    let mut reader = MosaicReader::new(ByteArrayInputFile::new(data), len).unwrap();
+
+    reader.project(&[]).unwrap();
+    let mut rg = reader.row_group_reader(0).unwrap();
+    let batch = rg.read_columns().unwrap();
+
+    assert_eq!(batch.num_columns(), 0);
+    assert_eq!(batch.num_rows(), 5);
 }
 
 #[test]
@@ -1763,14 +1870,22 @@ fn test_timestamp_ltz_roundtrip() {
     let (reader, _) = write_and_read(columns, &rows);
 
     let schema = reader.schema();
-    let dt0 = &schema.columns[0].data_type;
-    let dt1 = &schema.columns[1].data_type;
+    let micros_idx = schema
+        .columns
+        .iter()
+        .position(|c| c.name == "ts_micros")
+        .unwrap();
+    let millis_idx = schema
+        .columns
+        .iter()
+        .position(|c| c.name == "ts_millis")
+        .unwrap();
     assert_eq!(
-        *dt0,
+        schema.columns[millis_idx].data_type,
         DataType::Timestamp(TimeUnit::Millisecond, Some("Asia/Shanghai".into()))
     );
     assert_eq!(
-        *dt1,
+        schema.columns[micros_idx].data_type,
         DataType::Timestamp(TimeUnit::Microsecond, Some("America/New_York".into()))
     );
 
@@ -1779,7 +1894,7 @@ fn test_timestamp_ltz_roundtrip() {
     assert_eq!(batch.num_rows(), 3);
 
     let ts0 = batch
-        .column(0)
+        .column(millis_idx)
         .as_any()
         .downcast_ref::<TimestampMillisecondArray>()
         .unwrap();
@@ -1789,7 +1904,7 @@ fn test_timestamp_ltz_roundtrip() {
     assert_eq!(ts0.timezone().unwrap(), "Asia/Shanghai");
 
     let ts1 = batch
-        .column(1)
+        .column(micros_idx)
         .as_any()
         .downcast_ref::<TimestampMicrosecondArray>()
         .unwrap();
@@ -1844,22 +1959,38 @@ fn test_timestamp_micros_roundtrip() {
         ],
     ];
     let (reader, _) = write_and_read(columns, &rows);
+    let schema = reader.schema();
+    let millis_pos = schema
+        .columns
+        .iter()
+        .position(|c| c.name == "ts_millis")
+        .unwrap();
+    let micros_pos = schema
+        .columns
+        .iter()
+        .position(|c| c.name == "ts_micros")
+        .unwrap();
+    let nanos_pos = schema
+        .columns
+        .iter()
+        .position(|c| c.name == "ts_nanos")
+        .unwrap();
     let mut rg = reader.row_group_reader(0).unwrap();
     let batch = rg.read_columns().unwrap();
     assert_eq!(batch.num_rows(), 3);
 
     let ts_millis = batch
-        .column(0)
+        .column(millis_pos)
         .as_any()
         .downcast_ref::<TimestampMillisecondArray>()
         .unwrap();
     let ts_micros = batch
-        .column(1)
+        .column(micros_pos)
         .as_any()
         .downcast_ref::<TimestampMicrosecondArray>()
         .unwrap();
     let ts_nanos = batch
-        .column(2)
+        .column(nanos_pos)
         .as_any()
         .downcast_ref::<StructArray>()
         .unwrap();
@@ -2136,7 +2267,7 @@ fn test_stats_across_multiple_row_groups() {
         WriterOptions {
             compression: COMPRESSION_NONE,
             row_group_max_size: 100,
-            stats_columns: vec![0],
+            stats_columns: vec!["v".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -2182,7 +2313,7 @@ fn test_schema_order_preserved_after_roundtrip() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![1],
+            stats_columns: vec!["age".to_string()],
             num_buckets: 2,
             ..Default::default()
         },
@@ -2204,13 +2335,13 @@ fn test_schema_order_preserved_after_roundtrip() {
     let len = data.len() as u64;
     let reader = MosaicReader::new(ByteArrayInputFile::new(data), len).unwrap();
 
-    assert_eq!(reader.schema().columns[0].name, "name");
-    assert_eq!(reader.schema().columns[1].name, "age");
+    assert_eq!(reader.schema().columns[0].name, "age");
+    assert_eq!(reader.schema().columns[1].name, "name");
     assert_eq!(reader.schema().columns[2].name, "score");
 
     let stats = reader.row_group_stats(0).unwrap();
     assert_eq!(stats.len(), 1);
-    assert_eq!(stats[0].column_index, 1);
+    assert_eq!(stats[0].column_index, 0);
     assert!(matches!(&stats[0].min, Some(Value::Integer(20))));
     assert!(matches!(&stats[0].max, Some(Value::Integer(69))));
 
@@ -3563,7 +3694,7 @@ fn test_writer_stats_basic() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0, 2],
+            stats_columns: vec!["id".to_string(), "score".to_string()],
             num_buckets: 2,
             ..Default::default()
         },
@@ -3615,7 +3746,7 @@ fn test_writer_stats_with_nulls() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0, 1],
+            stats_columns: vec!["a".to_string(), "b".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -3655,7 +3786,7 @@ fn test_writer_stats_all_null() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0],
+            stats_columns: vec!["x".to_string()],
             num_buckets: 1,
             ..Default::default()
         },
@@ -3686,7 +3817,7 @@ fn test_writer_stats_matches_reader_stats() {
         &columns_to_arrow_schema(&columns),
         WriterOptions {
             compression: COMPRESSION_NONE,
-            stats_columns: vec![0, 1],
+            stats_columns: vec!["id".to_string(), "score".to_string()],
             num_buckets: 1,
             ..Default::default()
         },

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -71,20 +71,17 @@ impl MosaicSchema {
         sorted_indices.sort_by(|&a, &b| columns[a].0.cmp(&columns[b].0));
 
         let mut bucket_to_global = vec![Vec::new(); actual_buckets];
-        let mut cols: Vec<ColumnMeta> = columns
-            .into_iter()
-            .map(|(name, data_type, nullable)| ColumnMeta {
-                name,
-                data_type,
-                nullable,
-                bucket_id: 0,
-            })
-            .collect();
+        let mut cols: Vec<ColumnMeta> = Vec::with_capacity(num_columns);
 
-        for (sorted_pos, &global_idx) in sorted_indices.iter().enumerate() {
+        for (sorted_pos, &input_idx) in sorted_indices.iter().enumerate() {
             let bucket_id = spec::assign_bucket(sorted_pos, num_columns, actual_buckets);
-            cols[global_idx].bucket_id = bucket_id;
-            bucket_to_global[bucket_id].push(global_idx);
+            cols.push(ColumnMeta {
+                name: columns[input_idx].0.clone(),
+                data_type: columns[input_idx].1.clone(),
+                nullable: columns[input_idx].2,
+                bucket_id,
+            });
+            bucket_to_global[bucket_id].push(sorted_pos);
         }
 
         MosaicSchema {
@@ -135,16 +132,10 @@ impl MosaicSchema {
             None
         };
 
-        struct SortedEntry {
-            logical_index: usize,
-            name: String,
-            data_type: DataType,
-            nullable: bool,
-            sorted_pos: usize,
-        }
-
-        let mut entries = Vec::with_capacity(num_columns);
+        let mut columns = Vec::with_capacity(num_columns);
+        let mut bucket_to_global = vec![Vec::new(); num_buckets];
         let mut prev_encoded: Vec<u8> = Vec::new();
+        let mut seen_names = std::collections::HashSet::with_capacity(num_columns);
 
         for sorted_pos in 0..num_columns {
             let shared = varint::decode(data, &mut pos)? as usize;
@@ -173,67 +164,29 @@ impl MosaicSchema {
                 )
             })?;
 
-            let logical_index = varint::decode(data, &mut pos)? as usize;
-
-            let field = types::deserialize_field(&name, data, &mut pos)?;
-
-            entries.push(SortedEntry {
-                logical_index,
-                name,
-                data_type: field.data_type().clone(),
-                nullable: field.is_nullable(),
-                sorted_pos,
-            });
-        }
-
-        let mut columns = Vec::with_capacity(num_columns);
-        columns.resize_with(num_columns, || ColumnMeta {
-            name: String::new(),
-            data_type: DataType::Int32,
-            nullable: false,
-            bucket_id: 0,
-        });
-        let mut bucket_to_global = vec![Vec::new(); num_buckets];
-        let mut seen = vec![false; num_columns];
-
-        for entry in entries {
-            if entry.logical_index >= num_columns {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "schema: logical_index out of range",
-                ));
-            }
-            if seen[entry.logical_index] {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "schema: duplicate logical_index",
-                ));
-            }
-            seen[entry.logical_index] = true;
-            let bucket_id = spec::assign_bucket(entry.sorted_pos, num_columns, num_buckets);
-            columns[entry.logical_index] = ColumnMeta {
-                name: entry.name,
-                data_type: entry.data_type,
-                nullable: entry.nullable,
-                bucket_id,
-            };
-            bucket_to_global[bucket_id].push(entry.logical_index);
-        }
-
-        let mut seen_names = std::collections::HashSet::with_capacity(num_columns);
-        for col in &columns {
-            if col.name.is_empty() {
+            if name.is_empty() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "schema: empty column name",
                 ));
             }
-            if !seen_names.insert(&col.name) {
+            if !seen_names.insert(name.clone()) {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("schema: duplicate column name '{}'", col.name),
+                    format!("schema: duplicate column name '{}'", name),
                 ));
             }
+
+            let field = types::deserialize_field(&name, data, &mut pos)?;
+
+            let bucket_id = spec::assign_bucket(sorted_pos, num_columns, num_buckets);
+            columns.push(ColumnMeta {
+                name,
+                data_type: field.data_type().clone(),
+                nullable: field.is_nullable(),
+                bucket_id,
+            });
+            bucket_to_global[bucket_id].push(sorted_pos);
         }
 
         Ok(MosaicSchema {
@@ -246,16 +199,14 @@ impl MosaicSchema {
     pub fn serialize(&self) -> Vec<u8> {
         let num_columns = self.columns.len();
 
-        let mut sorted_indices: Vec<usize> = (0..num_columns).collect();
-        sorted_indices.sort_by(|&a, &b| self.columns[a].name.cmp(&self.columns[b].name));
-
-        let raw_names: Vec<Vec<u8>> = sorted_indices
+        let raw_names: Vec<Vec<u8>> = self
+            .columns
             .iter()
-            .map(|&i| self.columns[i].name.as_bytes().to_vec())
+            .map(|c| c.name.as_bytes().to_vec())
             .collect();
         let raw_refs: Vec<&[u8]> = raw_names.iter().map(|v| v.as_slice()).collect();
 
-        let plain_size = front_coded_size(&raw_refs, &sorted_indices);
+        let plain_size = front_coded_size(&raw_refs);
 
         let mut bpe_rules = Vec::new();
         let mut bpe_names = Vec::new();
@@ -269,7 +220,7 @@ impl MosaicSchema {
                     .map(|name| bpe::encode(name, &rules))
                     .collect();
                 let name_refs: Vec<&[u8]> = names.iter().map(|v| v.as_slice()).collect();
-                bpe_size = 1 + rules.len() * 2 + front_coded_size(&name_refs, &sorted_indices);
+                bpe_size = 1 + rules.len() * 2 + front_coded_size(&name_refs);
                 bpe_rules = rules;
                 bpe_names = names;
             }
@@ -287,26 +238,19 @@ impl MosaicSchema {
                 buf.push(rule[1]);
             }
             let bpe_refs: Vec<&[u8]> = bpe_names.iter().map(|v| v.as_slice()).collect();
-            write_front_coded(&mut buf, &bpe_refs, &sorted_indices, &self.columns);
+            write_front_coded(&mut buf, &bpe_refs, &self.columns);
         } else {
             buf.push(0); // NAME_ENCODING_FRONT_CODE
-            write_front_coded(&mut buf, &raw_refs, &sorted_indices, &self.columns);
+            write_front_coded(&mut buf, &raw_refs, &self.columns);
         }
 
         buf
     }
 }
 
-fn write_front_coded(
-    buf: &mut Vec<u8>,
-    name_bytes: &[&[u8]],
-    sorted_indices: &[usize],
-    columns: &[ColumnMeta],
-) {
+fn write_front_coded(buf: &mut Vec<u8>, name_bytes: &[&[u8]], columns: &[ColumnMeta]) {
     let mut prev: &[u8] = &[];
-    for (i, &global_idx) in sorted_indices.iter().enumerate() {
-        let col = &columns[global_idx];
-
+    for (i, col) in columns.iter().enumerate() {
         let cur = name_bytes[i];
         let shared = common_prefix_length(prev, cur);
         varint::encode(buf, shared as u32);
@@ -314,22 +258,20 @@ fn write_front_coded(
         buf.extend_from_slice(&cur[shared..]);
         prev = cur;
 
-        varint::encode(buf, global_idx as u32);
         let field = Field::new(&col.name, col.data_type.clone(), col.nullable);
         types::serialize_field(&field, buf);
     }
 }
 
-fn front_coded_size(names: &[&[u8]], sorted_indices: &[usize]) -> usize {
+fn front_coded_size(names: &[&[u8]]) -> usize {
     let mut size = 0;
     let mut prev: &[u8] = &[];
-    for (i, name) in names.iter().enumerate() {
+    for name in names {
         let shared = common_prefix_length(prev, name);
         let suffix_len = name.len() - shared;
         size += varint::encoded_size(shared as u32)
             + varint::encoded_size(suffix_len as u32)
-            + suffix_len
-            + varint::encoded_size(sorted_indices[i] as u32);
+            + suffix_len;
         prev = name;
     }
     size
@@ -366,23 +308,23 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_deserialize_preserves_column_order() {
+    fn test_serialize_deserialize_sorted_order() {
         let columns = vec![
             ("name".to_string(), DataType::Utf8, true),
             ("age".to_string(), DataType::Int32, true),
             ("score".to_string(), DataType::Float64, true),
         ];
         let schema = MosaicSchema::new(columns, 2);
-        assert_eq!(schema.columns[0].name, "name");
-        assert_eq!(schema.columns[1].name, "age");
+        assert_eq!(schema.columns[0].name, "age");
+        assert_eq!(schema.columns[1].name, "name");
         assert_eq!(schema.columns[2].name, "score");
 
         let data = schema.serialize();
         let restored = MosaicSchema::deserialize(&data).unwrap();
 
         assert_eq!(restored.columns.len(), 3);
-        assert_eq!(restored.columns[0].name, "name");
-        assert_eq!(restored.columns[1].name, "age");
+        assert_eq!(restored.columns[0].name, "age");
+        assert_eq!(restored.columns[1].name, "name");
         assert_eq!(restored.columns[2].name, "score");
         assert_eq!(restored.num_buckets, schema.num_buckets);
 

--- a/core/src/stats.rs
+++ b/core/src/stats.rs
@@ -81,6 +81,7 @@ pub fn compare_values(a: &Value, b: &Value) -> Option<Ordering> {
 
 struct ColTracker {
     column_index: usize,
+    batch_col_index: usize,
     data_type: DataType,
     null_count: usize,
     min: Option<Value>,
@@ -92,11 +93,12 @@ pub struct StatsCollector {
 }
 
 impl StatsCollector {
-    pub fn new(columns: &[(usize, DataType)]) -> Self {
+    pub fn new(columns: &[(usize, usize, DataType)]) -> Self {
         let trackers = columns
             .iter()
-            .map(|(idx, dt)| ColTracker {
+            .map(|(idx, batch_idx, dt)| ColTracker {
                 column_index: *idx,
+                batch_col_index: *batch_idx,
                 data_type: dt.clone(),
                 null_count: 0,
                 min: None,
@@ -112,7 +114,7 @@ impl StatsCollector {
 
     pub fn update(&mut self, row: &[Value]) {
         for tracker in &mut self.trackers {
-            let value = &row[tracker.column_index];
+            let value = &row[tracker.batch_col_index];
             if value.is_null() {
                 tracker.null_count += 1;
                 continue;
@@ -126,7 +128,7 @@ impl StatsCollector {
 
     pub fn update_batch(&mut self, batch: &RecordBatch) {
         for tracker in &mut self.trackers {
-            let array = batch.column(tracker.column_index);
+            let array = batch.column(tracker.batch_col_index);
             tracker.null_count += array.null_count();
             if !supports_stats(&tracker.data_type) {
                 continue;
@@ -509,7 +511,10 @@ mod tests {
 
     #[test]
     fn test_stats_collector() {
-        let columns = vec![(0usize, DataType::Int32), (1usize, DataType::Float64)];
+        let columns = vec![
+            (0usize, 0usize, DataType::Int32),
+            (1usize, 1usize, DataType::Float64),
+        ];
         let mut collector = StatsCollector::new(&columns);
 
         collector.update(&[Value::Integer(10), Value::Double(1.5)]);

--- a/core/src/writer.rs
+++ b/core/src/writer.rs
@@ -48,7 +48,7 @@ pub struct WriterOptions {
     pub row_group_max_size: u64,
     pub max_dict_total_bytes: usize,
     pub max_dict_entries: usize,
-    pub stats_columns: Vec<usize>,
+    pub stats_columns: Vec<String>,
     pub page_size_threshold: usize,
 }
 
@@ -74,6 +74,9 @@ struct RowGroupMeta {
     stats: Vec<ColumnStats>,
 }
 
+/// Columns are stored in name-sorted order regardless of input schema order.
+/// The reader returns columns in storage (name-sorted) order by default;
+/// use `project()` on the reader to control output column order.
 pub struct MosaicWriter<S: OutputFile> {
     out: S,
     schema: MosaicSchema,
@@ -84,6 +87,7 @@ pub struct MosaicWriter<S: OutputFile> {
     zstd_level: i32,
     row_group_max_size: u64,
     page_size_threshold: usize,
+    batch_col_map: Vec<usize>,
 
     row_group_metas: Vec<RowGroupMeta>,
     current_row_group_rows: usize,
@@ -99,13 +103,28 @@ impl<S: OutputFile> MosaicWriter<S> {
     pub fn new(out: S, schema: &Schema, options: WriterOptions) -> io::Result<Self> {
         let mosaic_schema = MosaicSchema::from_arrow(schema, options.num_buckets)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        Self::from_mosaic_schema(out, mosaic_schema, options)
+        let batch_col_map: Vec<usize> = mosaic_schema
+            .columns
+            .iter()
+            .map(|col| schema.index_of(&col.name).unwrap())
+            .collect();
+        Self::from_mosaic_schema_with_map(out, mosaic_schema, options, batch_col_map)
     }
 
     pub fn from_mosaic_schema(
         out: S,
         schema: MosaicSchema,
         options: WriterOptions,
+    ) -> io::Result<Self> {
+        let batch_col_map: Vec<usize> = (0..schema.columns.len()).collect();
+        Self::from_mosaic_schema_with_map(out, schema, options, batch_col_map)
+    }
+
+    fn from_mosaic_schema_with_map(
+        out: S,
+        schema: MosaicSchema,
+        options: WriterOptions,
+        batch_col_map: Vec<usize>,
     ) -> io::Result<Self> {
         let num_buckets = schema.num_buckets;
         let mut bucket_writers = Vec::with_capacity(num_buckets);
@@ -130,31 +149,32 @@ impl<S: OutputFile> MosaicWriter<S> {
         let stats_collector = if options.stats_columns.is_empty() {
             None
         } else {
-            let mut cols: Vec<(usize, arrow_schema::DataType)> =
+            let mut cols: Vec<(usize, usize, arrow_schema::DataType)> =
                 Vec::with_capacity(options.stats_columns.len());
-            for &idx in &options.stats_columns {
-                if idx >= schema.columns.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "stats_columns index {} is out of range (schema has {} columns)",
-                            idx,
-                            schema.columns.len()
-                        ),
-                    ));
-                }
+            for name in &options.stats_columns {
+                let idx = schema
+                    .columns
+                    .iter()
+                    .position(|c| c.name == *name)
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("stats_columns: column '{}' not found in schema", name),
+                        )
+                    })?;
                 let dt = &schema.columns[idx].data_type;
                 if !stats::supports_stats(dt) {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
-                            "stats_columns index {} has unsupported type {:?} for statistics",
-                            idx, dt
+                            "stats_columns: column '{}' has unsupported type {:?} for statistics",
+                            name, dt
                         ),
                     ));
                 }
-                cols.push((idx, dt.clone()));
+                cols.push((idx, batch_col_map[idx], dt.clone()));
             }
+            cols.sort_by_key(|(idx, _, _)| *idx);
             Some(StatsCollector::new(&cols))
         };
 
@@ -180,6 +200,7 @@ impl<S: OutputFile> MosaicWriter<S> {
             zstd_level: options.zstd_level,
             row_group_max_size: options.row_group_max_size,
             page_size_threshold: options.page_size_threshold,
+            batch_col_map,
             row_group_metas: Vec::new(),
             current_row_group_rows: 0,
             current_buffered_size: 0,
@@ -237,13 +258,13 @@ impl<S: OutputFile> MosaicWriter<S> {
         }
 
         for (i, col) in self.schema.columns.iter().enumerate() {
-            if !col.nullable && batch.column(i).null_count() > 0 {
+            if !col.nullable && batch.column(self.batch_col_map[i]).null_count() > 0 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
                         "non-nullable column '{}' has {} nulls in batch",
                         col.name,
-                        batch.column(i).null_count()
+                        batch.column(self.batch_col_map[i]).null_count()
                     ),
                 ));
             }
@@ -254,7 +275,7 @@ impl<S: OutputFile> MosaicWriter<S> {
             let global_indices = &self.schema.bucket_to_global[b];
             let arrays: Vec<&dyn Array> = global_indices
                 .iter()
-                .map(|&gi| batch.column(gi).as_ref())
+                .map(|&gi| batch.column(self.batch_col_map[gi]).as_ref())
                 .collect();
             let data_types: Vec<&arrow_schema::DataType> = global_indices
                 .iter()
@@ -766,7 +787,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stats_columns_out_of_range() {
+    fn test_stats_columns_not_found() {
         let arrow_schema = Schema::new(vec![
             Field::new("a", DataType::Int32, true),
             Field::new("b", DataType::Int64, true),
@@ -777,14 +798,14 @@ mod tests {
             &arrow_schema,
             WriterOptions {
                 num_buckets: 1,
-                stats_columns: vec![5],
+                stats_columns: vec!["x".to_string()],
                 ..Default::default()
             },
         );
         assert!(result.is_err());
         let err = result.err().expect("should be an error");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-        assert!(err.to_string().contains("out of range"));
+        assert!(err.to_string().contains("not found"));
     }
 
     #[test]
@@ -799,7 +820,7 @@ mod tests {
             &arrow_schema,
             WriterOptions {
                 num_buckets: 1,
-                stats_columns: vec![0, 1],
+                stats_columns: vec!["a".to_string(), "b".to_string()],
                 ..Default::default()
             },
         );
@@ -822,10 +843,48 @@ mod tests {
             &arrow_schema,
             WriterOptions {
                 num_buckets: 1,
-                stats_columns: vec![0, 1, 2],
+                stats_columns: vec!["a".to_string(), "b".to_string(), "c".to_string()],
                 ..Default::default()
             },
         );
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_stats_columns_sorted_by_index() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("x", DataType::Int32, true),
+            Field::new("y", DataType::Int64, true),
+            Field::new("z", DataType::Float64, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(
+            out,
+            &arrow_schema,
+            WriterOptions {
+                num_buckets: 1,
+                stats_columns: vec!["z".to_string(), "x".to_string()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(Int32Array::from(vec![10, 20])),
+                Arc::new(Int64Array::from(vec![100i64, 200])),
+                Arc::new(Float64Array::from(vec![1.5, 2.5])),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let stats = writer.row_group_stats(0);
+        assert_eq!(stats.len(), 2);
+        // sorted by column_index: x(0) before z(2)
+        assert_eq!(stats[0].column_index, 0);
+        assert_eq!(stats[1].column_index, 2);
     }
 }

--- a/core/tests/robustness_test.rs
+++ b/core/tests/robustness_test.rs
@@ -79,6 +79,17 @@ impl InputFile for ByteArrayInputFile {
     }
 }
 
+fn reorder_batch(batch: &RecordBatch, target_schema: &Schema) -> RecordBatch {
+    let mut fields = Vec::new();
+    let mut arrays = Vec::new();
+    for field in target_schema.fields() {
+        let idx = batch.schema().index_of(field.name()).unwrap();
+        fields.push(field.clone());
+        arrays.push(batch.column(idx).clone());
+    }
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays).unwrap()
+}
+
 fn write_file(schema: &Schema, batches: &[RecordBatch], options: WriterOptions) -> Vec<u8> {
     let out = MemOutputFile::new();
     let mut writer = MosaicWriter::new(out, schema, options).unwrap();
@@ -601,8 +612,9 @@ fn test_row_group_split_preserves_data() {
     for rg in 0..reader.num_row_groups() {
         let mut rg_reader = reader.row_group_reader(rg).unwrap();
         let batch = rg_reader.read_columns().unwrap();
+        let id_idx = batch.schema().index_of("id").unwrap();
         let id_col = batch
-            .column(0)
+            .column(id_idx)
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
@@ -683,7 +695,7 @@ fn test_stats_min_max_correctness() {
         WriterOptions {
             num_buckets: 1,
             row_group_max_size: 32, // Force each batch to be its own row group
-            stats_columns: vec![0],
+            stats_columns: vec!["v".to_string()],
             ..Default::default()
         },
     )
@@ -721,7 +733,7 @@ fn test_stats_with_all_null_row_group() {
         &schema,
         WriterOptions {
             num_buckets: 1,
-            stats_columns: vec![0],
+            stats_columns: vec!["v".to_string()],
             ..Default::default()
         },
     )
@@ -1078,21 +1090,29 @@ fn test_schema_roundtrip_preserves_types_and_nullability() {
     // Verify all columns preserved
     assert_eq!(mosaic_schema.columns.len(), 14);
 
-    // Verify names and types
-    assert_eq!(mosaic_schema.columns[0].name, "bool");
-    assert_eq!(mosaic_schema.columns[0].data_type, DataType::Boolean);
-    assert!(!mosaic_schema.columns[0].nullable);
+    // Verify names and types (columns are in sorted order)
+    let find = |name: &str| {
+        mosaic_schema
+            .columns
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap()
+    };
 
-    assert_eq!(mosaic_schema.columns[1].name, "i8");
-    assert_eq!(mosaic_schema.columns[1].data_type, DataType::Int8);
-    assert!(mosaic_schema.columns[1].nullable);
+    let c = find("bool");
+    assert_eq!(c.data_type, DataType::Boolean);
+    assert!(!c.nullable);
 
-    assert_eq!(mosaic_schema.columns[9].name, "str");
-    assert_eq!(mosaic_schema.columns[9].data_type, DataType::Utf8);
+    let c = find("i8");
+    assert_eq!(c.data_type, DataType::Int8);
+    assert!(c.nullable);
 
-    assert_eq!(mosaic_schema.columns[10].name, "bin");
-    assert_eq!(mosaic_schema.columns[10].data_type, DataType::Binary);
-    assert!(!mosaic_schema.columns[10].nullable);
+    let c = find("str");
+    assert_eq!(c.data_type, DataType::Utf8);
+
+    let c = find("bin");
+    assert_eq!(c.data_type, DataType::Binary);
+    assert!(!c.nullable);
 }
 
 #[test]
@@ -1183,7 +1203,7 @@ fn test_numeric_limits_roundtrip() {
     );
     let result = read_all(&data);
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], batch);
+    assert_eq!(reorder_batch(&result[0], &schema), batch);
 }
 
 // ======================== Multiple Writers Compatibility ========================
@@ -1263,7 +1283,7 @@ fn test_single_row_roundtrip() {
     let data = write_file(&schema, &[batch.clone()], WriterOptions::default());
     let result = read_all(&data);
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], batch);
+    assert_eq!(reorder_batch(&result[0], &schema), batch);
 }
 
 #[test]
@@ -1438,7 +1458,8 @@ fn test_all_null_boolean_column() {
 
     let data = write_file(&schema, &[batch], WriterOptions::default());
     let result = read_all(&data);
-    assert_eq!(result[0].column(1).null_count(), num_rows);
+    let flag_idx = result[0].schema().index_of("flag").unwrap();
+    assert_eq!(result[0].column(flag_idx).null_count(), num_rows);
 }
 
 // ======================== Decimal128 Tests ========================
@@ -2408,5 +2429,10 @@ fn run_random_schema_test(seed: u64, num_cols: usize, num_rows: usize) {
 
     // Verify data integrity by checking a sample of rows
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], batch, "seed={} data mismatch", seed);
+    assert_eq!(
+        reorder_batch(&result[0], &schema),
+        batch,
+        "seed={} data mismatch",
+        seed
+    );
 }

--- a/core/tests/stress_test.rs
+++ b/core/tests/stress_test.rs
@@ -105,6 +105,7 @@ fn assert_batches_equal(expected: &[RecordBatch], actual: &[RecordBatch]) {
     let mut act_batch_idx = 0;
 
     let num_cols = expected[0].num_columns();
+    let exp_schema = expected[0].schema();
     let mut row = 0;
     while row < expected_rows {
         let exp_batch = &expected[exp_batch_idx];
@@ -114,13 +115,15 @@ fn assert_batches_equal(expected: &[RecordBatch], actual: &[RecordBatch]) {
         let chunk = exp_remaining.min(act_remaining);
 
         for col in 0..num_cols {
+            let col_name = exp_schema.field(col).name();
+            let act_col_idx = act_batch.schema().index_of(col_name).unwrap();
             let exp_col = exp_batch.column(col).slice(exp_offset, chunk);
-            let act_col = act_batch.column(col).slice(act_offset, chunk);
+            let act_col = act_batch.column(act_col_idx).slice(act_offset, chunk);
             assert_eq!(
                 &exp_col,
                 &act_col,
                 "mismatch at column {} rows {}..{}",
-                col,
+                col_name,
                 row,
                 row + chunk
             );
@@ -1672,7 +1675,7 @@ fn test_stats_at_scale() {
         WriterOptions {
             num_buckets: 10,
             row_group_max_size: 32 * 1024 * 1024,
-            stats_columns: vec![0, 1],
+            stats_columns: vec!["id".to_string(), "value".to_string()],
             ..Default::default()
         },
     )

--- a/cpp/test_mosaic.cpp
+++ b/cpp/test_mosaic.cpp
@@ -87,18 +87,11 @@ static std::vector<uint8_t> write_and_get(
 }
 
 static std::shared_ptr<arrow::RecordBatch> read_row_group(
-    mosaic::Reader& reader, uint32_t rg,
-    const uint32_t* cols = nullptr, uint32_t num_cols = 0)
+    mosaic::Reader& reader, uint32_t rg)
 {
     struct ArrowArray c_array;
     struct ArrowSchema c_schema;
-
-    if (cols && num_cols > 0) {
-        reader.read_row_group(rg, cols, num_cols, &c_array, &c_schema);
-    } else {
-        reader.read_row_group(rg, &c_array, &c_schema);
-    }
-
+    reader.read_row_group(rg, &c_array, &c_schema);
     auto result = arrow::ImportRecordBatch(&c_array, &c_schema);
     assert(result.ok());
     return result.ValueUnsafe();
@@ -141,9 +134,9 @@ static void test_basic_roundtrip() {
     ASSERT_EQ(rb->num_rows(), 50);
     ASSERT_EQ(rb->num_columns(), 3);
 
-    auto ids = std::static_pointer_cast<arrow::Int32Array>(rb->column(0));
-    auto names = std::static_pointer_cast<arrow::StringArray>(rb->column(1));
-    auto scores = std::static_pointer_cast<arrow::DoubleArray>(rb->column(2));
+    auto ids = std::static_pointer_cast<arrow::Int32Array>(rb->GetColumnByName("id"));
+    auto names = std::static_pointer_cast<arrow::StringArray>(rb->GetColumnByName("name"));
+    auto scores = std::static_pointer_cast<arrow::DoubleArray>(rb->GetColumnByName("score"));
 
     for (int i = 0; i < 50; i++) {
         ASSERT_EQ(ids->Value(i), i);
@@ -179,7 +172,7 @@ static void test_null_values() {
     auto rb = read_row_group(reader, 0);
     ASSERT_EQ(rb->num_rows(), 3);
 
-    auto names = std::static_pointer_cast<arrow::StringArray>(rb->column(1));
+    auto names = std::static_pointer_cast<arrow::StringArray>(rb->GetColumnByName("name"));
     ASSERT_TRUE(!names->IsNull(0));
     ASSERT_EQ(names->GetString(0), "hello");
     ASSERT_TRUE(names->IsNull(1));
@@ -242,14 +235,14 @@ static void test_all_types() {
     ASSERT_EQ(rb->num_rows(), 1);
     ASSERT_EQ(rb->num_columns(), 9);
 
-    ASSERT_TRUE(std::static_pointer_cast<arrow::BooleanArray>(rb->column(0))->Value(0));
-    ASSERT_EQ(std::static_pointer_cast<arrow::Int8Array>(rb->column(1))->Value(0), 42);
-    ASSERT_EQ(std::static_pointer_cast<arrow::Int16Array>(rb->column(2))->Value(0), 1234);
-    ASSERT_EQ(std::static_pointer_cast<arrow::Int32Array>(rb->column(3))->Value(0), 100000);
-    ASSERT_EQ(std::static_pointer_cast<arrow::Int64Array>(rb->column(4))->Value(0), 9999999999LL);
-    ASSERT_TRUE(std::abs(std::static_pointer_cast<arrow::FloatArray>(rb->column(5))->Value(0) - 3.14f) < 1e-5f);
-    ASSERT_TRUE(std::abs(std::static_pointer_cast<arrow::DoubleArray>(rb->column(6))->Value(0) - 2.718281828) < 1e-9);
-    ASSERT_EQ(std::static_pointer_cast<arrow::StringArray>(rb->column(7))->GetString(0), "hello");
+    ASSERT_TRUE(std::static_pointer_cast<arrow::BooleanArray>(rb->GetColumnByName("f_bool"))->Value(0));
+    ASSERT_EQ(std::static_pointer_cast<arrow::Int8Array>(rb->GetColumnByName("f_int8"))->Value(0), 42);
+    ASSERT_EQ(std::static_pointer_cast<arrow::Int16Array>(rb->GetColumnByName("f_int16"))->Value(0), 1234);
+    ASSERT_EQ(std::static_pointer_cast<arrow::Int32Array>(rb->GetColumnByName("f_int32"))->Value(0), 100000);
+    ASSERT_EQ(std::static_pointer_cast<arrow::Int64Array>(rb->GetColumnByName("f_int64"))->Value(0), 9999999999LL);
+    ASSERT_TRUE(std::abs(std::static_pointer_cast<arrow::FloatArray>(rb->GetColumnByName("f_float32"))->Value(0) - 3.14f) < 1e-5f);
+    ASSERT_TRUE(std::abs(std::static_pointer_cast<arrow::DoubleArray>(rb->GetColumnByName("f_float64"))->Value(0) - 2.718281828) < 1e-9);
+    ASSERT_EQ(std::static_pointer_cast<arrow::StringArray>(rb->GetColumnByName("f_utf8"))->GetString(0), "hello");
     printf("  PASS test_all_types\n");
 }
 
@@ -283,11 +276,44 @@ static void test_projection() {
     buf.data = data_vec;
     auto reader = mosaic::make_reader(make_input(buf), buf.data.size());
 
-    uint32_t cols[] = {0, 1};
-    auto rb = read_row_group(reader, 0, cols, 2);
-    ASSERT_EQ(rb->num_columns(), 2);
+    const char* cols[] = {"c", "a", "b"};
+    reader.set_projection(cols, 3);
+    auto rb = read_row_group(reader, 0);
+    ASSERT_EQ(rb->num_columns(), 3);
     ASSERT_EQ(rb->num_rows(), 20);
+    ASSERT_EQ(rb->schema()->field(0)->name(), "c");
+    ASSERT_EQ(rb->schema()->field(1)->name(), "a");
+    ASSERT_EQ(rb->schema()->field(2)->name(), "b");
     printf("  PASS test_projection\n");
+}
+
+static void test_projection_empty() {
+    auto schema = arrow::schema({
+        arrow::field("a", arrow::int32()),
+        arrow::field("b", arrow::utf8()),
+    });
+
+    arrow::Int32Builder ab;
+    arrow::StringBuilder bb;
+    for (int i = 0; i < 5; i++) {
+        assert(ab.Append(i).ok());
+        assert(bb.Append("v" + std::to_string(i)).ok());
+    }
+    auto batch = arrow::RecordBatch::Make(schema, 5, {
+        ab.Finish().ValueUnsafe(), bb.Finish().ValueUnsafe(),
+    });
+
+    auto data_vec = write_and_get(schema, batch);
+
+    MemBuffer buf;
+    buf.data = data_vec;
+    auto reader = mosaic::make_reader(make_input(buf), buf.data.size());
+
+    reader.set_projection(nullptr, 0);
+    auto rb = read_row_group(reader, 0);
+    ASSERT_EQ(rb->num_columns(), 0);
+    ASSERT_EQ(rb->num_rows(), 5);
+    printf("  PASS test_projection_empty\n");
 }
 
 static void test_statistics() {
@@ -311,7 +337,7 @@ static void test_statistics() {
     });
 
     mosaic::WriterOptions opts;
-    uint32_t stats_cols[] = {0, 2};
+    const char* stats_cols[] = {"id", "score"};
     opts.stats_columns = stats_cols;
     opts.num_stats_columns = 2;
     auto data_vec = write_and_get(schema, batch, opts);
@@ -324,7 +350,7 @@ static void test_statistics() {
     ASSERT_TRUE(stats.size() > 0);
 
     for (auto& s : stats) {
-        ASSERT_TRUE(s.column_index == 0 || s.column_index == 2);
+        ASSERT_TRUE(s.column_name == "id" || s.column_name == "score");
         ASSERT_EQ(s.null_count, 0u);
         ASSERT_TRUE(s.has_min_max());
     }
@@ -358,7 +384,7 @@ static void test_compression_zstd() {
     auto rb = read_row_group(reader, 0);
     ASSERT_EQ(rb->num_rows(), 100);
 
-    auto xs = std::static_pointer_cast<arrow::Int32Array>(rb->column(0));
+    auto xs = std::static_pointer_cast<arrow::Int32Array>(rb->GetColumnByName("x"));
     for (int i = 0; i < 100; i++) {
         ASSERT_EQ(xs->Value(i), i);
     }
@@ -454,8 +480,8 @@ static void test_multiple_row_groups() {
     int offset = 0;
     for (uint32_t rg = 0; rg < reader.num_row_groups(); rg++) {
         auto rb = read_row_group(reader, rg);
-        auto ids = std::static_pointer_cast<arrow::Int32Array>(rb->column(0));
-        auto datas = std::static_pointer_cast<arrow::Int64Array>(rb->column(1));
+        auto ids = std::static_pointer_cast<arrow::Int32Array>(rb->GetColumnByName("id"));
+        auto datas = std::static_pointer_cast<arrow::Int64Array>(rb->GetColumnByName("data"));
         for (int64_t i = 0; i < rb->num_rows(); i++) {
             ASSERT_EQ(ids->Value(i), offset + static_cast<int>(i));
             ASSERT_EQ(datas->Value(i), static_cast<int64_t>(offset + i) * 3);
@@ -487,7 +513,7 @@ static void test_writer_stats() {
     });
 
     mosaic::WriterOptions opts;
-    uint32_t stats_cols[] = {0, 2};
+    const char* stats_cols[] = {"id", "score"};
     opts.stats_columns = stats_cols;
     opts.num_stats_columns = 2;
 
@@ -509,13 +535,13 @@ static void test_writer_stats() {
     ASSERT_TRUE(stats.size() > 0);
 
     for (auto& s : stats) {
-        ASSERT_TRUE(s.column_index == 0 || s.column_index == 2);
+        ASSERT_TRUE(s.column_name == "id" || s.column_name == "score");
         ASSERT_EQ(s.null_count, 0u);
         ASSERT_TRUE(s.has_min_max());
     }
 
     auto id_stat = std::find_if(stats.begin(), stats.end(),
-        [](const mosaic::ColumnStatistics& s) { return s.column_index == 0; });
+        [](const mosaic::ColumnStatistics& s) { return s.column_name == "id"; });
     ASSERT_TRUE(id_stat != stats.end());
     ASSERT_EQ(id_stat->min_value.size(), 4u);
     ASSERT_EQ(id_stat->max_value.size(), 4u);
@@ -553,7 +579,7 @@ static void test_writer_stats_with_nulls() {
 
     mosaic::WriterOptions opts;
     opts.num_buckets = 1;
-    uint32_t stats_cols[] = {0, 1};
+    const char* stats_cols[] = {"a", "b"};
     opts.stats_columns = stats_cols;
     opts.num_stats_columns = 2;
 
@@ -575,7 +601,7 @@ static void test_writer_stats_with_nulls() {
     ASSERT_EQ(stats.size(), 2u);
 
     auto a_stat = std::find_if(stats.begin(), stats.end(),
-        [](const mosaic::ColumnStatistics& s) { return s.column_index == 0; });
+        [](const mosaic::ColumnStatistics& s) { return s.column_name == "a"; });
     ASSERT_TRUE(a_stat != stats.end());
     ASSERT_EQ(a_stat->null_count, 1u);
     ASSERT_TRUE(a_stat->has_min_max());
@@ -588,7 +614,7 @@ static void test_writer_stats_with_nulls() {
     ASSERT_EQ(max_a, 20);
 
     auto b_stat = std::find_if(stats.begin(), stats.end(),
-        [](const mosaic::ColumnStatistics& s) { return s.column_index == 1; });
+        [](const mosaic::ColumnStatistics& s) { return s.column_name == "b"; });
     ASSERT_TRUE(b_stat != stats.end());
     ASSERT_EQ(b_stat->null_count, 2u);
     ASSERT_TRUE(b_stat->has_min_max());
@@ -618,7 +644,7 @@ static void test_writer_stats_all_null() {
 
     mosaic::WriterOptions opts;
     opts.num_buckets = 1;
-    uint32_t stats_cols[] = {0};
+    const char* stats_cols[] = {"x"};
     opts.stats_columns = stats_cols;
     opts.num_stats_columns = 1;
 
@@ -638,6 +664,7 @@ static void test_writer_stats_all_null() {
     ASSERT_EQ(writer.num_row_groups(), 1u);
     auto stats = writer.get_row_group_statistics(0);
     ASSERT_EQ(stats.size(), 1u);
+    ASSERT_EQ(stats[0].column_name, "x");
     ASSERT_EQ(stats[0].null_count, 3u);
     ASSERT_TRUE(!stats[0].has_min_max());
     printf("  PASS test_writer_stats_all_null\n");
@@ -661,7 +688,7 @@ static void test_writer_stats_matches_reader() {
 
     mosaic::WriterOptions opts;
     opts.num_buckets = 1;
-    uint32_t stats_cols[] = {0, 1};
+    const char* stats_cols[] = {"id", "value"};
     opts.stats_columns = stats_cols;
     opts.num_stats_columns = 2;
 
@@ -687,7 +714,7 @@ static void test_writer_stats_matches_reader() {
 
     ASSERT_EQ(writer_stats.size(), reader_stats.size());
     for (size_t i = 0; i < writer_stats.size(); i++) {
-        ASSERT_EQ(writer_stats[i].column_index, reader_stats[i].column_index);
+        ASSERT_EQ(writer_stats[i].column_name, reader_stats[i].column_name);
         ASSERT_EQ(writer_stats[i].null_count, reader_stats[i].null_count);
         ASSERT_EQ(writer_stats[i].min_value, reader_stats[i].min_value);
         ASSERT_EQ(writer_stats[i].max_value, reader_stats[i].max_value);
@@ -701,6 +728,7 @@ int main() {
     test_null_values();
     test_all_types();
     test_projection();
+    test_projection_empty();
     test_statistics();
     test_compression_zstd();
     test_schema_roundtrip();
@@ -709,6 +737,6 @@ int main() {
     test_writer_stats_with_nulls();
     test_writer_stats_all_null();
     test_writer_stats_matches_reader();
-    printf("All %d tests passed.\n", 12);
+    printf("All %d tests passed.\n", 13);
     return 0;
 }

--- a/docs/cpp-api.html
+++ b/docs/cpp-api.html
@@ -160,7 +160,7 @@ g++ -std=c++17 -I include/ example.cpp \
                     <tr><td><code>row_group_max_size</code></td><td>uint64_t</td><td>256 MB</td><td>Max row group size</td></tr>
                     <tr><td><code>max_dict_total_bytes</code></td><td>uint32_t</td><td>32 KB</td><td>Max dict size per column</td></tr>
                     <tr><td><code>max_dict_entries</code></td><td>uint32_t</td><td>255</td><td>Max dict entries per column</td></tr>
-                    <tr><td><code>stats_columns</code></td><td>const uint32_t*</td><td>NULL</td><td>Column indices to build min/max stats for</td></tr>
+                    <tr><td><code>stats_columns</code></td><td>const char* const*</td><td>NULL</td><td>Column names to build min/max stats for</td></tr>
                     <tr><td><code>num_stats_columns</code></td><td>uint32_t</td><td>0</td><td>Length of stats_columns array</td></tr>
                     <tr><td><code>page_size_threshold</code></td><td>uint32_t</td><td>32 KB</td><td>Min avg column page size to enable paged mode</td></tr>
                 </tbody>
@@ -176,7 +176,7 @@ g++ -std=c++17 -I include/ example.cpp \
                     <tr><td><code>estimated_file_size()</code></td><td><code>int64_t</code></td><td>Estimated output file size in bytes (for file rolling)</td></tr>
                     <tr><td><code>close()</code></td><td><code>void</code></td><td>Flush remaining data and write footer</td></tr>
                     <tr><td><code>num_row_groups()</code></td><td><code>uint32_t</code></td><td>Number of row groups written (available after close)</td></tr>
-                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>vector&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group (available after close)</td></tr>
+                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>vector&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group (available after close); each entry has a <code>column_name</code> field</td></tr>
                 </tbody>
             </table>
 
@@ -214,10 +214,10 @@ reader.export_schema(&amp;ffi_schema);
                 <tbody>
                     <tr><td><code>num_row_groups()</code></td><td><code>uint32_t</code></td><td>Row group count</td></tr>
                     <tr><td><code>row_group_num_rows(rg)</code></td><td><code>uint32_t</code></td><td>Number of rows in a specific row group</td></tr>
-                    <tr><td><code>export_schema(&amp;ffi_schema)</code></td><td><code>void</code></td><td>Export schema via Arrow C Data Interface</td></tr>
-                    <tr><td><code>read_row_group(rg, &amp;array, &amp;schema)</code></td><td><code>void</code></td><td>Read all columns of a row group</td></tr>
-                    <tr><td><code>read_row_group(rg, cols, n, &amp;array, &amp;schema)</code></td><td><code>void</code></td><td>Read projected columns of a row group</td></tr>
-                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>vector&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group</td></tr>
+                    <tr><td><code>export_schema(&amp;ffi_schema)</code></td><td><code>void</code></td><td>Export schema via Arrow C Data Interface (columns in name-sorted order)</td></tr>
+                    <tr><td><code>set_projection(cols, num_cols)</code></td><td><code>void</code></td><td>Set projection: subsequent reads return only the named columns in the specified order</td></tr>
+                    <tr><td><code>read_row_group(rg, &amp;array, &amp;schema)</code></td><td><code>void</code></td><td>Read a row group (all columns or projected columns if set_projection() was called)</td></tr>
+                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>vector&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group; each entry has a <code>column_name</code> field</td></tr>
                 </tbody>
             </table>
 
@@ -252,16 +252,23 @@ reader.export_schema(&amp;ffi_schema);
 
             <h3>Projection Pushdown</h3>
             <p>
-                Use <code>read_row_group</code> with column indices to read only specific columns.
+                Use <code>set_projection()</code> to select and reorder columns by name.
                 Only the buckets containing the projected columns are decompressed, reducing
-                I/O and memory for wide tables. The returned batch contains only the projected columns.
+                I/O and memory for wide tables. The output preserves the order you specify:
             </p>
-<pre><code><span class="kw">uint32_t</span> projected[] = { <span class="num">0</span>, <span class="num">2</span> };
+<pre><code><span class="cmt">// Only read "name" and "score" columns, in that order</span>
+<span class="kw">const char</span>* cols[] = { <span class="str">"name"</span>, <span class="str">"score"</span> };
+reader.set_projection(cols, <span class="num">2</span>);
+
 ArrowArray ffi_array;
 ArrowSchema ffi_schema;
-reader.read_row_group(<span class="num">0</span>, projected, <span class="num">2</span>, &amp;ffi_array, &amp;ffi_schema);
+reader.read_row_group(<span class="num">0</span>, &amp;ffi_array, &amp;ffi_schema);
 <span class="kw">auto</span> batch = arrow::ImportRecordBatch(&amp;ffi_array, &amp;ffi_schema).ValueOrDie();
-<span class="cmt">// batch contains only the projected columns</span></code></pre>
+<span class="cmt">// batch contains only "name" and "score", in that order</span>
+
+<span class="cmt">// Empty projection: count-only read (0 columns, row count preserved)</span>
+reader.set_projection(<span class="kw">nullptr</span>, <span class="num">0</span>);
+<span class="kw">uint32_t</span> num_rows = reader.row_group_num_rows(<span class="num">0</span>);</code></pre>
 
             <h3>Column Statistics (Filter Pushdown)</h3>
             <p>
@@ -269,7 +276,7 @@ reader.read_row_group(<span class="num">0</span>, projected, <span class="num">2
                 from the writer (after close) and from the reader:
             </p>
 <pre><code><span class="cmt">// Writing with stats (arrow_schema is an ArrowSchema* from C Data Interface)</span>
-<span class="kw">uint32_t</span> stats_cols[] = { <span class="num">0</span>, <span class="num">2</span> };
+<span class="kw">const char</span>* stats_cols[] = { <span class="str">"id"</span>, <span class="str">"score"</span> };
 <span class="ty">mosaic</span>::<span class="ty">WriterOptions</span> opts;
 opts.compression = <span class="num">1</span>;
 opts.stats_columns = stats_cols;
@@ -280,7 +287,7 @@ writer.close();
 <span class="kw">for</span> (<span class="kw">uint32_t</span> rg = <span class="num">0</span>; rg &lt; writer.num_row_groups(); rg++) {
     <span class="kw">auto</span> stats = writer.get_row_group_statistics(rg);
     <span class="kw">for</span> (<span class="kw">const auto</span>&amp; stat : stats) {
-        <span class="kw">uint32_t</span> col_idx = stat.column_index;
+        <span class="cmt">// stat.column_name identifies which column</span>
         <span class="kw">uint64_t</span> null_count = stat.null_count;
         <span class="kw">if</span> (stat.has_min_max()) {
             <span class="cmt">// stat.min_value / stat.max_value are std::vector&lt;uint8_t&gt;</span>
@@ -291,7 +298,7 @@ writer.close();
 <span class="kw">for</span> (<span class="kw">uint32_t</span> rg = <span class="num">0</span>; rg &lt; reader.num_row_groups(); rg++) {
     <span class="kw">auto</span> stats = reader.get_row_group_statistics(rg);
     <span class="kw">for</span> (<span class="kw">const auto</span>&amp; stat : stats) {
-        <span class="kw">uint32_t</span> col_idx = stat.column_index;
+        <span class="cmt">// stat.column_name identifies which column</span>
         <span class="kw">uint64_t</span> null_count = stat.null_count;
         <span class="kw">if</span> (stat.has_min_max()) {
             <span class="cmt">// stat.min_value / stat.max_value are std::vector&lt;uint8_t&gt;</span>
@@ -305,7 +312,7 @@ writer.close();
                     <tr><th>Field</th><th>Type</th><th>Description</th></tr>
                 </thead>
                 <tbody>
-                    <tr><td><code>column_index</code></td><td><code>uint32_t</code></td><td>Column index in the schema</td></tr>
+                    <tr><td><code>column_name</code></td><td><code>std::string</code></td><td>Column name</td></tr>
                     <tr><td><code>null_count</code></td><td><code>uint64_t</code></td><td>Number of null values</td></tr>
                     <tr><td><code>has_min_max()</code></td><td><code>bool</code></td><td>Whether min/max are available</td></tr>
                     <tr><td><code>min_value</code></td><td><code>vector&lt;uint8_t&gt;</code></td><td>Min value as big-endian bytes (empty if all-null)</td></tr>
@@ -399,8 +406,9 @@ writer.close();
 
             <div class="warning">
                 <strong>Column ordering</strong>
-                The reader preserves the original schema column order.
-                Use <code>export_schema()</code> to inspect the schema via Arrow C Data Interface.
+                Columns are stored in name-sorted order regardless of the input schema order.
+                The reader returns columns in storage (name-sorted) order by default.
+                Use <code>set_projection()</code> to select and reorder output columns.
             </div>
 
             <div class="tip">

--- a/docs/design.html
+++ b/docs/design.html
@@ -692,7 +692,6 @@ repeated numRules times:
 varint   sharedPrefixLen       (bytes shared with previous column name)
 varint   suffixLen             (bytes of new suffix)
 bytes    suffix                (suffixLen bytes, raw or BPE-encoded)
-varint   globalColumnIndex     (original column index before name-sorting)
 TypeDescriptor</code></pre>
             <p>
                 The first column has <code>sharedPrefixLen = 0</code>. To reconstruct a column name,
@@ -701,8 +700,7 @@ TypeDescriptor</code></pre>
                 expanding tokens &ge; 0x80 using the merge rules.
             </p>
             <p>
-                The <code>globalColumnIndex</code> records the original column position before name-sorting.
-                This allows the reader to restore the original schema column order when returning data to the caller.
+                Columns are stored and returned in name-sorted order.
             </p>
 
             <h3>TypeDescriptor</h3>

--- a/docs/java-api.html
+++ b/docs/java-api.html
@@ -166,7 +166,7 @@
                     <tr><td><code>rowGroupMaxSize(long)</code></td><td>256 MB</td><td>Max uncompressed bytes per row group</td></tr>
                     <tr><td><code>maxDictTotalBytes(int)</code></td><td>32 KB</td><td>Max dictionary size per column</td></tr>
                     <tr><td><code>maxDictEntries(int)</code></td><td>255</td><td>Max distinct values for DICT encoding</td></tr>
-                    <tr><td><code>statsColumns(int...)</code></td><td>(empty)</td><td>Column indices to build min/max stats for filter pushdown</td></tr>
+                    <tr><td><code>statsColumns(String...)</code></td><td>(empty)</td><td>Column names to build min/max stats for filter pushdown</td></tr>
                     <tr><td><code>pageSizeThreshold(int)</code></td><td>32 KB</td><td>Min avg column page size to enable paged mode (per-column compression)</td></tr>
                 </tbody>
             </table>
@@ -181,7 +181,7 @@
                     <tr><td><code>estimatedFileSize()</code></td><td><code>long</code></td><td>Estimated output file size in bytes (for file rolling)</td></tr>
                     <tr><td><code>close()</code></td><td><code>void</code></td><td>Flush remaining data and write footer</td></tr>
                     <tr><td><code>numRowGroups()</code></td><td><code>int</code></td><td>Number of row groups written (available after close)</td></tr>
-                    <tr><td><code>getRowGroupStatistics(rg)</code></td><td><code>List&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group (available after close)</td></tr>
+                    <tr><td><code>getRowGroupStatistics(rg)</code></td><td><code>Map&lt;String, ColumnStatistics&gt;</code></td><td>Column statistics for a row group, keyed by column name (available after close)</td></tr>
                 </tbody>
             </table>
 
@@ -203,16 +203,14 @@
 
             <h3>2. Inspect the Schema</h3>
             <p>
-                The reader exposes the file schema as a standard Arrow <code>Schema</code> object:
+                The reader exposes the file schema as a standard Arrow <code>Schema</code> object.
+                Columns are in name-sorted order (the storage order):
             </p>
 <pre><code><span class="ty">Schema</span> schema = reader.getSchema();
 <span class="kw">for</span> (<span class="ty">Field</span> field : schema.getFields()) {
     System.out.printf(<span class="str">"name=%s type=%s nullable=%b%n"</span>,
         field.getName(), field.getType(), field.isNullable());
-}
-
-<span class="kw">int</span> nameCol = schema.getFields().indexOf(schema.findField(<span class="str">"name"</span>));
-<span class="kw">int</span> scoreCol = schema.getFields().indexOf(schema.findField(<span class="str">"score"</span>));</code></pre>
+}</code></pre>
 
             <h3>Reader Methods</h3>
             <table>
@@ -220,12 +218,12 @@
                     <tr><th>Method</th><th>Return</th><th>Description</th></tr>
                 </thead>
                 <tbody>
-                    <tr><td><code>getSchema()</code></td><td><code>Schema</code></td><td>Arrow Schema for the file</td></tr>
+                    <tr><td><code>getSchema()</code></td><td><code>Schema</code></td><td>Arrow Schema for the file (columns in name-sorted order)</td></tr>
                     <tr><td><code>numRowGroups()</code></td><td><code>int</code></td><td>Row group count</td></tr>
                     <tr><td><code>rowGroupNumRows(rg)</code></td><td><code>int</code></td><td>Number of rows in a specific row group</td></tr>
-                    <tr><td><code>readRowGroup(rg, allocator)</code></td><td><code>VectorSchemaRoot</code></td><td>Read all columns of a row group</td></tr>
-                    <tr><td><code>readRowGroup(rg, cols, allocator)</code></td><td><code>VectorSchemaRoot</code></td><td>Read projected columns of a row group</td></tr>
-                    <tr><td><code>getRowGroupStatistics(rg)</code></td><td><code>List&lt;ColumnStatistics&gt;</code></td><td>Column statistics for a row group</td></tr>
+                    <tr><td><code>project(String[])</code></td><td><code>void</code></td><td>Set projection: subsequent reads return only the named columns in the specified order</td></tr>
+                    <tr><td><code>readRowGroup(rg, allocator)</code></td><td><code>VectorSchemaRoot</code></td><td>Read a row group (all columns or projected columns if project() was called)</td></tr>
+                    <tr><td><code>getRowGroupStatistics(rg)</code></td><td><code>Map&lt;String, ColumnStatistics&gt;</code></td><td>Column statistics for a row group, keyed by column name</td></tr>
                 </tbody>
             </table>
 
@@ -253,15 +251,19 @@
 
             <h3>Projection Pushdown</h3>
             <p>
-                Use <code>readRowGroup(rgIndex, projectedColumns, allocator)</code> to read only specific columns.
+                Use <code>project()</code> to select and reorder columns by name.
                 Only the buckets containing the projected columns are decompressed, significantly
-                reducing I/O and memory for wide tables.
+                reducing I/O and memory for wide tables. The output preserves the order you specify:
             </p>
-<pre><code><span class="cmt">// Only read "name" and "score" columns</span>
-<span class="kw">int</span>[] projected = { nameCol, scoreCol };
-<span class="kw">try</span> (<span class="ty">VectorSchemaRoot</span> batch = reader.readRowGroup(rg, projected, allocator)) {
-    <span class="cmt">// batch contains only the projected columns</span>
-}</code></pre>
+<pre><code><span class="cmt">// Only read "name" and "score" columns, in that order</span>
+reader.project(<span class="kw">new</span> <span class="ty">String</span>[]{<span class="str">"name"</span>, <span class="str">"score"</span>});
+<span class="kw">try</span> (<span class="ty">VectorSchemaRoot</span> batch = reader.readRowGroup(rg, allocator)) {
+    <span class="cmt">// batch contains only "name" and "score", in that order</span>
+}
+
+<span class="cmt">// Empty projection: count-only read (0 columns, row count preserved)</span>
+reader.project(<span class="kw">new</span> <span class="ty">String</span>[]{});
+<span class="kw">int</span> rowCount = reader.rowGroupNumRows(rg);</code></pre>
 
             <h3>Column Statistics (Filter Pushdown)</h3>
             <p>
@@ -269,26 +271,28 @@
                 from the writer (after close) and from the reader. This allows you to obtain
                 min/max statistics immediately after writing without re-reading the file:
             </p>
+<pre><code><span class="ty">WriterOptions</span> opts = <span class="kw">new</span> <span class="ty">WriterOptions</span>()
+    .statsColumns(<span class="str">"id"</span>, <span class="str">"score"</span>);  <span class="cmt">// build stats for "id" and "score" columns</span></code></pre>
 <pre><code><span class="cmt">// Get stats directly from the writer after close</span>
 <span class="ty">MosaicWriter</span> writer = <span class="kw">new</span> <span class="ty">MosaicWriter</span>(baos, arrowSchema, opts, allocator);
 writer.write(root);
 writer.close();
 
 <span class="kw">for</span> (<span class="kw">int</span> rg = <span class="num">0</span>; rg &lt; writer.numRowGroups(); rg++) {
-    <span class="ty">List</span>&lt;<span class="ty">ColumnStatistics</span>&gt; stats = writer.getRowGroupStatistics(rg);
+    <span class="ty">Map</span>&lt;<span class="ty">String</span>, <span class="ty">ColumnStatistics</span>&gt; stats = writer.getRowGroupStatistics(rg);
+    <span class="ty">ColumnStatistics</span> idStats = stats.get(<span class="str">"id"</span>);
     <span class="cmt">// use stats for indexing, metadata, etc.</span>
 }</code></pre>
             <p>
                 The reader can also access per-row-group statistics to skip row groups
                 that don't match a filter predicate:
             </p>
-<pre><code><span class="ty">WriterOptions</span> opts = <span class="kw">new</span> <span class="ty">WriterOptions</span>()
-    .statsColumns(<span class="num">0</span>, <span class="num">2</span>);  <span class="cmt">// build stats for columns 0 and 2</span></code></pre>
-<pre><code><span class="cmt">// Reading stats</span>
+<pre><code><span class="cmt">// Reading stats from the reader</span>
 <span class="kw">for</span> (<span class="kw">int</span> rg = <span class="num">0</span>; rg &lt; reader.numRowGroups(); rg++) {
-    <span class="ty">List</span>&lt;<span class="ty">ColumnStatistics</span>&gt; stats = reader.getRowGroupStatistics(rg);
-    <span class="kw">for</span> (<span class="ty">ColumnStatistics</span> stat : stats) {
-        <span class="kw">int</span> colIdx = stat.getColumnIndex();
+    <span class="ty">Map</span>&lt;<span class="ty">String</span>, <span class="ty">ColumnStatistics</span>&gt; stats = reader.getRowGroupStatistics(rg);
+    <span class="kw">for</span> (<span class="ty">Map.Entry</span>&lt;<span class="ty">String</span>, <span class="ty">ColumnStatistics</span>&gt; entry : stats.entrySet()) {
+        <span class="ty">String</span> colName = entry.getKey();
+        <span class="ty">ColumnStatistics</span> stat = entry.getValue();
         <span class="kw">long</span> nullCount = stat.getNullCount();
         <span class="kw">if</span> (stat.hasMinMax()) {
             <span class="kw">byte</span>[] min = stat.getMin();  <span class="cmt">// big-endian wire format</span>
@@ -303,7 +307,6 @@ writer.close();
                     <tr><th>Method</th><th>Return</th><th>Description</th></tr>
                 </thead>
                 <tbody>
-                    <tr><td><code>getColumnIndex()</code></td><td><code>int</code></td><td>Column index in the schema</td></tr>
                     <tr><td><code>getNullCount()</code></td><td><code>long</code></td><td>Number of null values</td></tr>
                     <tr><td><code>hasMinMax()</code></td><td><code>boolean</code></td><td>Whether min/max are available</td></tr>
                     <tr><td><code>getMin()</code></td><td><code>byte[]</code></td><td>Min value as big-endian bytes (null if all-null)</td></tr>
@@ -385,8 +388,9 @@ writer.close();
 
             <div class="warning">
                 <strong>Column ordering</strong>
-                The reader preserves the original schema column order.
-                Use <code>reader.getSchema()</code> to inspect the schema and locate columns by name.
+                Columns are stored in name-sorted order regardless of the input schema order.
+                The reader returns columns in storage (name-sorted) order by default.
+                Use <code>project()</code> to select and reorder output columns.
             </div>
 
             <div class="tip">

--- a/docs/python-api.html
+++ b/docs/python-api.html
@@ -137,7 +137,7 @@ data = buf.getvalue()</code></pre>
                     <tr><td><code>row_group_max_size</code></td><td>256 MB</td><td>Max uncompressed bytes per row group</td></tr>
                     <tr><td><code>max_dict_total_bytes</code></td><td>32 KB</td><td>Max dictionary size per column</td></tr>
                     <tr><td><code>max_dict_entries</code></td><td>255</td><td>Max distinct values for DICT encoding</td></tr>
-                    <tr><td><code>stats_columns</code></td><td>[]</td><td>Column indices to build min/max stats for filter pushdown</td></tr>
+                    <tr><td><code>stats_columns</code></td><td>[]</td><td>Column names to build min/max stats for filter pushdown</td></tr>
                     <tr><td><code>page_size_threshold</code></td><td>32 KB</td><td>Min avg column page size to enable paged mode (per-column compression)</td></tr>
                 </tbody>
             </table>
@@ -152,7 +152,7 @@ data = buf.getvalue()</code></pre>
                     <tr><td><code>estimated_file_size()</code></td><td><code>int</code></td><td>Estimated output file size in bytes (for file rolling)</td></tr>
                     <tr><td><code>close()</code></td><td><code>None</code></td><td>Flush remaining data and write footer</td></tr>
                     <tr><td><code>num_row_groups</code></td><td><code>int</code></td><td>Number of row groups written (available after close)</td></tr>
-                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>list[ColumnStatistics]</code></td><td>Column statistics for a row group (available after close)</td></tr>
+                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>dict[str, ColumnStatistics]</code></td><td>Column statistics for a row group, keyed by column name (available after close)</td></tr>
                 </tbody>
             </table>
 
@@ -172,14 +172,12 @@ reader = MosaicReader.from_input_file(read_at, len(data))</code></pre>
 
             <h3>2. Inspect the Schema</h3>
             <p>
-                The reader exposes the file schema as a standard PyArrow <code>Schema</code> object:
+                The reader exposes the file schema as a standard PyArrow <code>Schema</code> object.
+                Columns are in name-sorted order (the storage order):
             </p>
 <pre><code>print(reader.schema)
 <span class="kw">for</span> field <span class="kw">in</span> reader.schema:
-    print(<span class="str">f"name={field.name} type={field.type} nullable={field.nullable}"</span>)
-
-name_col = reader.schema.get_field_index(<span class="str">"name"</span>)
-score_col = reader.schema.get_field_index(<span class="str">"score"</span>)</code></pre>
+    print(<span class="str">f"name={field.name} type={field.type} nullable={field.nullable}"</span>)</code></pre>
 
             <h3>Reader Methods</h3>
             <table>
@@ -187,12 +185,13 @@ score_col = reader.schema.get_field_index(<span class="str">"score"</span>)</cod
                     <tr><th>Method / Property</th><th>Return</th><th>Description</th></tr>
                 </thead>
                 <tbody>
-                    <tr><td><code>schema</code></td><td><code>pa.Schema</code></td><td>Arrow Schema for the file</td></tr>
+                    <tr><td><code>schema</code></td><td><code>pa.Schema</code></td><td>Arrow Schema for the file (columns in name-sorted order)</td></tr>
                     <tr><td><code>num_row_groups</code></td><td><code>int</code></td><td>Row group count</td></tr>
                     <tr><td><code>row_group_num_rows(rg)</code></td><td><code>int</code></td><td>Number of rows in a specific row group</td></tr>
-                    <tr><td><code>read_row_group(rg, columns=None)</code></td><td><code>pa.RecordBatch</code></td><td>Read a row group (optionally with projection)</td></tr>
-                    <tr><td><code>read_all(columns=None)</code></td><td><code>pa.Table</code></td><td>Read entire file as a Table</td></tr>
-                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>list[ColumnStatistics]</code></td><td>Column statistics for a row group</td></tr>
+                    <tr><td><code>project(columns)</code></td><td><code>None</code></td><td>Set projection: subsequent reads return only the named columns in the specified order</td></tr>
+                    <tr><td><code>read_row_group(rg)</code></td><td><code>pa.RecordBatch</code></td><td>Read a row group (all columns or projected columns if project() was called)</td></tr>
+                    <tr><td><code>read_all()</code></td><td><code>pa.Table</code></td><td>Read entire file as a Table</td></tr>
+                    <tr><td><code>get_row_group_statistics(rg)</code></td><td><code>dict[str, ColumnStatistics]</code></td><td>Column statistics for a row group, keyed by column name</td></tr>
                 </tbody>
             </table>
 
@@ -208,33 +207,37 @@ score_col = reader.schema.get_field_index(<span class="str">"score"</span>)</cod
 
             <h3>Projection Pushdown</h3>
             <p>
-                Use <code>read_row_group(rg_index, columns=[...])</code> to read only specific columns.
+                Use <code>project()</code> to select and reorder columns by name.
                 Only the buckets containing the projected columns are decompressed, significantly
-                reducing I/O and memory for wide tables.
+                reducing I/O and memory for wide tables. The output preserves the order you specify:
             </p>
-<pre><code><span class="cmt"># Only read "name" and "score" columns</span>
-projected = [name_col, score_col]
-batch = reader.read_row_group(rg, columns=projected)
-<span class="cmt"># batch contains only the projected columns</span></code></pre>
+<pre><code><span class="cmt"># Only read "name" and "score" columns, in that order</span>
+reader.project([<span class="str">"name"</span>, <span class="str">"score"</span>])
+batch = reader.read_row_group(rg)
+<span class="cmt"># batch contains only "name" and "score", in that order</span>
+
+<span class="cmt"># Empty projection: count-only read (0 columns, row count preserved)</span>
+reader.project([])
+num_rows = reader.row_group_num_rows(rg)</code></pre>
 
             <h3>Column Statistics (Filter Pushdown)</h3>
             <p>
                 When stats columns are configured during writing, statistics are available both
                 from the writer (after close) and from the reader:
             </p>
-<pre><code>opts = WriterOptions(stats_columns=[<span class="num">0</span>, <span class="num">2</span>])  <span class="cmt"># build stats for columns 0 and 2</span></code></pre>
+<pre><code>opts = WriterOptions(stats_columns=[<span class="str">"id"</span>, <span class="str">"score"</span>])  <span class="cmt"># build stats for "id" and "score"</span></code></pre>
 <pre><code><span class="cmt"># Get stats directly from the writer after close</span>
 <span class="kw">with</span> MosaicWriter(buf, pa_schema, opts) <span class="kw">as</span> writer:
     writer.write(batch)
 
 <span class="kw">for</span> rg <span class="kw">in</span> range(writer.num_row_groups):
-    <span class="kw">for</span> stat <span class="kw">in</span> writer.get_row_group_statistics(rg):
-        col_idx = stat.column_index
-        null_count = stat.null_count</code></pre>
+    stats = writer.get_row_group_statistics(rg)  <span class="cmt"># dict[str, ColumnStatistics]</span>
+    id_stats = stats[<span class="str">"id"</span>]
+    null_count = id_stats.null_count</code></pre>
 <pre><code><span class="cmt"># Or read stats from the reader</span>
 <span class="kw">for</span> rg <span class="kw">in</span> range(reader.num_row_groups):
-    <span class="kw">for</span> stat <span class="kw">in</span> reader.get_row_group_statistics(rg):
-        col_idx = stat.column_index
+    stats = reader.get_row_group_statistics(rg)
+    <span class="kw">for</span> col_name, stat <span class="kw">in</span> stats.items():
         null_count = stat.null_count
         <span class="kw">if</span> stat.has_min_max:
             min_val = stat.min   <span class="cmt"># bytes, big-endian wire format</span>
@@ -246,7 +249,6 @@ batch = reader.read_row_group(rg, columns=projected)
                     <tr><th>Attribute</th><th>Type</th><th>Description</th></tr>
                 </thead>
                 <tbody>
-                    <tr><td><code>column_index</code></td><td><code>int</code></td><td>Column index in the schema</td></tr>
                     <tr><td><code>null_count</code></td><td><code>int</code></td><td>Number of null values</td></tr>
                     <tr><td><code>has_min_max</code></td><td><code>bool</code></td><td>Whether min/max are available</td></tr>
                     <tr><td><code>min</code></td><td><code>bytes</code></td><td>Min value as big-endian bytes (None if all-null)</td></tr>
@@ -291,7 +293,7 @@ table = mosaic.read_table(
                 </thead>
                 <tbody>
                     <tr><td><code>write_table(table, stream, options=None)</code></td><td>Write a <code>pa.Table</code> via an OutputFile (file-like object)</td></tr>
-                    <tr><td><code>read_table(read_at_fn, file_length, columns=None)</code></td><td>Read a <code>pa.Table</code> via an InputFile (<code>read_at</code> callback + length)</td></tr>
+                    <tr><td><code>read_table(read_at_fn, file_length, columns=None)</code></td><td>Read a <code>pa.Table</code> via an InputFile; <code>columns</code> is a list of column names to project</td></tr>
                 </tbody>
             </table>
 
@@ -336,8 +338,9 @@ reader = MosaicReader.from_input_file(
 
             <div class="warning">
                 <strong>Column ordering</strong>
-                The reader preserves the original schema column order.
-                Use <code>reader.schema</code> to inspect the schema and locate columns by name.
+                Columns are stored in name-sorted order regardless of the input schema order.
+                The reader returns columns in storage (name-sorted) order by default.
+                Use <code>project()</code> to select and reorder output columns.
             </div>
 
             <div class="tip">

--- a/docs/rust-api.html
+++ b/docs/rust-api.html
@@ -120,7 +120,7 @@ writer.close().unwrap();
                     <tr><td><code>estimated_file_size()</code></td><td><code>u64</code></td><td>Estimated output file size in bytes (for file rolling)</td></tr>
                     <tr><td><code>close()</code></td><td><code>io::Result&lt;()&gt;</code></td><td>Flush remaining data and write footer</td></tr>
                     <tr><td><code>num_row_groups()</code></td><td><code>usize</code></td><td>Number of row groups written (available after close)</td></tr>
-                    <tr><td><code>row_group_stats(rg_index)</code></td><td><code>&amp;[ColumnStats]</code></td><td>Column statistics for a row group (available after close)</td></tr>
+                    <tr><td><code>row_group_stats(rg_index)</code></td><td><code>&amp;[ColumnStats]</code></td><td>Column statistics for a row group (available after close); each entry has a <code>column_index</code> into the sorted schema</td></tr>
                 </tbody>
             </table>
 
@@ -139,13 +139,13 @@ writer.close().unwrap();
 <h3>1. Open and Inspect the Schema</h3>
             <p>
                 Pass your <code>InputFile</code> implementation and the file length directly
-                to <code>MosaicReader::new</code>:
+                to <code>MosaicReader::new</code>. Columns are in name-sorted order (the storage order):
             </p>
 <pre><code><span class="kw">use</span> mosaic_core::reader::{MosaicReader, InputFile, ReaderAccess};
 
 <span class="kw">let</span> reader = MosaicReader::new(my_input_file, file_len).unwrap();
 
-<span class="cmt">// Iterate over all columns</span>
+<span class="cmt">// Iterate over all columns (name-sorted order)</span>
 <span class="kw">for</span> col <span class="kw">in</span> &amp;reader.schema().columns {
     println!(<span class="str">"name={} type={:?} nullable={}"</span>,
         col.name, col.data_type, col.nullable);
@@ -193,25 +193,28 @@ writer.close().unwrap();
 
             <h3>Projection Pushdown</h3>
             <p>
-                Use <code>row_group_reader_projected</code> to read only specific columns.
+                Use <code>project()</code> to select and reorder columns by name.
                 Only the buckets containing the projected columns are decompressed &mdash;
                 reading 1 column out of 10,000 only touches 1 bucket instead of all 100.
-                The returned batch contains only the projected columns.
+                The output preserves the order you specify:
             </p>
-<pre><code><span class="kw">let</span> name_col = reader.schema().columns.iter()
-    .position(|c| c.name == <span class="str">"name"</span>).unwrap();
-<span class="kw">let</span> score_col = reader.schema().columns.iter()
-    .position(|c| c.name == <span class="str">"score"</span>).unwrap();
+<pre><code><span class="cmt">// Project "name" and "score" columns, in that order</span>
+<span class="kw">let</span> <span class="kw">mut</span> reader = MosaicReader::new(my_input_file, file_len).unwrap();
+reader.project(&amp;[<span class="str">"name"</span>, <span class="str">"score"</span>]).unwrap();
 
-<span class="kw">let</span> <span class="kw">mut</span> rg = reader.row_group_reader_projected(rg_idx, &amp;[name_col, score_col]).unwrap();
+<span class="kw">let</span> <span class="kw">mut</span> rg = reader.row_group_reader(<span class="num">0</span>).unwrap();
 <span class="kw">let</span> batch = rg.read_columns().unwrap();
-<span class="cmt">// batch contains only 2 columns: "name" and "score"</span>
-<span class="cmt">// Use batch.schema().field(i).name() to identify columns</span></code></pre>
+<span class="cmt">// batch contains only 2 columns: "name" and "score", in that order</span>
+
+<span class="cmt">// Empty projection: count-only read (0 columns, row count preserved)</span>
+reader.project(&amp;[]).unwrap();
+<span class="kw">let</span> num_rows = reader.row_group_num_rows(<span class="num">0</span>)?;</code></pre>
 
             <div class="note">
                 <strong>Column ordering</strong>
-                The reader preserves the original schema column order.
-                Use <code>reader.schema().columns[i].name</code> or positional lookup to access columns.
+                Columns are stored in name-sorted order regardless of the input schema order.
+                The reader returns columns in storage (name-sorted) order by default.
+                Use <code>project()</code> to select and reorder output columns.
             </div>
 
 
@@ -223,7 +226,7 @@ writer.close().unwrap();
 
             <h3>Writing with Stats</h3>
 <pre><code><span class="kw">let</span> <span class="kw">mut</span> writer = MosaicWriter::new(output, &amp;arrow_schema, WriterOptions {
-    stats_columns: <span class="kw">vec!</span>[<span class="num">0</span>, <span class="num">2</span>],  <span class="cmt">// build stats for columns 0 and 2</span>
+    stats_columns: <span class="kw">vec!</span>[<span class="str">"age"</span>.into(), <span class="str">"score"</span>.into()],  <span class="cmt">// build stats for "age" and "score"</span>
     ..Default::default()
 })?;</code></pre>
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -114,7 +114,7 @@ pub struct MosaicWriterOptions {
     pub row_group_max_size: u64,
     pub max_dict_total_bytes: u32,
     pub max_dict_entries: u32,
-    pub stats_columns: *const u32,
+    pub stats_columns: *const *const c_char,
     pub num_stats_columns: u32,
     pub page_size_threshold: u32,
 }
@@ -139,6 +139,8 @@ pub extern "C" fn mosaic_writer_options_default() -> MosaicWriterOptions {
 
 pub struct MosaicWriterHandle {
     inner: MosaicWriter<FfiOutputFile>,
+    stat_name_cache: Option<Vec<Vec<CString>>>,
+    stat_value_cache: Option<Vec<Vec<(Option<Vec<u8>>, Option<Vec<u8>>)>>>,
 }
 
 /// Open a writer. The `ffi_schema` is consumed: ownership transfers to the callee
@@ -170,10 +172,26 @@ pub unsafe extern "C" fn mosaic_writer_open(
         let stats_cols = if options.stats_columns.is_null() || options.num_stats_columns == 0 {
             Vec::new()
         } else {
-            std::slice::from_raw_parts(options.stats_columns, options.num_stats_columns as usize)
-                .iter()
-                .map(|&c| c as usize)
-                .collect()
+            let ptrs = std::slice::from_raw_parts(
+                options.stats_columns,
+                options.num_stats_columns as usize,
+            );
+            let mut names = Vec::with_capacity(ptrs.len());
+            for &p in ptrs {
+                if p.is_null() {
+                    set_error("stats_columns contains null pointer".into());
+                    return ptr::null_mut();
+                }
+                let cstr = std::ffi::CStr::from_ptr(p);
+                match cstr.to_str() {
+                    Ok(s) => names.push(s.to_owned()),
+                    Err(_) => {
+                        set_error("stats_columns contains invalid UTF-8".into());
+                        return ptr::null_mut();
+                    }
+                }
+            }
+            names
         };
         let num_buckets = if options.num_buckets == 0 {
             DEFAULT_NUM_BUCKETS
@@ -191,7 +209,11 @@ pub unsafe extern "C" fn mosaic_writer_open(
             page_size_threshold: options.page_size_threshold as usize,
         };
         match MosaicWriter::new(ffi_stream, &arrow_schema, opts) {
-            Ok(writer) => Box::into_raw(Box::new(MosaicWriterHandle { inner: writer })),
+            Ok(writer) => Box::into_raw(Box::new(MosaicWriterHandle {
+                inner: writer,
+                stat_name_cache: None,
+                stat_value_cache: None,
+            })),
             Err(e) => {
                 set_error(format!("writer open failed: {}", e));
                 ptr::null_mut()
@@ -292,136 +314,109 @@ pub unsafe extern "C" fn mosaic_writer_row_group_num_stats(
     0
 }
 
-/// Get the column index for a writer stats entry.
+/// Batch-fetch all stats for a writer row group.
+/// Caller must pre-allocate arrays with at least `num_stats` elements.
+/// `names` is filled with pointers to NUL-terminated strings (valid until writer is freed).
+/// `null_counts` is filled with null counts.
+/// `min_ptrs`/`min_lens` and `max_ptrs`/`max_lens` are filled with pointers to byte data
+/// (valid until writer is freed). A null pointer with len 0 means no min/max (all-null column).
+/// Returns 0 on success, -1 on error.
 #[no_mangle]
-pub unsafe extern "C" fn mosaic_writer_row_group_stat_column_index(
-    handle: *const MosaicWriterHandle,
+pub unsafe extern "C" fn mosaic_writer_row_group_stats(
+    handle: *mut MosaicWriterHandle,
     rg_index: u32,
-    stat_index: u32,
-    out: *mut u32,
+    names: *mut *const c_char,
+    null_counts: *mut u64,
+    min_ptrs: *mut *const u8,
+    min_lens: *mut usize,
+    max_ptrs: *mut *const u8,
+    max_lens: *mut usize,
 ) -> c_int {
-    if handle.is_null() || out.is_null() {
+    if handle.is_null() {
         set_error("null pointer".into());
         return -1;
     }
-    let h = &*handle;
+    let h = &mut *handle;
     let rg = rg_index as usize;
     if rg >= h.inner.num_row_groups() {
         set_error("rg_index out of range".into());
         return -1;
     }
     let stats = h.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        set_error("stat_index out of range".into());
-        return -1;
-    }
-    *out = stats[idx].column_index as u32;
-    0
-}
+    let schema = h.inner.schema();
 
-/// Get the null count for a writer stats entry.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_writer_row_group_stat_null_count(
-    handle: *const MosaicWriterHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out: *mut u64,
-) -> c_int {
-    if handle.is_null() || out.is_null() {
-        set_error("null pointer".into());
-        return -1;
-    }
-    let h = &*handle;
-    let rg = rg_index as usize;
-    if rg >= h.inner.num_row_groups() {
-        set_error("rg_index out of range".into());
-        return -1;
-    }
-    let stats = h.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        set_error("stat_index out of range".into());
-        return -1;
-    }
-    *out = stats[idx].null_count as u64;
-    0
-}
-
-thread_local! {
-    static WRITER_STAT_MIN_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-    static WRITER_STAT_MAX_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-}
-
-/// Get the min value for a writer stats entry as raw bytes.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_writer_row_group_stat_min(
-    handle: *const MosaicWriterHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-) -> *const u8 {
-    writer_stat_value_ptr(handle, rg_index, stat_index, out_len, true)
-}
-
-/// Get the max value for a writer stats entry as raw bytes.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_writer_row_group_stat_max(
-    handle: *const MosaicWriterHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-) -> *const u8 {
-    writer_stat_value_ptr(handle, rg_index, stat_index, out_len, false)
-}
-
-unsafe fn writer_stat_value_ptr(
-    handle: *const MosaicWriterHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-    is_min: bool,
-) -> *const u8 {
-    if handle.is_null() || out_len.is_null() {
-        return ptr::null();
-    }
-    let h = &*handle;
-    let rg = rg_index as usize;
-    if rg >= h.inner.num_row_groups() {
-        *out_len = 0;
-        return ptr::null();
-    }
-    let stats = h.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        *out_len = 0;
-        return ptr::null();
-    }
-    let value = if is_min {
-        &stats[idx].min
-    } else {
-        &stats[idx].max
-    };
-    match value {
-        Some(v) => {
-            let bytes = v.to_be_bytes();
-            let buf_ref = if is_min {
-                &WRITER_STAT_MIN_BUF
-            } else {
-                &WRITER_STAT_MAX_BUF
-            };
-            buf_ref.with(|buf| {
-                let mut b = buf.borrow_mut();
-                *b = bytes;
-                *out_len = b.len();
-                b.as_ptr()
-            })
+    // Ensure name CStrings are cached
+    if h.stat_name_cache.is_none() {
+        let num_rg = h.inner.num_row_groups();
+        let mut cache = Vec::with_capacity(num_rg);
+        for r in 0..num_rg {
+            let s = h.inner.row_group_stats(r);
+            let names_vec: Vec<CString> = s
+                .iter()
+                .map(|st| {
+                    CString::new(schema.columns[st.column_index].name.as_str()).unwrap_or_default()
+                })
+                .collect();
+            cache.push(names_vec);
         }
-        None => {
-            *out_len = 0;
-            ptr::null()
+        h.stat_name_cache = Some(cache);
+    }
+    // Ensure value bytes are cached
+    if h.stat_value_cache.is_none() {
+        let num_rg = h.inner.num_row_groups();
+        let mut cache = Vec::with_capacity(num_rg);
+        for r in 0..num_rg {
+            let s = h.inner.row_group_stats(r);
+            let vals: Vec<(Option<Vec<u8>>, Option<Vec<u8>>)> = s
+                .iter()
+                .map(|st| {
+                    (
+                        st.min.as_ref().map(|v| v.to_be_bytes()),
+                        st.max.as_ref().map(|v| v.to_be_bytes()),
+                    )
+                })
+                .collect();
+            cache.push(vals);
+        }
+        h.stat_value_cache = Some(cache);
+    }
+
+    let name_cache = &h.stat_name_cache.as_ref().unwrap()[rg];
+    let value_cache = &h.stat_value_cache.as_ref().unwrap()[rg];
+
+    for (i, st) in stats.iter().enumerate() {
+        if !names.is_null() {
+            *names.add(i) = name_cache[i].as_ptr();
+        }
+        if !null_counts.is_null() {
+            *null_counts.add(i) = st.null_count as u64;
+        }
+        if !min_ptrs.is_null() && !min_lens.is_null() {
+            match &value_cache[i].0 {
+                Some(b) => {
+                    *min_ptrs.add(i) = b.as_ptr();
+                    *min_lens.add(i) = b.len();
+                }
+                None => {
+                    *min_ptrs.add(i) = ptr::null();
+                    *min_lens.add(i) = 0;
+                }
+            }
+        }
+        if !max_ptrs.is_null() && !max_lens.is_null() {
+            match &value_cache[i].1 {
+                Some(b) => {
+                    *max_ptrs.add(i) = b.as_ptr();
+                    *max_lens.add(i) = b.len();
+                }
+                None => {
+                    *max_ptrs.add(i) = ptr::null();
+                    *max_lens.add(i) = 0;
+                }
+            }
         }
     }
+    0
 }
 
 /// Write an Arrow RecordBatch to the writer via the Arrow C Data Interface.
@@ -503,6 +498,8 @@ impl InputFile for FfiInputFile {
 
 pub struct MosaicReaderHandle {
     reader: MosaicReader<FfiInputFile>,
+    stat_name_cache: Option<Vec<Vec<CString>>>,
+    stat_value_cache: Option<Vec<Vec<(Option<Vec<u8>>, Option<Vec<u8>>)>>>,
 }
 
 pub struct MosaicRowGroupReaderHandle {
@@ -522,7 +519,11 @@ pub unsafe extern "C" fn mosaic_reader_open(
         };
         let ffi_input = FfiInputFile { raw: input_file };
         match MosaicReader::new(ffi_input, file_len) {
-            Ok(reader) => Box::into_raw(Box::new(MosaicReaderHandle { reader })),
+            Ok(reader) => Box::into_raw(Box::new(MosaicReaderHandle {
+                reader,
+                stat_name_cache: None,
+                stat_value_cache: None,
+            })),
             Err(e) => {
                 set_error(format!("open failed: {}", e));
                 ptr::null_mut()
@@ -631,41 +632,50 @@ pub unsafe extern "C" fn mosaic_reader_open_row_group(
     }
 }
 
-/// Open a row group reader with projection pushdown.
-/// Only decompresses buckets containing the specified columns.
+/// Set projection on the reader. Subsequent row group reads will only
+/// decompress buckets containing the specified columns.
 #[no_mangle]
-pub unsafe extern "C" fn mosaic_reader_open_row_group_projected(
+pub unsafe extern "C" fn mosaic_reader_set_projection(
     handle: *mut MosaicReaderHandle,
-    rg_index: u32,
-    columns: *const u32,
+    columns: *const *const c_char,
     num_columns: u32,
-) -> *mut MosaicRowGroupReaderHandle {
+) -> c_int {
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         if handle.is_null() {
             set_error("null reader handle".into());
-            return ptr::null_mut();
+            return -1;
         }
-        if columns.is_null() && num_columns > 0 {
-            set_error("null columns pointer".into());
-            return ptr::null_mut();
+        let h = &mut *handle;
+        if num_columns == 0 || columns.is_null() {
+            match h.reader.project(&[]) {
+                Ok(()) => return 0,
+                Err(e) => {
+                    set_error(e.to_string());
+                    return -1;
+                }
+            }
         }
-        let h = &*handle;
-        let col_indices: Vec<usize> = if num_columns > 0 {
-            std::slice::from_raw_parts(columns, num_columns as usize)
-                .iter()
-                .map(|&c| c as usize)
-                .collect()
-        } else {
-            Vec::new()
-        };
-        match h
-            .reader
-            .row_group_reader_projected(rg_index as usize, &col_indices)
-        {
-            Ok(rg) => Box::into_raw(Box::new(MosaicRowGroupReaderHandle { inner: rg })),
+        let ptrs = std::slice::from_raw_parts(columns, num_columns as usize);
+        let mut names = Vec::with_capacity(num_columns as usize);
+        for &p in ptrs {
+            if p.is_null() {
+                set_error("columns contains null pointer".into());
+                return -1;
+            }
+            match std::ffi::CStr::from_ptr(p).to_str() {
+                Ok(s) => names.push(s),
+                Err(_) => {
+                    set_error("columns contains invalid UTF-8".into());
+                    return -1;
+                }
+            }
+        }
+        let col_refs: Vec<&str> = names.iter().copied().collect();
+        match h.reader.project(&col_refs) {
+            Ok(()) => 0,
             Err(e) => {
-                set_error(format!("open row group projected failed: {}", e));
-                ptr::null_mut()
+                set_error(e.to_string());
+                -1
             }
         }
     }));
@@ -673,7 +683,7 @@ pub unsafe extern "C" fn mosaic_reader_open_row_group_projected(
         Ok(val) => val,
         Err(e) => {
             set_error(panic_message(&e));
-            ptr::null_mut()
+            -1
         }
     }
 }
@@ -752,139 +762,104 @@ pub unsafe extern "C" fn mosaic_reader_row_group_num_stats(
     0
 }
 
-/// Get the column index for a stats entry.
-/// Returns 0 on success, -1 on error. Writes result to `out`.
+/// Batch-fetch all stats for a reader row group.
+/// Caller must pre-allocate arrays with at least `num_stats` elements.
+/// `names` is filled with pointers to NUL-terminated strings (valid until reader is freed).
+/// `null_counts` is filled with null counts.
+/// `min_ptrs`/`min_lens` and `max_ptrs`/`max_lens` are filled with pointers to byte data
+/// (valid until reader is freed). A null pointer with len 0 means no min/max (all-null column).
+/// Returns 0 on success, -1 on error.
 #[no_mangle]
-pub unsafe extern "C" fn mosaic_reader_row_group_stat_column_index(
-    handle: *const MosaicReaderHandle,
+pub unsafe extern "C" fn mosaic_reader_row_group_stats(
+    handle: *mut MosaicReaderHandle,
     rg_index: u32,
-    stat_index: u32,
-    out: *mut u32,
+    names: *mut *const c_char,
+    null_counts: *mut u64,
+    min_ptrs: *mut *const u8,
+    min_lens: *mut usize,
+    max_ptrs: *mut *const u8,
+    max_lens: *mut usize,
 ) -> c_int {
-    if handle.is_null() || out.is_null() {
+    if handle.is_null() {
         set_error("null pointer".into());
         return -1;
     }
-    let h = &*handle;
-    let stats = match h.reader.row_group_stats(rg_index as usize) {
+    let h = &mut *handle;
+    let rg = rg_index as usize;
+    let stats = match h.reader.row_group_stats(rg) {
         Ok(s) => s,
         Err(e) => {
             set_error(e.to_string());
             return -1;
         }
     };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        set_error("stat_index out of range".into());
-        return -1;
+    let schema = h.reader.schema();
+
+    // Ensure caches are built
+    if h.stat_name_cache.is_none() {
+        let num_rg = h.reader.num_row_groups();
+        let mut name_cache = Vec::with_capacity(num_rg);
+        let mut value_cache = Vec::with_capacity(num_rg);
+        for r in 0..num_rg {
+            let s = h.reader.row_group_stats(r).unwrap_or(&[]);
+            let names_vec: Vec<CString> = s
+                .iter()
+                .map(|st| {
+                    CString::new(schema.columns[st.column_index].name.as_str()).unwrap_or_default()
+                })
+                .collect();
+            let vals: Vec<(Option<Vec<u8>>, Option<Vec<u8>>)> = s
+                .iter()
+                .map(|st| {
+                    (
+                        st.min.as_ref().map(|v| v.to_be_bytes()),
+                        st.max.as_ref().map(|v| v.to_be_bytes()),
+                    )
+                })
+                .collect();
+            name_cache.push(names_vec);
+            value_cache.push(vals);
+        }
+        h.stat_name_cache = Some(name_cache);
+        h.stat_value_cache = Some(value_cache);
     }
-    *out = stats[idx].column_index as u32;
+
+    let name_cache = &h.stat_name_cache.as_ref().unwrap()[rg];
+    let value_cache = &h.stat_value_cache.as_ref().unwrap()[rg];
+
+    for (i, st) in stats.iter().enumerate() {
+        if !names.is_null() {
+            *names.add(i) = name_cache[i].as_ptr();
+        }
+        if !null_counts.is_null() {
+            *null_counts.add(i) = st.null_count as u64;
+        }
+        if !min_ptrs.is_null() && !min_lens.is_null() {
+            match &value_cache[i].0 {
+                Some(b) => {
+                    *min_ptrs.add(i) = b.as_ptr();
+                    *min_lens.add(i) = b.len();
+                }
+                None => {
+                    *min_ptrs.add(i) = ptr::null();
+                    *min_lens.add(i) = 0;
+                }
+            }
+        }
+        if !max_ptrs.is_null() && !max_lens.is_null() {
+            match &value_cache[i].1 {
+                Some(b) => {
+                    *max_ptrs.add(i) = b.as_ptr();
+                    *max_lens.add(i) = b.len();
+                }
+                None => {
+                    *max_ptrs.add(i) = ptr::null();
+                    *max_lens.add(i) = 0;
+                }
+            }
+        }
+    }
     0
-}
-
-/// Get the null count for a stats entry.
-/// Returns 0 on success, -1 on error. Writes result to `out`.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_reader_row_group_stat_null_count(
-    handle: *const MosaicReaderHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out: *mut u64,
-) -> c_int {
-    if handle.is_null() || out.is_null() {
-        set_error("null pointer".into());
-        return -1;
-    }
-    let h = &*handle;
-    let stats = match h.reader.row_group_stats(rg_index as usize) {
-        Ok(s) => s,
-        Err(e) => {
-            set_error(e.to_string());
-            return -1;
-        }
-    };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        set_error("stat_index out of range".into());
-        return -1;
-    }
-    *out = stats[idx].null_count as u64;
-    0
-}
-
-/// Get the min value for a stats entry as raw bytes.
-/// Returns null if the column is all-null (no min). Sets out_len to the byte length.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_reader_row_group_stat_min(
-    handle: *const MosaicReaderHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-) -> *const u8 {
-    stat_value_ptr(handle, rg_index, stat_index, out_len, true)
-}
-
-/// Get the max value for a stats entry as raw bytes.
-/// Returns null if the column is all-null (no max). Sets out_len to the byte length.
-#[no_mangle]
-pub unsafe extern "C" fn mosaic_reader_row_group_stat_max(
-    handle: *const MosaicReaderHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-) -> *const u8 {
-    stat_value_ptr(handle, rg_index, stat_index, out_len, false)
-}
-
-thread_local! {
-    static STAT_MIN_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-    static STAT_MAX_BUF: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
-}
-
-unsafe fn stat_value_ptr(
-    handle: *const MosaicReaderHandle,
-    rg_index: u32,
-    stat_index: u32,
-    out_len: *mut usize,
-    is_min: bool,
-) -> *const u8 {
-    if handle.is_null() || out_len.is_null() {
-        return ptr::null();
-    }
-    let h = &*handle;
-    let stats = match h.reader.row_group_stats(rg_index as usize) {
-        Ok(s) => s,
-        Err(_) => {
-            *out_len = 0;
-            return ptr::null();
-        }
-    };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        *out_len = 0;
-        return ptr::null();
-    }
-    let value = if is_min {
-        &stats[idx].min
-    } else {
-        &stats[idx].max
-    };
-    match value {
-        Some(v) => {
-            let bytes = v.to_be_bytes();
-            let buf_ref = if is_min { &STAT_MIN_BUF } else { &STAT_MAX_BUF };
-            buf_ref.with(|buf| {
-                let mut b = buf.borrow_mut();
-                *b = bytes;
-                *out_len = b.len();
-                b.as_ptr()
-            })
-        }
-        None => {
-            *out_len = 0;
-            ptr::null()
-        }
-    }
 }
 
 // ======================== Record Batch (Arrow C Data Interface) ========================

--- a/include/mosaic.hpp
+++ b/include/mosaic.hpp
@@ -89,7 +89,7 @@ struct WriterOptions {
     uint64_t row_group_max_size = 256ULL * 1024 * 1024;
     uint32_t max_dict_total_bytes = 32 * 1024;
     uint32_t max_dict_entries = 255;
-    const uint32_t* stats_columns = nullptr;
+    const char* const* stats_columns = nullptr;
     uint32_t num_stats_columns = 0;
     uint32_t page_size_threshold = 32 * 1024;
 };
@@ -97,13 +97,16 @@ struct WriterOptions {
 // ======================== Statistics ========================
 
 struct ColumnStatistics {
-    uint32_t column_index;
+    std::string column_name;
     uint64_t null_count;
     std::vector<uint8_t> min_value;
     std::vector<uint8_t> max_value;
     bool has_min_max() const { return !min_value.empty(); }
 };
 
+/// Columns are stored in name-sorted order regardless of input schema order.
+/// The reader returns columns in storage (name-sorted) order by default;
+/// use Reader::set_projection() to control output column order.
 class Writer {
 public:
     /// Construct a writer. `arrow_schema` is a pointer to an ArrowSchema (Arrow C Data Interface).
@@ -183,22 +186,30 @@ public:
         return out;
     }
 
-    std::vector<ColumnStatistics> get_row_group_statistics(uint32_t rg_index) const {
+    std::vector<ColumnStatistics> get_row_group_statistics(uint32_t rg_index) {
         uint32_t n = 0;
         check(mosaic_writer_row_group_num_stats(handle_, rg_index, &n));
+        if (n == 0) return {};
+        std::vector<const char*> names(n);
+        std::vector<uint64_t> null_counts(n);
+        std::vector<const uint8_t*> min_ptrs(n);
+        std::vector<size_t> min_lens(n);
+        std::vector<const uint8_t*> max_ptrs(n);
+        std::vector<size_t> max_lens(n);
+        check(mosaic_writer_row_group_stats(handle_, rg_index,
+            names.data(), null_counts.data(),
+            min_ptrs.data(), min_lens.data(),
+            max_ptrs.data(), max_lens.data()));
         std::vector<ColumnStatistics> result;
         result.reserve(n);
         for (uint32_t i = 0; i < n; i++) {
             ColumnStatistics s;
-            check(mosaic_writer_row_group_stat_column_index(handle_, rg_index, i, &s.column_index));
-            check(mosaic_writer_row_group_stat_null_count(handle_, rg_index, i, &s.null_count));
-            size_t min_len = 0, max_len = 0;
-            const uint8_t* min_ptr = mosaic_writer_row_group_stat_min(handle_, rg_index, i, &min_len);
-            const uint8_t* max_ptr = mosaic_writer_row_group_stat_max(handle_, rg_index, i, &max_len);
-            if (min_ptr && min_len > 0)
-                s.min_value.assign(min_ptr, min_ptr + min_len);
-            if (max_ptr && max_len > 0)
-                s.max_value.assign(max_ptr, max_ptr + max_len);
+            s.column_name = names[i] ? names[i] : "";
+            s.null_count = null_counts[i];
+            if (min_ptrs[i] && min_lens[i] > 0)
+                s.min_value.assign(min_ptrs[i], min_ptrs[i] + min_lens[i]);
+            if (max_ptrs[i] && max_lens[i] > 0)
+                s.max_value.assign(max_ptrs[i], max_ptrs[i] + max_lens[i]);
             result.push_back(std::move(s));
         }
         return result;
@@ -239,6 +250,8 @@ inline uint64_t input_length(void* ctx) noexcept {
 
 } // namespace detail
 
+/// Schema and output columns are in storage order (name-sorted).
+/// Use set_projection() to select and reorder output columns.
 class Reader {
 public:
     Reader(const Reader&) = delete;
@@ -275,18 +288,8 @@ public:
         if (rc != 0) throw Error("record_batch_export failed");
     }
 
-    void read_row_group(uint32_t rg_index, const uint32_t* cols, uint32_t num_cols,
-                        void* out_array, void* out_schema) {
-        auto* rg = mosaic_reader_open_row_group_projected(handle_, rg_index, cols, num_cols);
-        if (!rg) throw Error("failed to open row group");
-        auto* rb = mosaic_row_group_reader_read_columns(rg);
-        mosaic_row_group_reader_free(rg);
-        if (!rb) throw Error("read_columns failed");
-        int rc = mosaic_record_batch_export(rb,
-            static_cast<ArrowArray*>(out_array),
-            static_cast<ArrowSchema*>(out_schema));
-        mosaic_record_batch_free(rb);
-        if (rc != 0) throw Error("record_batch_export failed");
+    void set_projection(const char* const* cols, uint32_t num_cols) {
+        check(mosaic_reader_set_projection(handle_, cols, num_cols));
     }
 
     uint32_t row_group_num_rows(uint32_t rg_index) const {
@@ -295,22 +298,30 @@ public:
         return out;
     }
 
-    std::vector<ColumnStatistics> get_row_group_statistics(uint32_t rg_index) const {
+    std::vector<ColumnStatistics> get_row_group_statistics(uint32_t rg_index) {
         uint32_t n = 0;
         check(mosaic_reader_row_group_num_stats(handle_, rg_index, &n));
+        if (n == 0) return {};
+        std::vector<const char*> names(n);
+        std::vector<uint64_t> null_counts(n);
+        std::vector<const uint8_t*> min_ptrs(n);
+        std::vector<size_t> min_lens(n);
+        std::vector<const uint8_t*> max_ptrs(n);
+        std::vector<size_t> max_lens(n);
+        check(mosaic_reader_row_group_stats(handle_, rg_index,
+            names.data(), null_counts.data(),
+            min_ptrs.data(), min_lens.data(),
+            max_ptrs.data(), max_lens.data()));
         std::vector<ColumnStatistics> result;
         result.reserve(n);
         for (uint32_t i = 0; i < n; i++) {
             ColumnStatistics s;
-            check(mosaic_reader_row_group_stat_column_index(handle_, rg_index, i, &s.column_index));
-            check(mosaic_reader_row_group_stat_null_count(handle_, rg_index, i, &s.null_count));
-            size_t min_len = 0, max_len = 0;
-            const uint8_t* min_ptr = mosaic_reader_row_group_stat_min(handle_, rg_index, i, &min_len);
-            const uint8_t* max_ptr = mosaic_reader_row_group_stat_max(handle_, rg_index, i, &max_len);
-            if (min_ptr && min_len > 0)
-                s.min_value.assign(min_ptr, min_ptr + min_len);
-            if (max_ptr && max_len > 0)
-                s.max_value.assign(max_ptr, max_ptr + max_len);
+            s.column_name = names[i] ? names[i] : "";
+            s.null_count = null_counts[i];
+            if (min_ptrs[i] && min_lens[i] > 0)
+                s.min_value.assign(min_ptrs[i], min_ptrs[i] + min_lens[i]);
+            if (max_ptrs[i] && max_lens[i] > 0)
+                s.max_value.assign(max_ptrs[i], max_ptrs[i] + max_lens[i]);
             result.push_back(std::move(s));
         }
         return result;

--- a/java/src/main/java/org/apache/paimon/mosaic/ColumnStatistics.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/ColumnStatistics.java
@@ -21,20 +21,14 @@ package org.apache.paimon.mosaic;
 
 public class ColumnStatistics {
 
-    private final int columnIndex;
     private final long nullCount;
     private final byte[] min;
     private final byte[] max;
 
-    ColumnStatistics(int columnIndex, long nullCount, byte[] min, byte[] max) {
-        this.columnIndex = columnIndex;
+    ColumnStatistics(long nullCount, byte[] min, byte[] max) {
         this.nullCount = nullCount;
         this.min = min;
         this.max = max;
-    }
-
-    public int getColumnIndex() {
-        return columnIndex;
     }
 
     public long getNullCount() {

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
@@ -19,8 +19,9 @@
 
 package org.apache.paimon.mosaic;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
@@ -29,6 +30,10 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+/**
+ * Schema and output columns are in storage order (name-sorted).
+ * Use {@link #project} to select and reorder output columns.
+ */
 public class MosaicReader implements AutoCloseable {
 
     private long handle;
@@ -66,20 +71,12 @@ public class MosaicReader implements AutoCloseable {
         return NativeLib.nativeReaderNumRowGroups(handle);
     }
 
-    public VectorSchemaRoot readRowGroup(int rgIndex, BufferAllocator allocator) {
-        long rgHandle = NativeLib.nativeReaderOpenRowGroup(handle, rgIndex);
-        if (rgHandle == 0) {
-            throw new RuntimeException("failed to open row group " + rgIndex);
-        }
-        try {
-            return readRowGroupHandle(rgHandle, allocator);
-        } finally {
-            NativeLib.nativeRowGroupReaderFree(rgHandle);
-        }
+    public void project(String[] columns) {
+        NativeLib.nativeReaderSetProjection(handle, columns);
     }
 
-    public VectorSchemaRoot readRowGroup(int rgIndex, int[] columns, BufferAllocator allocator) {
-        long rgHandle = NativeLib.nativeReaderOpenRowGroupProjected(handle, rgIndex, columns);
+    public VectorSchemaRoot readRowGroup(int rgIndex, BufferAllocator allocator) {
+        long rgHandle = NativeLib.nativeReaderOpenRowGroup(handle, rgIndex);
         if (rgHandle == 0) {
             throw new RuntimeException("failed to open row group " + rgIndex);
         }
@@ -111,23 +108,21 @@ public class MosaicReader implements AutoCloseable {
     }
 
     /**
-     * Returns column statistics for the given row group. The returned list follows the same order
-     * as the {@code statsColumns} specified in {@link WriterOptions} when the file was written.
+     * Returns column statistics for the given row group, keyed by column name.
      */
-    public List<ColumnStatistics> getRowGroupStatistics(int rgIndex) {
-        int n = NativeLib.nativeReaderRowGroupNumStats(handle, rgIndex);
-        if (n < 0) {
-            throw new RuntimeException("failed to get row group statistics for index " + rgIndex);
+    public Map<String, ColumnStatistics> getRowGroupStatistics(int rgIndex) {
+        String[] names = NativeLib.nativeReaderRowGroupStatNames(handle, rgIndex);
+        if (names == null || names.length == 0) {
+            return Collections.emptyMap();
         }
-        List<ColumnStatistics> result = new ArrayList<>(n);
-        for (int i = 0; i < n; i++) {
-            result.add(new ColumnStatistics(
-                    NativeLib.nativeReaderRowGroupStatColumnIndex(handle, rgIndex, i),
-                    NativeLib.nativeReaderRowGroupStatNullCount(handle, rgIndex, i),
-                    NativeLib.nativeReaderRowGroupStatMin(handle, rgIndex, i),
-                    NativeLib.nativeReaderRowGroupStatMax(handle, rgIndex, i)));
+        long[] nullCounts = NativeLib.nativeReaderRowGroupStatNullCounts(handle, rgIndex);
+        byte[][] mins = NativeLib.nativeReaderRowGroupStatMins(handle, rgIndex);
+        byte[][] maxs = NativeLib.nativeReaderRowGroupStatMaxs(handle, rgIndex);
+        Map<String, ColumnStatistics> result = new LinkedHashMap<>(names.length);
+        for (int i = 0; i < names.length; i++) {
+            result.put(names[i], new ColumnStatistics(nullCounts[i], mins[i], maxs[i]));
         }
-        return result;
+        return Collections.unmodifiableMap(result);
     }
 
     @Override

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicWriter.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicWriter.java
@@ -22,7 +22,9 @@ package org.apache.paimon.mosaic;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
@@ -31,12 +33,17 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+/**
+ * Columns are stored in name-sorted order regardless of input schema order.
+ * The reader returns columns in storage (name-sorted) order by default;
+ * use {@link MosaicReader#project} to control output column order.
+ */
 public class MosaicWriter implements AutoCloseable {
 
     private long handle;
     private boolean closed;
     private final BufferAllocator allocator;
-    private List<List<ColumnStatistics>> rowGroupStats;
+    private List<Map<String, ColumnStatistics>> rowGroupStats;
 
     public MosaicWriter(OutputStream outputStream, Schema arrowSchema, BufferAllocator allocator) {
         this(outputStream, arrowSchema, new WriterOptions(), allocator);
@@ -107,10 +114,9 @@ public class MosaicWriter implements AutoCloseable {
     }
 
     /**
-     * Returns column statistics for the given row group. The returned list follows the same order
-     * as the {@code statsColumns} specified in {@link WriterOptions}.
+     * Returns column statistics for the given row group, keyed by column name.
      */
-    public List<ColumnStatistics> getRowGroupStatistics(int rgIndex) {
+    public Map<String, ColumnStatistics> getRowGroupStatistics(int rgIndex) {
         if (rowGroupStats == null) {
             throw new IllegalStateException("writer is not closed yet");
         }
@@ -133,22 +139,21 @@ public class MosaicWriter implements AutoCloseable {
 
     private void collectStatistics() {
         int numRg = NativeLib.nativeWriterNumRowGroups(handle);
-        List<List<ColumnStatistics>> allStats = new ArrayList<>(numRg);
+        List<Map<String, ColumnStatistics>> allStats = new ArrayList<>(numRg);
         for (int rg = 0; rg < numRg; rg++) {
-            int n = NativeLib.nativeWriterRowGroupNumStats(handle, rg);
-            if (n <= 0) {
-                allStats.add(Collections.emptyList());
+            String[] names = NativeLib.nativeWriterRowGroupStatNames(handle, rg);
+            if (names == null || names.length == 0) {
+                allStats.add(Collections.emptyMap());
                 continue;
             }
-            List<ColumnStatistics> rgStats = new ArrayList<>(n);
-            for (int i = 0; i < n; i++) {
-                rgStats.add(new ColumnStatistics(
-                        NativeLib.nativeWriterRowGroupStatColumnIndex(handle, rg, i),
-                        NativeLib.nativeWriterRowGroupStatNullCount(handle, rg, i),
-                        NativeLib.nativeWriterRowGroupStatMin(handle, rg, i),
-                        NativeLib.nativeWriterRowGroupStatMax(handle, rg, i)));
+            long[] nullCounts = NativeLib.nativeWriterRowGroupStatNullCounts(handle, rg);
+            byte[][] mins = NativeLib.nativeWriterRowGroupStatMins(handle, rg);
+            byte[][] maxs = NativeLib.nativeWriterRowGroupStatMaxs(handle, rg);
+            Map<String, ColumnStatistics> rgStats = new LinkedHashMap<>(names.length);
+            for (int i = 0; i < names.length; i++) {
+                rgStats.put(names[i], new ColumnStatistics(nullCounts[i], mins[i], maxs[i]));
             }
-            allStats.add(Collections.unmodifiableList(rgStats));
+            allStats.add(Collections.unmodifiableMap(rgStats));
         }
         this.rowGroupStats = Collections.unmodifiableList(allStats);
     }

--- a/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
@@ -104,18 +104,17 @@ final class NativeLib {
     static native long nativeWriterOpen(OutputStream stream, long arrowSchemaAddr,
                                         int numBuckets, int compression, int zstdLevel,
                                         long rowGroupMaxSize, int maxDictTotalBytes,
-                                        int maxDictEntries, int[] statsColumns,
+                                        int maxDictEntries, String[] statsColumns,
                                         int pageSizeThreshold);
     static native void nativeWriterClose(long handle);
     static native void nativeWriterFree(long handle);
     static native long nativeWriterEstimatedSize(long handle);
     static native void nativeWriterWriteBatch(long writerHandle, long arrayAddr, long schemaAddr);
     static native int nativeWriterNumRowGroups(long handle);
-    static native int nativeWriterRowGroupNumStats(long handle, int rgIndex);
-    static native int nativeWriterRowGroupStatColumnIndex(long handle, int rgIndex, int statIndex);
-    static native long nativeWriterRowGroupStatNullCount(long handle, int rgIndex, int statIndex);
-    static native byte[] nativeWriterRowGroupStatMin(long handle, int rgIndex, int statIndex);
-    static native byte[] nativeWriterRowGroupStatMax(long handle, int rgIndex, int statIndex);
+    static native String[] nativeWriterRowGroupStatNames(long handle, int rgIndex);
+    static native long[] nativeWriterRowGroupStatNullCounts(long handle, int rgIndex);
+    static native byte[][] nativeWriterRowGroupStatMins(long handle, int rgIndex);
+    static native byte[][] nativeWriterRowGroupStatMaxs(long handle, int rgIndex);
 
     // Reader
     static native long nativeReaderOpen(Object inputFile, long fileLength);
@@ -123,7 +122,7 @@ final class NativeLib {
     static native int nativeReaderExportSchema(long handle, long schemaAddr);
     static native int nativeReaderNumRowGroups(long handle);
     static native long nativeReaderOpenRowGroup(long handle, int rgIndex);
-    static native long nativeReaderOpenRowGroupProjected(long handle, int rgIndex, int[] columns);
+    static native void nativeReaderSetProjection(long handle, String[] columns);
 
     // RowGroupReader
     static native int nativeRowGroupReaderNumRows(long handle);
@@ -134,9 +133,8 @@ final class NativeLib {
     static native int nativeReaderRowGroupNumRows(long handle, int rgIndex);
 
     // Row group stats
-    static native int nativeReaderRowGroupNumStats(long handle, int rgIndex);
-    static native int nativeReaderRowGroupStatColumnIndex(long handle, int rgIndex, int statIndex);
-    static native long nativeReaderRowGroupStatNullCount(long handle, int rgIndex, int statIndex);
-    static native byte[] nativeReaderRowGroupStatMin(long handle, int rgIndex, int statIndex);
-    static native byte[] nativeReaderRowGroupStatMax(long handle, int rgIndex, int statIndex);
+    static native String[] nativeReaderRowGroupStatNames(long handle, int rgIndex);
+    static native long[] nativeReaderRowGroupStatNullCounts(long handle, int rgIndex);
+    static native byte[][] nativeReaderRowGroupStatMins(long handle, int rgIndex);
+    static native byte[][] nativeReaderRowGroupStatMaxs(long handle, int rgIndex);
 }

--- a/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
@@ -29,7 +29,7 @@ public class WriterOptions {
     private long rowGroupMaxSize = 256L * 1024 * 1024;
     private int maxDictTotalBytes = 32 * 1024;
     private int maxDictEntries = 255;
-    private int[] statsColumns = new int[0];
+    private String[] statsColumns = new String[0];
     private int pageSizeThreshold = 32 * 1024;
 
     public WriterOptions() {}
@@ -64,7 +64,7 @@ public class WriterOptions {
         return this;
     }
 
-    public WriterOptions statsColumns(int... columns) {
+    public WriterOptions statsColumns(String... columns) {
         this.statsColumns = columns.clone();
         return this;
     }
@@ -80,6 +80,6 @@ public class WriterOptions {
     long getRowGroupMaxSize() { return rowGroupMaxSize; }
     int getMaxDictTotalBytes() { return maxDictTotalBytes; }
     int getMaxDictEntries() { return maxDictEntries; }
-    int[] getStatsColumns() { return statsColumns; }
+    String[] getStatsColumns() { return statsColumns; }
     int getPageSizeThreshold() { return pageSizeThreshold; }
 }

--- a/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
+++ b/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
@@ -24,7 +24,6 @@ import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
-import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -268,18 +267,96 @@ public class MosaicRoundtripTest {
         }
 
         try (MosaicReader reader = readerFromBytes(data)) {
-            int aCol = reader.getSchema().getFields().indexOf(reader.getSchema().findField("a"));
-            int bCol = reader.getSchema().getFields().indexOf(reader.getSchema().findField("b"));
-            int[] projected = {aCol, bCol};
+            reader.project(new String[]{"a", "b"});
 
             int totalRows = 0;
             for (int rg = 0; rg < reader.numRowGroups(); rg++) {
-                try (VectorSchemaRoot batch = reader.readRowGroup(rg, projected, allocator)) {
+                try (VectorSchemaRoot batch = reader.readRowGroup(rg, allocator)) {
                     totalRows += batch.getRowCount();
                     assertEquals(2, batch.getFieldVectors().size());
                 }
             }
             assertEquals(20, totalRows);
+        }
+    }
+
+    @Test
+    public void testProjectionOrder() {
+        Schema arrowSchema = new Schema(Arrays.asList(
+                Field.nullable("a", new ArrowType.Int(32, true)),
+                Field.nullable("b", ArrowType.Utf8.INSTANCE),
+                Field.nullable("c", new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE))
+        ));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            IntVector aVec = (IntVector) root.getVector("a");
+            VarCharVector bVec = (VarCharVector) root.getVector("b");
+            Float8Vector cVec = (Float8Vector) root.getVector("c");
+
+            int n = 10;
+            aVec.allocateNew(n);
+            bVec.allocateNew(n);
+            cVec.allocateNew(n);
+            for (int i = 0; i < n; i++) {
+                aVec.set(i, i);
+                bVec.setSafe(i, ("s" + i).getBytes());
+                cVec.set(i, i * 0.5);
+            }
+            root.setRowCount(n);
+            data = writeToBytes(arrowSchema, new WriterOptions().numBuckets(2), writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data)) {
+            reader.project(new String[]{"c", "a", "b"});
+            try (VectorSchemaRoot batch = reader.readRowGroup(0, allocator)) {
+                assertEquals(3, batch.getFieldVectors().size());
+                assertEquals("c", batch.getVector(0).getName());
+                assertEquals("a", batch.getVector(1).getName());
+                assertEquals("b", batch.getVector(2).getName());
+                assertEquals(10, batch.getRowCount());
+
+                Float8Vector cOut = (Float8Vector) batch.getVector(0);
+                IntVector aOut = (IntVector) batch.getVector(1);
+                VarCharVector bOut = (VarCharVector) batch.getVector(2);
+                for (int i = 0; i < 10; i++) {
+                    assertEquals(i, aOut.get(i));
+                    assertEquals("s" + i, new String(bOut.get(i)));
+                    assertEquals(i * 0.5, cOut.get(i), 1e-10);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testProjectionEmpty() {
+        Schema arrowSchema = new Schema(Arrays.asList(
+                Field.nullable("a", new ArrowType.Int(32, true)),
+                Field.nullable("b", ArrowType.Utf8.INSTANCE)
+        ));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            IntVector aVec = (IntVector) root.getVector("a");
+            VarCharVector bVec = (VarCharVector) root.getVector("b");
+
+            int n = 5;
+            aVec.allocateNew(n);
+            bVec.allocateNew(n);
+            for (int i = 0; i < n; i++) {
+                aVec.set(i, i);
+                bVec.setSafe(i, ("v" + i).getBytes());
+            }
+            root.setRowCount(n);
+            data = writeToBytes(arrowSchema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data)) {
+            reader.project(new String[]{});
+            try (VectorSchemaRoot batch = reader.readRowGroup(0, allocator)) {
+                assertEquals(0, batch.getFieldVectors().size());
+                assertEquals(5, batch.getRowCount());
+            }
         }
     }
 
@@ -291,7 +368,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("value", new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0, 2);
+        WriterOptions opts = new WriterOptions().statsColumns("id", "value");
 
         byte[] data;
         try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
@@ -315,10 +392,11 @@ public class MosaicRoundtripTest {
 
         try (MosaicReader reader = readerFromBytes(data)) {
             for (int rg = 0; rg < reader.numRowGroups(); rg++) {
-                java.util.List<ColumnStatistics> stats = reader.getRowGroupStatistics(rg);
+                java.util.Map<String, ColumnStatistics> stats = reader.getRowGroupStatistics(rg);
                 assertTrue(stats.size() > 0);
-                for (ColumnStatistics stat : stats) {
-                    assertTrue(stat.getColumnIndex() == 0 || stat.getColumnIndex() == 2);
+                assertTrue(stats.containsKey("id"));
+                assertTrue(stats.containsKey("value"));
+                for (ColumnStatistics stat : stats.values()) {
                     assertEquals(0, stat.getNullCount());
                     assertTrue(stat.hasMinMax());
                     assertNotNull(stat.getMin());
@@ -600,7 +678,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("b", new ArrowType.Int(64, true))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0, 1).numBuckets(1);
+        WriterOptions opts = new WriterOptions().statsColumns("a", "b").numBuckets(1);
 
         byte[] data;
         try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
@@ -624,10 +702,10 @@ public class MosaicRoundtripTest {
         }
 
         try (MosaicReader reader = readerFromBytes(data)) {
-            List<ColumnStatistics> stats = reader.getRowGroupStatistics(0);
+            java.util.Map<String, ColumnStatistics> stats = reader.getRowGroupStatistics(0);
             assertEquals(2, stats.size());
 
-            ColumnStatistics aStat = stats.stream().filter(s -> s.getColumnIndex() == 0).findFirst().get();
+            ColumnStatistics aStat = stats.get("a");
             assertEquals(1, aStat.getNullCount());
             assertTrue(aStat.hasMinMax());
             int minA = ByteBuffer.wrap(aStat.getMin()).order(ByteOrder.BIG_ENDIAN).getInt();
@@ -635,7 +713,7 @@ public class MosaicRoundtripTest {
             assertEquals(5, minA);
             assertEquals(20, maxA);
 
-            ColumnStatistics bStat = stats.stream().filter(s -> s.getColumnIndex() == 1).findFirst().get();
+            ColumnStatistics bStat = stats.get("b");
             assertEquals(2, bStat.getNullCount());
             assertTrue(bStat.hasMinMax());
             long minB = ByteBuffer.wrap(bStat.getMin()).order(ByteOrder.BIG_ENDIAN).getLong();
@@ -651,7 +729,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("x", new ArrowType.Int(32, true))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0).numBuckets(1);
+        WriterOptions opts = new WriterOptions().statsColumns("x").numBuckets(1);
 
         byte[] data;
         try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
@@ -665,10 +743,11 @@ public class MosaicRoundtripTest {
         }
 
         try (MosaicReader reader = readerFromBytes(data)) {
-            List<ColumnStatistics> stats = reader.getRowGroupStatistics(0);
+            java.util.Map<String, ColumnStatistics> stats = reader.getRowGroupStatistics(0);
             assertEquals(1, stats.size());
-            assertEquals(3, stats.get(0).getNullCount());
-            assertFalse(stats.get(0).hasMinMax());
+            ColumnStatistics xStat = stats.get("x");
+            assertEquals(3, xStat.getNullCount());
+            assertFalse(xStat.hasMinMax());
         }
     }
 
@@ -736,7 +815,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("score", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0, 2);
+        WriterOptions opts = new WriterOptions().statsColumns("id", "score");
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MosaicWriter writer = new MosaicWriter(baos, arrowSchema, opts, allocator);
@@ -761,17 +840,18 @@ public class MosaicRoundtripTest {
         writer.close();
 
         assertEquals(1, writer.numRowGroups());
-        List<ColumnStatistics> stats = writer.getRowGroupStatistics(0);
+        java.util.Map<String, ColumnStatistics> stats = writer.getRowGroupStatistics(0);
         assertTrue(stats.size() > 0);
-        for (ColumnStatistics stat : stats) {
-            assertTrue(stat.getColumnIndex() == 0 || stat.getColumnIndex() == 2);
+        assertTrue(stats.containsKey("id"));
+        assertTrue(stats.containsKey("score"));
+        for (ColumnStatistics stat : stats.values()) {
             assertEquals(0, stat.getNullCount());
             assertTrue(stat.hasMinMax());
             assertNotNull(stat.getMin());
             assertNotNull(stat.getMax());
         }
 
-        ColumnStatistics idStat = stats.stream().filter(s -> s.getColumnIndex() == 0).findFirst().get();
+        ColumnStatistics idStat = stats.get("id");
         int minId = ByteBuffer.wrap(idStat.getMin()).order(ByteOrder.BIG_ENDIAN).getInt();
         int maxId = ByteBuffer.wrap(idStat.getMax()).order(ByteOrder.BIG_ENDIAN).getInt();
         assertEquals(0, minId);
@@ -785,7 +865,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("b", new ArrowType.Int(64, true))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0, 1).numBuckets(1);
+        WriterOptions opts = new WriterOptions().statsColumns("a", "b").numBuckets(1);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MosaicWriter writer = new MosaicWriter(baos, arrowSchema, opts, allocator);
@@ -811,10 +891,10 @@ public class MosaicRoundtripTest {
         writer.close();
 
         assertEquals(1, writer.numRowGroups());
-        List<ColumnStatistics> stats = writer.getRowGroupStatistics(0);
+        java.util.Map<String, ColumnStatistics> stats = writer.getRowGroupStatistics(0);
         assertEquals(2, stats.size());
 
-        ColumnStatistics aStat = stats.stream().filter(s -> s.getColumnIndex() == 0).findFirst().get();
+        ColumnStatistics aStat = stats.get("a");
         assertEquals(1, aStat.getNullCount());
         assertTrue(aStat.hasMinMax());
         int minA = ByteBuffer.wrap(aStat.getMin()).order(ByteOrder.BIG_ENDIAN).getInt();
@@ -822,7 +902,7 @@ public class MosaicRoundtripTest {
         assertEquals(5, minA);
         assertEquals(20, maxA);
 
-        ColumnStatistics bStat = stats.stream().filter(s -> s.getColumnIndex() == 1).findFirst().get();
+        ColumnStatistics bStat = stats.get("b");
         assertEquals(2, bStat.getNullCount());
         assertTrue(bStat.hasMinMax());
         long minB = ByteBuffer.wrap(bStat.getMin()).order(ByteOrder.BIG_ENDIAN).getLong();
@@ -837,7 +917,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("x", new ArrowType.Int(32, true))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0).numBuckets(1);
+        WriterOptions opts = new WriterOptions().statsColumns("x").numBuckets(1);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MosaicWriter writer = new MosaicWriter(baos, arrowSchema, opts, allocator);
@@ -853,10 +933,11 @@ public class MosaicRoundtripTest {
         writer.close();
 
         assertEquals(1, writer.numRowGroups());
-        List<ColumnStatistics> stats = writer.getRowGroupStatistics(0);
+        java.util.Map<String, ColumnStatistics> stats = writer.getRowGroupStatistics(0);
         assertEquals(1, stats.size());
-        assertEquals(3, stats.get(0).getNullCount());
-        assertFalse(stats.get(0).hasMinMax());
+        ColumnStatistics xStat = stats.get("x");
+        assertEquals(3, xStat.getNullCount());
+        assertFalse(xStat.hasMinMax());
     }
 
     @Test
@@ -866,7 +947,7 @@ public class MosaicRoundtripTest {
                 Field.nullable("value", new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))
         ));
 
-        WriterOptions opts = new WriterOptions().statsColumns(0, 1).numBuckets(1);
+        WriterOptions opts = new WriterOptions().statsColumns("id", "value").numBuckets(1);
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MosaicWriter writer = new MosaicWriter(baos, arrowSchema, opts, allocator);
@@ -887,14 +968,14 @@ public class MosaicRoundtripTest {
 
         byte[] data = baos.toByteArray();
         try (MosaicReader reader = readerFromBytes(data)) {
-            List<ColumnStatistics> writerStats = writer.getRowGroupStatistics(0);
-            List<ColumnStatistics> readerStats = reader.getRowGroupStatistics(0);
+            java.util.Map<String, ColumnStatistics> writerStats = writer.getRowGroupStatistics(0);
+            java.util.Map<String, ColumnStatistics> readerStats = reader.getRowGroupStatistics(0);
 
             assertEquals(writerStats.size(), readerStats.size());
-            for (int i = 0; i < writerStats.size(); i++) {
-                ColumnStatistics ws = writerStats.get(i);
-                ColumnStatistics rs = readerStats.get(i);
-                assertEquals(ws.getColumnIndex(), rs.getColumnIndex());
+            for (String colName : writerStats.keySet()) {
+                ColumnStatistics ws = writerStats.get(colName);
+                ColumnStatistics rs = readerStats.get(colName);
+                assertNotNull(rs);
                 assertEquals(ws.getNullCount(), rs.getNullCount());
                 assertEquals(ws.hasMinMax(), rs.hasMinMax());
                 assertArrayEquals(ws.getMin(), rs.getMin());

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -20,8 +20,10 @@ use std::panic::{self, AssertUnwindSafe};
 use std::ptr;
 use std::sync::Arc;
 
-use jni::objects::{GlobalRef, JByteArray, JClass, JIntArray, JMethodID, JObject, JValue};
-use jni::sys::{jint, jlong};
+use jni::objects::{
+    GlobalRef, JByteArray, JClass, JMethodID, JObject, JObjectArray, JString, JValue,
+};
+use jni::sys::{jint, jlong, jlongArray};
 use jni::JNIEnv;
 use jni::JavaVM;
 
@@ -205,7 +207,7 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterOpen(
     row_group_max_size: jlong,
     max_dict_total_bytes: jint,
     max_dict_entries: jint,
-    stats_columns: jni::objects::JIntArray,
+    stats_columns: JObjectArray<'_>,
     page_size_threshold: jint,
 ) -> jlong {
     let raw_env = env.get_raw();
@@ -266,17 +268,31 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterOpen(
             cached_array_len: 0,
         };
 
-        let stats_cols: Vec<usize> = match env.get_array_length(&stats_columns) {
+        let stats_cols: Vec<String> = match env.get_array_length(&stats_columns) {
             Ok(len) if len > 0 => {
-                let mut buf = vec![0i32; len as usize];
-                if env
-                    .get_int_array_region(&stats_columns, 0, &mut buf)
-                    .is_ok()
-                {
-                    buf.iter().map(|&v| v as usize).collect()
-                } else {
-                    Vec::new()
+                let mut names = Vec::with_capacity(len as usize);
+                for i in 0..len {
+                    let obj = match env.get_object_array_element(&stats_columns, i) {
+                        Ok(o) => o,
+                        Err(_) => {
+                            throw(&mut env, "failed to read stats_columns element");
+                            return 0;
+                        }
+                    };
+                    let jstr = JString::from(obj);
+                    let s: String = match env.get_string(&jstr) {
+                        Ok(s) => s.into(),
+                        Err(_) => {
+                            throw(
+                                &mut env,
+                                "failed to convert stats_columns element to string",
+                            );
+                            return 0;
+                        }
+                    };
+                    names.push(s);
                 }
+                names
             }
             _ => Vec::new(),
         };
@@ -385,131 +401,130 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterNumRo
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupNumStats(
-    _env: JNIEnv,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatNames<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
     _class: JClass,
     handle: jlong,
     rg_index: jint,
-) -> jint {
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
     if handle == 0 {
-        return 0;
+        return null;
     }
     let writer = unsafe { &*(handle as *const WriterHandle) };
     let rg = rg_index as usize;
     if rg >= writer.inner.num_row_groups() {
-        return -1;
-    }
-    writer.inner.row_group_stats(rg).len() as jint
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatColumnIndex(
-    _env: JNIEnv,
-    _class: JClass,
-    handle: jlong,
-    rg_index: jint,
-    stat_index: jint,
-) -> jint {
-    if handle == 0 {
-        return -1;
-    }
-    let writer = unsafe { &*(handle as *const WriterHandle) };
-    let rg = rg_index as usize;
-    if rg >= writer.inner.num_row_groups() {
-        return -1;
+        return null;
     }
     let stats = writer.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return -1;
-    }
-    stats[idx].column_index as jint
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatNullCount(
-    _env: JNIEnv,
-    _class: JClass,
-    handle: jlong,
-    rg_index: jint,
-    stat_index: jint,
-) -> jlong {
-    if handle == 0 {
-        return 0;
-    }
-    let writer = unsafe { &*(handle as *const WriterHandle) };
-    let rg = rg_index as usize;
-    if rg >= writer.inner.num_row_groups() {
-        return 0;
-    }
-    let stats = writer.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return 0;
-    }
-    stats[idx].null_count as jlong
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatMin<'a>(
-    env: JNIEnv<'a>,
-    _class: JClass<'a>,
-    handle: jlong,
-    rg_index: jint,
-    stat_index: jint,
-) -> JByteArray<'a> {
-    if handle == 0 {
-        return JByteArray::default();
-    }
-    let writer = unsafe { &*(handle as *const WriterHandle) };
-    let rg = rg_index as usize;
-    if rg >= writer.inner.num_row_groups() {
-        return JByteArray::default();
-    }
-    let stats = writer.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return JByteArray::default();
-    }
-    let buf = match &stats[idx].min {
-        Some(v) => v.to_be_bytes(),
-        None => return JByteArray::default(),
+    let schema = writer.inner.schema();
+    let arr = match env.new_object_array(stats.len() as i32, "java/lang/String", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
     };
-    if buf.is_empty() {
-        return JByteArray::default();
+    for (i, st) in stats.iter().enumerate() {
+        let name = &schema.columns[st.column_index].name;
+        if let Ok(s) = env.new_string(name) {
+            let _ = env.set_object_array_element(&arr, i as i32, &s);
+        }
     }
-    env.byte_array_from_slice(&buf).unwrap_or_default()
+    arr
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatMax<'a>(
-    env: JNIEnv<'a>,
-    _class: JClass<'a>,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatNullCounts(
+    env: JNIEnv,
+    _class: JClass,
     handle: jlong,
     rg_index: jint,
-    stat_index: jint,
-) -> JByteArray<'a> {
+) -> jlongArray {
     if handle == 0 {
-        return JByteArray::default();
+        return std::ptr::null_mut();
     }
     let writer = unsafe { &*(handle as *const WriterHandle) };
     let rg = rg_index as usize;
     if rg >= writer.inner.num_row_groups() {
-        return JByteArray::default();
+        return std::ptr::null_mut();
     }
     let stats = writer.inner.row_group_stats(rg);
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return JByteArray::default();
+    let counts: Vec<jlong> = stats.iter().map(|s| s.null_count as jlong).collect();
+    match env.new_long_array(counts.len() as i32) {
+        Ok(arr) => {
+            let _ = env.set_long_array_region(&arr, 0, &counts);
+            arr.into_raw()
+        }
+        Err(_) => std::ptr::null_mut(),
     }
-    let buf = match &stats[idx].max {
-        Some(v) => v.to_be_bytes(),
-        None => return JByteArray::default(),
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatMins<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _class: JClass,
+    handle: jlong,
+    rg_index: jint,
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
+    if handle == 0 {
+        return null;
+    }
+    let writer = unsafe { &*(handle as *const WriterHandle) };
+    let rg = rg_index as usize;
+    if rg >= writer.inner.num_row_groups() {
+        return null;
+    }
+    let stats = writer.inner.row_group_stats(rg);
+    let arr = match env.new_object_array(stats.len() as i32, "[B", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
     };
-    if buf.is_empty() {
-        return JByteArray::default();
+    for (i, st) in stats.iter().enumerate() {
+        if let Some(v) = &st.min {
+            let bytes = v.to_be_bytes();
+            if let Ok(ba) = env.byte_array_from_slice(&bytes) {
+                let _ = env.set_object_array_element(&arr, i as i32, &ba);
+            }
+        }
     }
-    env.byte_array_from_slice(&buf).unwrap_or_default()
+    arr
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterRowGroupStatMaxs<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _class: JClass,
+    handle: jlong,
+    rg_index: jint,
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
+    if handle == 0 {
+        return null;
+    }
+    let writer = unsafe { &*(handle as *const WriterHandle) };
+    let rg = rg_index as usize;
+    if rg >= writer.inner.num_row_groups() {
+        return null;
+    }
+    let stats = writer.inner.row_group_stats(rg);
+    let arr = match env.new_object_array(stats.len() as i32, "[B", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
+    };
+    for (i, st) in stats.iter().enumerate() {
+        if let Some(v) = &st.max {
+            let bytes = v.to_be_bytes();
+            if let Ok(ba) = env.byte_array_from_slice(&bytes) {
+                let _ = env.set_object_array_element(&arr, i as i32, &ba);
+            }
+        }
+    }
+    arr
 }
 
 // ======================== Writer.writeBatch (Arrow C Data Interface) ========================
@@ -715,53 +730,52 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpenR
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpenRowGroupProjected(
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderSetProjection(
     mut env: JNIEnv,
     _class: JClass,
     handle: jlong,
-    rg_index: jint,
-    columns: JIntArray,
-) -> jlong {
+    columns: JObjectArray,
+) {
     let raw_env = env.get_raw();
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         if handle == 0 {
             throw(&mut env, "null reader handle");
-            return 0;
+            return;
         }
-        let rh = unsafe { &*(handle as *const ReaderHandle) };
-        let col_indices: Vec<usize> = match env.get_array_length(&columns) {
+        let rh = unsafe { &mut *(handle as *mut ReaderHandle) };
+        let col_names: Vec<String> = match env.get_array_length(&columns) {
             Ok(len) if len > 0 => {
-                let mut buf = vec![0i32; len as usize];
-                if env.get_int_array_region(&columns, 0, &mut buf).is_ok() {
-                    buf.iter().map(|&v| v as usize).collect()
-                } else {
-                    throw(&mut env, "failed to read columns array");
-                    return 0;
+                let mut names = Vec::with_capacity(len as usize);
+                for i in 0..len {
+                    let obj = match env.get_object_array_element(&columns, i) {
+                        Ok(o) => o,
+                        Err(_) => {
+                            throw(&mut env, "failed to read columns array element");
+                            return;
+                        }
+                    };
+                    let jstr = JString::from(obj);
+                    let s: String = match env.get_string(&jstr) {
+                        Ok(js) => js.into(),
+                        Err(_) => {
+                            throw(&mut env, "failed to convert column name to string");
+                            return;
+                        }
+                    };
+                    names.push(s);
                 }
+                names
             }
             _ => Vec::new(),
         };
-        match rh
-            .reader
-            .row_group_reader_projected(rg_index as usize, &col_indices)
-        {
-            Ok(rg) => {
-                let rg_handle = Box::new(RowGroupReaderHandle { inner: rg });
-                Box::into_raw(rg_handle) as jlong
-            }
-            Err(e) => {
-                throw(&mut env, &format!("open row group projected failed: {}", e));
-                0
-            }
+        let col_refs: Vec<&str> = col_names.iter().map(|s| s.as_str()).collect();
+        if let Err(e) = rh.reader.project(&col_refs) {
+            throw(&mut env, &format!("set projection failed: {}", e));
         }
     }));
-    match result {
-        Ok(val) => val,
-        Err(e) => {
-            let mut env = unsafe { JNIEnv::from_raw(raw_env).unwrap() };
-            throw(&mut env, &panic_message(&e));
-            0
-        }
+    if let Err(e) = result {
+        let mut env = unsafe { JNIEnv::from_raw(raw_env).unwrap() };
+        throw(&mut env, &panic_message(&e));
     }
 }
 
@@ -813,126 +827,126 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGr
 // ======================== Row Group Stats ========================
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupNumStats(
-    _env: JNIEnv,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatNames<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
     _class: JClass,
     handle: jlong,
     rg_index: jint,
-) -> jint {
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
     if handle == 0 {
-        return 0;
+        return null;
     }
     let rh = unsafe { &*(handle as *const ReaderHandle) };
-    match rh.reader.row_group_stats(rg_index as usize) {
-        Ok(s) => s.len() as jint,
-        Err(_) => -1,
+    let stats = match rh.reader.row_group_stats(rg_index as usize) {
+        Ok(s) => s,
+        Err(_) => return null,
+    };
+    let schema = rh.reader.schema();
+    let arr = match env.new_object_array(stats.len() as i32, "java/lang/String", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
+    };
+    for (i, st) in stats.iter().enumerate() {
+        let name = &schema.columns[st.column_index].name;
+        if let Ok(s) = env.new_string(name) {
+            let _ = env.set_object_array_element(&arr, i as i32, &s);
+        }
     }
+    arr
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatColumnIndex(
-    _env: JNIEnv,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatNullCounts(
+    env: JNIEnv,
     _class: JClass,
     handle: jlong,
     rg_index: jint,
-    stat_index: jint,
-) -> jint {
+) -> jlongArray {
     if handle == 0 {
-        return -1;
+        return std::ptr::null_mut();
     }
     let rh = unsafe { &*(handle as *const ReaderHandle) };
     let stats = match rh.reader.row_group_stats(rg_index as usize) {
         Ok(s) => s,
-        Err(_) => return -1,
+        Err(_) => return std::ptr::null_mut(),
     };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return -1;
+    let counts: Vec<jlong> = stats.iter().map(|s| s.null_count as jlong).collect();
+    match env.new_long_array(counts.len() as i32) {
+        Ok(arr) => {
+            let _ = env.set_long_array_region(&arr, 0, &counts);
+            arr.into_raw()
+        }
+        Err(_) => std::ptr::null_mut(),
     }
-    stats[idx].column_index as jint
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatNullCount(
-    _env: JNIEnv,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMins<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
     _class: JClass,
     handle: jlong,
     rg_index: jint,
-    stat_index: jint,
-) -> jlong {
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
     if handle == 0 {
-        return 0;
+        return null;
     }
     let rh = unsafe { &*(handle as *const ReaderHandle) };
     let stats = match rh.reader.row_group_stats(rg_index as usize) {
         Ok(s) => s,
-        Err(_) => return -1,
+        Err(_) => return null,
     };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return 0;
+    let arr = match env.new_object_array(stats.len() as i32, "[B", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
+    };
+    for (i, st) in stats.iter().enumerate() {
+        if let Some(v) = &st.min {
+            let bytes = v.to_be_bytes();
+            if let Ok(ba) = env.byte_array_from_slice(&bytes) {
+                let _ = env.set_object_array_element(&arr, i as i32, &ba);
+            }
+        }
     }
-    stats[idx].null_count as jlong
+    arr
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMin<'a>(
-    env: JNIEnv<'a>,
-    _class: JClass<'a>,
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMaxs<
+    'local,
+>(
+    mut env: JNIEnv<'local>,
+    _class: JClass,
     handle: jlong,
     rg_index: jint,
-    stat_index: jint,
-) -> JByteArray<'a> {
+) -> JObjectArray<'local> {
+    let null = JObjectArray::default();
     if handle == 0 {
-        return JByteArray::default();
+        return null;
     }
     let rh = unsafe { &*(handle as *const ReaderHandle) };
     let stats = match rh.reader.row_group_stats(rg_index as usize) {
         Ok(s) => s,
-        Err(_) => return JByteArray::default(),
+        Err(_) => return null,
     };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return JByteArray::default();
-    }
-    let buf = match &stats[idx].min {
-        Some(v) => v.to_be_bytes(),
-        None => return JByteArray::default(),
+    let arr = match env.new_object_array(stats.len() as i32, "[B", &JObject::null()) {
+        Ok(a) => a,
+        Err(_) => return null,
     };
-    if buf.is_empty() {
-        return JByteArray::default();
+    for (i, st) in stats.iter().enumerate() {
+        if let Some(v) = &st.max {
+            let bytes = v.to_be_bytes();
+            if let Ok(ba) = env.byte_array_from_slice(&bytes) {
+                let _ = env.set_object_array_element(&arr, i as i32, &ba);
+            }
+        }
     }
-    env.byte_array_from_slice(&buf).unwrap_or_default()
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderRowGroupStatMax<'a>(
-    env: JNIEnv<'a>,
-    _class: JClass<'a>,
-    handle: jlong,
-    rg_index: jint,
-    stat_index: jint,
-) -> JByteArray<'a> {
-    if handle == 0 {
-        return JByteArray::default();
-    }
-    let rh = unsafe { &*(handle as *const ReaderHandle) };
-    let stats = match rh.reader.row_group_stats(rg_index as usize) {
-        Ok(s) => s,
-        Err(_) => return JByteArray::default(),
-    };
-    let idx = stat_index as usize;
-    if idx >= stats.len() {
-        return JByteArray::default();
-    }
-    let buf = match &stats[idx].max {
-        Some(v) => v.to_be_bytes(),
-        None => return JByteArray::default(),
-    };
-    if buf.is_empty() {
-        return JByteArray::default();
-    }
-    env.byte_array_from_slice(&buf).unwrap_or_default()
+    arr
 }
 
 // ======================== Columnar Read (Arrow C Data Interface) ========================

--- a/python/mosaic/_ffi.py
+++ b/python/mosaic/_ffi.py
@@ -118,7 +118,7 @@ class MosaicWriterOptions(Structure):
         ("row_group_max_size", c_uint64),
         ("max_dict_total_bytes", c_uint32),
         ("max_dict_entries", c_uint32),
-        ("stats_columns", POINTER(c_uint32)),
+        ("stats_columns", POINTER(c_char_p)),
         ("num_stats_columns", c_uint32),
         ("page_size_threshold", c_uint32),
     ]
@@ -154,17 +154,13 @@ lib.mosaic_writer_num_row_groups.restype = c_int
 lib.mosaic_writer_row_group_num_stats.argtypes = [c_void_p, c_uint32, POINTER(c_uint32)]
 lib.mosaic_writer_row_group_num_stats.restype = c_int
 
-lib.mosaic_writer_row_group_stat_column_index.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_uint32)]
-lib.mosaic_writer_row_group_stat_column_index.restype = c_int
-
-lib.mosaic_writer_row_group_stat_null_count.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_uint64)]
-lib.mosaic_writer_row_group_stat_null_count.restype = c_int
-
-lib.mosaic_writer_row_group_stat_min.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_size_t)]
-lib.mosaic_writer_row_group_stat_min.restype = POINTER(c_uint8)
-
-lib.mosaic_writer_row_group_stat_max.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_size_t)]
-lib.mosaic_writer_row_group_stat_max.restype = POINTER(c_uint8)
+lib.mosaic_writer_row_group_stats.argtypes = [
+    c_void_p, c_uint32,
+    POINTER(c_char_p), POINTER(c_uint64),
+    POINTER(POINTER(c_uint8)), POINTER(c_size_t),
+    POINTER(POINTER(c_uint8)), POINTER(c_size_t),
+]
+lib.mosaic_writer_row_group_stats.restype = c_int
 
 # ======================== Reader ========================
 
@@ -185,10 +181,10 @@ lib.mosaic_reader_num_row_groups.restype = c_int
 lib.mosaic_reader_open_row_group.argtypes = [c_void_p, c_uint32]
 lib.mosaic_reader_open_row_group.restype = c_void_p
 
-lib.mosaic_reader_open_row_group_projected.argtypes = [
-    c_void_p, c_uint32, POINTER(c_uint32), c_uint32,
+lib.mosaic_reader_set_projection.argtypes = [
+    c_void_p, POINTER(c_char_p), c_uint32,
 ]
-lib.mosaic_reader_open_row_group_projected.restype = c_void_p
+lib.mosaic_reader_set_projection.restype = c_int32
 
 lib.mosaic_row_group_reader_free.argtypes = [c_void_p]
 lib.mosaic_row_group_reader_free.restype = None
@@ -223,17 +219,13 @@ lib.mosaic_reader_row_group_num_rows.restype = c_int
 lib.mosaic_reader_row_group_num_stats.argtypes = [c_void_p, c_uint32, POINTER(c_uint32)]
 lib.mosaic_reader_row_group_num_stats.restype = c_int
 
-lib.mosaic_reader_row_group_stat_column_index.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_uint32)]
-lib.mosaic_reader_row_group_stat_column_index.restype = c_int
-
-lib.mosaic_reader_row_group_stat_null_count.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_uint64)]
-lib.mosaic_reader_row_group_stat_null_count.restype = c_int
-
-lib.mosaic_reader_row_group_stat_min.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_size_t)]
-lib.mosaic_reader_row_group_stat_min.restype = POINTER(c_uint8)
-
-lib.mosaic_reader_row_group_stat_max.argtypes = [c_void_p, c_uint32, c_uint32, POINTER(c_size_t)]
-lib.mosaic_reader_row_group_stat_max.restype = POINTER(c_uint8)
+lib.mosaic_reader_row_group_stats.argtypes = [
+    c_void_p, c_uint32,
+    POINTER(c_char_p), POINTER(c_uint64),
+    POINTER(POINTER(c_uint8)), POINTER(c_size_t),
+    POINTER(POINTER(c_uint8)), POINTER(c_size_t),
+]
+lib.mosaic_reader_row_group_stats.restype = c_int
 
 # ======================== Error ========================
 

--- a/python/mosaic/mosaic.py
+++ b/python/mosaic/mosaic.py
@@ -59,6 +59,32 @@ def _check_error(msg="operation failed"):
     raise RuntimeError(msg)
 
 
+def _fetch_rg_stats(num_stats_fn, stats_fn, handle, rg_index):
+    n_out = ctypes.c_uint32(0)
+    rc = num_stats_fn(handle, rg_index, ctypes.byref(n_out))
+    if rc != 0:
+        _check_error("num_stats failed")
+    n = n_out.value
+    if n == 0:
+        return {}
+    names = (ctypes.c_char_p * n)()
+    null_counts = (ctypes.c_uint64 * n)()
+    min_ptrs = (ctypes.POINTER(ctypes.c_uint8) * n)()
+    min_lens = (ctypes.c_size_t * n)()
+    max_ptrs = (ctypes.POINTER(ctypes.c_uint8) * n)()
+    max_lens = (ctypes.c_size_t * n)()
+    rc = stats_fn(handle, rg_index, names, null_counts, min_ptrs, min_lens, max_ptrs, max_lens)
+    if rc != 0:
+        _check_error("row_group_stats failed")
+    result = {}
+    for i in range(n):
+        col_name = names[i].decode("utf-8")
+        min_val = ctypes.string_at(min_ptrs[i], min_lens[i]) if min_ptrs[i] and min_lens[i] > 0 else None
+        max_val = ctypes.string_at(max_ptrs[i], max_lens[i]) if max_ptrs[i] and max_lens[i] > 0 else None
+        result[col_name] = ColumnStatistics(null_counts[i], min_val, max_val)
+    return result
+
+
 class WriterOptions:
     COMPRESSION_NONE = 0
     COMPRESSION_ZSTD = 1
@@ -93,8 +119,10 @@ class WriterOptions:
         opts.max_dict_entries = self.max_dict_entries
         refs = []
         if self.stats_columns:
-            arr = (ctypes.c_uint32 * len(self.stats_columns))(*self.stats_columns)
+            encoded = [s.encode("utf-8") for s in self.stats_columns]
+            arr = (ctypes.c_char_p * len(encoded))(*encoded)
             refs.append(arr)
+            refs.append(encoded)
             opts.stats_columns = arr
             opts.num_stats_columns = len(self.stats_columns)
         else:
@@ -105,6 +133,12 @@ class WriterOptions:
 
 
 class MosaicWriter:
+    """Columns are stored in name-sorted order regardless of input schema order.
+
+    The reader returns columns in storage (name-sorted) order by default;
+    use :meth:`MosaicReader.project` to control output column order.
+    """
+
     def __init__(self, stream, schema, options=None):
         if not isinstance(schema, pa.Schema):
             raise TypeError(f"expected pyarrow.Schema, got {type(schema)}")
@@ -195,11 +229,7 @@ class MosaicWriter:
         return len(self._row_group_stats)
 
     def get_row_group_statistics(self, rg_index):
-        """Returns column statistics for the given row group.
-
-        The returned list follows the same order as the stats_columns
-        specified in WriterOptions.
-        """
+        """Returns column statistics for the given row group, keyed by column name."""
         if self._row_group_stats is None:
             raise RuntimeError("writer is not closed yet")
         return self._row_group_stats[rg_index]
@@ -221,26 +251,10 @@ class MosaicWriter:
         lib.mosaic_writer_num_row_groups(self._handle, ctypes.byref(n_rg))
         all_stats = []
         for rg in range(n_rg.value):
-            n_stats = ctypes.c_uint32(0)
-            lib.mosaic_writer_row_group_num_stats(self._handle, rg, ctypes.byref(n_stats))
-            rg_stats = []
-            for i in range(n_stats.value):
-                col_idx = ctypes.c_uint32(0)
-                null_count = ctypes.c_uint64(0)
-                lib.mosaic_writer_row_group_stat_column_index(
-                    self._handle, rg, i, ctypes.byref(col_idx))
-                lib.mosaic_writer_row_group_stat_null_count(
-                    self._handle, rg, i, ctypes.byref(null_count))
-                min_len = ctypes.c_size_t(0)
-                max_len = ctypes.c_size_t(0)
-                min_ptr = lib.mosaic_writer_row_group_stat_min(
-                    self._handle, rg, i, ctypes.byref(min_len))
-                max_ptr = lib.mosaic_writer_row_group_stat_max(
-                    self._handle, rg, i, ctypes.byref(max_len))
-                min_val = bytes(min_ptr[:min_len.value]) if min_ptr and min_len.value > 0 else None
-                max_val = bytes(max_ptr[:max_len.value]) if max_ptr and max_len.value > 0 else None
-                rg_stats.append(ColumnStatistics(col_idx.value, null_count.value, min_val, max_val))
-            all_stats.append(rg_stats)
+            all_stats.append(_fetch_rg_stats(
+                lib.mosaic_writer_row_group_num_stats,
+                lib.mosaic_writer_row_group_stats,
+                self._handle, rg))
         self._row_group_stats = all_stats
 
     def __enter__(self):
@@ -254,8 +268,7 @@ class MosaicWriter:
 
 
 class ColumnStatistics:
-    def __init__(self, column_index, null_count, min, max):
-        self.column_index = column_index
+    def __init__(self, null_count, min, max):
         self.null_count = null_count
         self.min = min
         self.max = max
@@ -266,6 +279,11 @@ class ColumnStatistics:
 
 
 class MosaicReader:
+    """Schema and output columns are in storage order (name-sorted).
+
+    Use :meth:`project` to select and reorder output columns.
+    """
+
     def __init__(self, handle, refs=None):
         self._handle = handle
         self._refs = refs
@@ -321,14 +339,16 @@ class MosaicReader:
             _check_error("num_row_groups failed")
         return out.value
 
-    def read_row_group(self, rg_index, columns=None):
-        if columns is not None:
-            arr = (ctypes.c_uint32 * len(columns))(*columns)
-            rg_handle = lib.mosaic_reader_open_row_group_projected(
-                self._handle, rg_index, arr, len(columns),
-            )
-        else:
-            rg_handle = lib.mosaic_reader_open_row_group(self._handle, rg_index)
+    def project(self, columns):
+        """Set projection on the reader. Subsequent reads only return the named columns."""
+        c_strs = [c.encode("utf-8") for c in columns]
+        arr = (ctypes.c_char_p * len(columns))(*c_strs)
+        rc = lib.mosaic_reader_set_projection(self._handle, arr, len(columns))
+        if rc != 0:
+            _check_error("set_projection failed")
+
+    def read_row_group(self, rg_index):
+        rg_handle = lib.mosaic_reader_open_row_group(self._handle, rg_index)
         if not rg_handle:
             _check_error(f"failed to open row group {rg_index}")
         rb_handle = lib.mosaic_row_group_reader_read_columns(rg_handle)
@@ -351,16 +371,13 @@ class MosaicReader:
         finally:
             lib.mosaic_record_batch_free(rb_handle)
 
-    def read_all(self, columns=None):
+    def read_all(self):
         batches = []
         for rg in range(self.num_row_groups):
-            batches.append(self.read_row_group(rg, columns=columns))
+            batches.append(self.read_row_group(rg))
         if batches:
             return pa.Table.from_batches(batches, schema=batches[0].schema)
-        schema = self._schema
-        if columns is not None:
-            schema = pa.schema([self._schema.field(i) for i in columns])
-        return pa.Table.from_batches([], schema=schema)
+        return pa.Table.from_batches([], schema=self._schema)
 
     def row_group_num_rows(self, rg_index):
         out = ctypes.c_uint32(0)
@@ -370,40 +387,11 @@ class MosaicReader:
         return out.value
 
     def get_row_group_statistics(self, rg_index):
-        """Returns column statistics for the given row group.
-
-        The returned list follows the same order as the stats_columns
-        specified in WriterOptions when the file was written.
-        """
-        n_out = ctypes.c_uint32(0)
-        rc = lib.mosaic_reader_row_group_num_stats(self._handle, rg_index, ctypes.byref(n_out))
-        if rc != 0:
-            _check_error("row_group_num_stats failed")
-        n = n_out.value
-        result = []
-        for i in range(n):
-            col_idx_out = ctypes.c_uint32(0)
-            rc = lib.mosaic_reader_row_group_stat_column_index(
-                self._handle, rg_index, i, ctypes.byref(col_idx_out)
-            )
-            if rc != 0:
-                _check_error("stat_column_index failed")
-            col_idx = col_idx_out.value
-            null_count_out = ctypes.c_uint64(0)
-            rc = lib.mosaic_reader_row_group_stat_null_count(
-                self._handle, rg_index, i, ctypes.byref(null_count_out)
-            )
-            if rc != 0:
-                _check_error("stat_null_count failed")
-            null_count = null_count_out.value
-            out_len = ctypes.c_size_t(0)
-            ptr = lib.mosaic_reader_row_group_stat_min(self._handle, rg_index, i, ctypes.byref(out_len))
-            min_val = ctypes.string_at(ptr, out_len.value) if ptr and out_len.value > 0 else None
-            out_len = ctypes.c_size_t(0)
-            ptr = lib.mosaic_reader_row_group_stat_max(self._handle, rg_index, i, ctypes.byref(out_len))
-            max_val = ctypes.string_at(ptr, out_len.value) if ptr and out_len.value > 0 else None
-            result.append(ColumnStatistics(col_idx, null_count, min_val, max_val))
-        return result
+        """Returns column statistics for the given row group, keyed by column name."""
+        return _fetch_rg_stats(
+            lib.mosaic_reader_row_group_num_stats,
+            lib.mosaic_reader_row_group_stats,
+            self._handle, rg_index)
 
     def close(self):
         if self._handle:
@@ -432,4 +420,6 @@ def write_table(table, stream, options=None):
 
 def read_table(read_at_fn, file_length, columns=None):
     with MosaicReader.from_input_file(read_at_fn, file_length) as reader:
-        return reader.read_all(columns=columns)
+        if columns:
+            reader.project(columns)
+        return reader.read_all()

--- a/python/tests/test_mosaic.py
+++ b/python/tests/test_mosaic.py
@@ -348,12 +348,11 @@ class TestProjection:
         data = _write_to_bytes(pa_schema, batch, opts)
 
         with _reader_from_bytes(data) as reader:
-            a_col = reader.schema.get_field_index("a")
-            b_col = reader.schema.get_field_index("b")
+            reader.project(["a", "b"])
 
             total_rows = 0
             for rg in range(reader.num_row_groups):
-                rb = reader.read_row_group(rg, columns=[a_col, b_col])
+                rb = reader.read_row_group(rg)
                 assert rb.num_columns == 2
                 total_rows += rb.num_rows
 
@@ -380,10 +379,64 @@ class TestProjection:
         data = _write_to_bytes(pa_schema, batch)
 
         with _reader_from_bytes(data) as reader:
-            b_col = reader.schema.get_field_index("b")
-            rb = reader.read_row_group(0, columns=[b_col])
+            reader.project(["b"])
+            rb = reader.read_row_group(0)
             assert rb.num_columns == 1
             assert rb.num_rows == 10
+
+    def test_projection_preserves_order(self):
+        pa_schema = pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.utf8()),
+                pa.field("c", pa.float64()),
+            ]
+        )
+
+        batch = pa.record_batch(
+            [
+                pa.array(list(range(10)), type=pa.int32()),
+                pa.array([f"s{i}" for i in range(10)]),
+                pa.array([float(i) * 0.5 for i in range(10)]),
+            ],
+            names=["a", "b", "c"],
+        )
+
+        opts = WriterOptions(num_buckets=2)
+        data = _write_to_bytes(pa_schema, batch, opts)
+
+        with _reader_from_bytes(data) as reader:
+            reader.project(["c", "a", "b"])
+            rb = reader.read_row_group(0)
+            assert rb.num_columns == 3
+            assert rb.schema.names == ["c", "a", "b"]
+            assert rb.column("c").to_pylist() == [i * 0.5 for i in range(10)]
+            assert rb.column("a").to_pylist() == list(range(10))
+            assert rb.column("b").to_pylist() == [f"s{i}" for i in range(10)]
+
+    def test_projection_empty(self):
+        pa_schema = pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.utf8()),
+            ]
+        )
+
+        batch = pa.record_batch(
+            [
+                pa.array(list(range(5)), type=pa.int32()),
+                pa.array([f"v{i}" for i in range(5)]),
+            ],
+            names=["a", "b"],
+        )
+
+        data = _write_to_bytes(pa_schema, batch)
+
+        with _reader_from_bytes(data) as reader:
+            reader.project([])
+            rb = reader.read_row_group(0)
+            assert rb.num_columns == 0
+            assert rb.num_rows == 5
 
 
 class TestSchema:
@@ -436,16 +489,17 @@ class TestStatistics:
             names=["id", "name", "score"],
         )
 
-        opts = WriterOptions(stats_columns=[0, 2])
+        opts = WriterOptions(stats_columns=["id", "score"])
         data = _write_to_bytes(pa_schema, batch, opts)
 
         with _reader_from_bytes(data) as reader:
             for rg in range(reader.num_row_groups):
                 stats = reader.get_row_group_statistics(rg)
                 assert len(stats) > 0
-                for stat in stats:
+                assert isinstance(stats, dict)
+                for name, stat in stats.items():
                     assert isinstance(stat, ColumnStatistics)
-                    assert stat.column_index in (0, 2)
+                    assert name in ("id", "score")
                     assert stat.null_count == 0
                     assert stat.has_min_max
                     assert stat.min is not None
@@ -453,7 +507,7 @@ class TestStatistics:
                     assert len(stat.min) > 0
                     assert len(stat.max) > 0
 
-                id_stat = next(s for s in stats if s.column_index == 0)
+                id_stat = stats["id"]
                 min_id = struct.unpack(">i", id_stat.min)[0]
                 max_id = struct.unpack(">i", id_stat.max)[0]
                 assert min_id == 0
@@ -472,14 +526,14 @@ class TestStatistics:
             names=["a", "b"],
         )
 
-        opts = WriterOptions(stats_columns=[0, 1], num_buckets=1)
+        opts = WriterOptions(stats_columns=["a", "b"], num_buckets=1)
         data = _write_to_bytes(pa_schema, batch, opts)
 
         with _reader_from_bytes(data) as reader:
             stats = reader.get_row_group_statistics(0)
             assert len(stats) == 2
 
-            a_stat = next(s for s in stats if s.column_index == 0)
+            a_stat = stats["a"]
             assert a_stat.null_count == 1
             assert a_stat.has_min_max
             min_a = struct.unpack(">i", a_stat.min)[0]
@@ -487,7 +541,7 @@ class TestStatistics:
             assert min_a == 5
             assert max_a == 20
 
-            b_stat = next(s for s in stats if s.column_index == 1)
+            b_stat = stats["b"]
             assert b_stat.null_count == 2
             assert b_stat.has_min_max
             min_b = struct.unpack(">q", b_stat.min)[0]
@@ -502,16 +556,16 @@ class TestStatistics:
             [pa.array([None, None, None], type=pa.int32())], names=["x"]
         )
 
-        opts = WriterOptions(stats_columns=[0], num_buckets=1)
+        opts = WriterOptions(stats_columns=["x"], num_buckets=1)
         data = _write_to_bytes(pa_schema, batch, opts)
 
         with _reader_from_bytes(data) as reader:
             stats = reader.get_row_group_statistics(0)
             assert len(stats) == 1
-            assert stats[0].null_count == 3
-            assert not stats[0].has_min_max
-            assert stats[0].min is None
-            assert stats[0].max is None
+            assert stats["x"].null_count == 3
+            assert not stats["x"].has_min_max
+            assert stats["x"].min is None
+            assert stats["x"].max is None
 
 
 class TestConvenience:
@@ -607,7 +661,7 @@ class TestWriter:
             names=["id", "name", "score"],
         )
 
-        opts = WriterOptions(stats_columns=[0, 2])
+        opts = WriterOptions(stats_columns=["id", "score"])
         buf = io.BytesIO()
         writer = MosaicWriter(buf, pa_schema, opts)
         writer.write(batch)
@@ -616,15 +670,16 @@ class TestWriter:
         assert writer.num_row_groups >= 1
         stats = writer.get_row_group_statistics(0)
         assert len(stats) > 0
-        for stat in stats:
+        assert isinstance(stats, dict)
+        for name, stat in stats.items():
             assert isinstance(stat, ColumnStatistics)
-            assert stat.column_index in (0, 2)
+            assert name in ("id", "score")
             assert stat.null_count == 0
             assert stat.has_min_max
             assert stat.min is not None
             assert stat.max is not None
 
-        id_stat = next(s for s in stats if s.column_index == 0)
+        id_stat = stats["id"]
         min_id = struct.unpack(">i", id_stat.min)[0]
         max_id = struct.unpack(">i", id_stat.max)[0]
         assert min_id == 0
@@ -643,7 +698,7 @@ class TestWriter:
             names=["a", "b"],
         )
 
-        opts = WriterOptions(stats_columns=[0, 1], num_buckets=1)
+        opts = WriterOptions(stats_columns=["a", "b"], num_buckets=1)
         buf = io.BytesIO()
         writer = MosaicWriter(buf, pa_schema, opts)
         writer.write(batch)
@@ -653,7 +708,7 @@ class TestWriter:
         stats = writer.get_row_group_statistics(0)
         assert len(stats) == 2
 
-        a_stat = next(s for s in stats if s.column_index == 0)
+        a_stat = stats["a"]
         assert a_stat.null_count == 1
         assert a_stat.has_min_max
         min_a = struct.unpack(">i", a_stat.min)[0]
@@ -661,7 +716,7 @@ class TestWriter:
         assert min_a == 5
         assert max_a == 20
 
-        b_stat = next(s for s in stats if s.column_index == 1)
+        b_stat = stats["b"]
         assert b_stat.null_count == 2
         assert b_stat.has_min_max
         min_b = struct.unpack(">q", b_stat.min)[0]
@@ -676,7 +731,7 @@ class TestWriter:
             [pa.array([None, None, None], type=pa.int32())], names=["x"]
         )
 
-        opts = WriterOptions(stats_columns=[0], num_buckets=1)
+        opts = WriterOptions(stats_columns=["x"], num_buckets=1)
         buf = io.BytesIO()
         writer = MosaicWriter(buf, pa_schema, opts)
         writer.write(batch)
@@ -685,10 +740,10 @@ class TestWriter:
         assert writer.num_row_groups == 1
         stats = writer.get_row_group_statistics(0)
         assert len(stats) == 1
-        assert stats[0].null_count == 3
-        assert not stats[0].has_min_max
-        assert stats[0].min is None
-        assert stats[0].max is None
+        assert stats["x"].null_count == 3
+        assert not stats["x"].has_min_max
+        assert stats["x"].min is None
+        assert stats["x"].max is None
 
     def test_writer_stats_matches_reader_stats(self):
         pa_schema = pa.schema(
@@ -706,7 +761,7 @@ class TestWriter:
             names=["id", "score"],
         )
 
-        opts = WriterOptions(stats_columns=[0, 1], num_buckets=1)
+        opts = WriterOptions(stats_columns=["id", "score"], num_buckets=1)
         buf = io.BytesIO()
         writer = MosaicWriter(buf, pa_schema, opts)
         writer.write(batch)
@@ -718,12 +773,12 @@ class TestWriter:
                 w_stats = writer.get_row_group_statistics(rg)
                 r_stats = reader.get_row_group_statistics(rg)
                 assert len(w_stats) == len(r_stats)
-                for ws, rs in zip(w_stats, r_stats):
-                    assert ws.column_index == rs.column_index
-                    assert ws.null_count == rs.null_count
-                    assert ws.has_min_max == rs.has_min_max
-                    assert ws.min == rs.min
-                    assert ws.max == rs.max
+                assert set(w_stats.keys()) == set(r_stats.keys())
+                for name in w_stats:
+                    assert w_stats[name].null_count == r_stats[name].null_count
+                    assert w_stats[name].has_min_max == r_stats[name].has_min_max
+                    assert w_stats[name].min == r_stats[name].min
+                    assert w_stats[name].max == r_stats[name].max
 
     def test_row_group_num_rows(self):
         pa_schema = pa.schema(


### PR DESCRIPTION
- Remove globalColumnIndex from schema serialization; columns are now always stored and returned in name-sorted order
- Add reader-level project(column_names) API that controls output column order (supports empty projection for count-only reads)
- Replace per-element stat FFI/JNI calls with batch array methods (4 arrays: names, null_counts, mins, maxs) to reduce crossing overhead
- Stats API returns Map<String, ColumnStatistics> keyed by column name (Java/Python) or vector<ColumnStatistics> with column_name field (C++)
- WriterOptions.stats_columns now takes column names instead of indices
- Add projection order and empty projection tests across all languages
- Update all API docs and C++ tests to reflect the new interfaces