### PR TITLE
fix: schema layout version compatibility

### DIFF
--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -264,7 +264,7 @@ impl<I: InputFile> MosaicReader<I> {
         }
 
         let version = footer[25];
-        if version != VERSION {
+        if version != LEGACY_VERSION && version != VERSION {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unsupported version: {}", version),
@@ -321,7 +321,7 @@ impl<I: InputFile> MosaicReader<I> {
             }
         };
 
-        let schema = MosaicSchema::deserialize(&schema_raw)?;
+        let schema = MosaicSchema::deserialize_for_version(version, &schema_raw)?;
 
         if schema.num_buckets != num_buckets {
             return Err(io::Error::new(

--- a/core/src/schema.rs
+++ b/core/src/schema.rs
@@ -25,6 +25,11 @@ use crate::spec;
 use crate::types;
 use crate::varint;
 
+const NAME_ENCODING_FRONT_CODE: u8 = 0;
+const NAME_ENCODING_BPE: u8 = 1;
+const SCHEMA_LAYOUT_V2: u8 = 2;
+type BpeRules = Vec<[u8; 2]>;
+
 #[derive(Debug, Clone)]
 pub struct ColumnMeta {
     pub name: String,
@@ -39,7 +44,7 @@ pub struct MosaicSchema {
     pub columns: Vec<ColumnMeta>,
     /// bucket_to_global[bucket_id] = [global_col_indices...] in name-sorted order
     pub bucket_to_global: Vec<Vec<usize>>,
-    /// original_order[orig_pos] = sorted_pos. Used as default output order when no projection is set.
+    /// Column indices used as default output order when no projection is set.
     pub original_order: Vec<usize>,
 }
 
@@ -100,90 +105,36 @@ impl MosaicSchema {
     }
 
     pub fn deserialize(data: &[u8]) -> io::Result<Self> {
-        let mut pos = 0;
-        let num_columns = varint::decode(data, &mut pos)? as usize;
-        let num_buckets = varint::decode(data, &mut pos)? as usize;
-
-        if num_buckets == 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "schema: num_buckets must be > 0",
-            ));
-        }
-
-        if pos >= data.len() {
-            return Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "schema: missing name encoding byte",
-            ));
-        }
-        let name_encoding = data[pos];
-        pos += 1;
-
-        let bpe_rules: Option<Vec<[u8; 2]>> = if name_encoding == 1 {
-            let num_rules = varint::decode(data, &mut pos)? as usize;
-            let mut rules = Vec::with_capacity(num_rules);
-            for _ in 0..num_rules {
-                if pos + 2 > data.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "schema: truncated BPE rules",
-                    ));
-                }
-                let left = data[pos];
-                let right = data[pos + 1];
-                pos += 2;
-                rules.push([left, right]);
-            }
-            Some(rules)
+        if has_current_layout_marker(data)? {
+            Self::deserialize_current(data)
         } else {
-            None
-        };
+            Self::deserialize_legacy(data)
+        }
+    }
+
+    pub(crate) fn deserialize_for_version(version: u8, data: &[u8]) -> io::Result<Self> {
+        match version {
+            spec::LEGACY_VERSION => Self::deserialize_legacy(data),
+            spec::VERSION => Self::deserialize_current(data),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported version: {}", version),
+            )),
+        }
+    }
+
+    fn deserialize_current(data: &[u8]) -> io::Result<Self> {
+        let mut pos = 0;
+        let (num_columns, num_buckets, bpe_rules) = read_header(data, &mut pos, true)?;
 
         let mut columns = Vec::with_capacity(num_columns);
         let mut bucket_to_global = vec![Vec::new(); num_buckets];
-        let mut prev_encoded: Vec<u8> = Vec::new();
+        let mut name_decoder = NameDecoder::new(bpe_rules);
         let mut seen_names = std::collections::HashSet::with_capacity(num_columns);
 
         for sorted_pos in 0..num_columns {
-            let shared = varint::decode(data, &mut pos)? as usize;
-            let suffix_len = varint::decode(data, &mut pos)? as usize;
-
-            if shared > prev_encoded.len() || pos + suffix_len > data.len() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "schema: corrupted column name encoding",
-                ));
-            }
-            let mut encoded = Vec::with_capacity(shared + suffix_len);
-            encoded.extend_from_slice(&prev_encoded[..shared]);
-            encoded.extend_from_slice(&data[pos..pos + suffix_len]);
-            pos += suffix_len;
-            prev_encoded = encoded.clone();
-
-            let name_bytes = match &bpe_rules {
-                Some(rules) => bpe::decode(&encoded, rules),
-                None => encoded,
-            };
-            let name = String::from_utf8(name_bytes).map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "schema: invalid UTF-8 column name",
-                )
-            })?;
-
-            if name.is_empty() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "schema: empty column name",
-                ));
-            }
-            if !seen_names.insert(name.clone()) {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("schema: duplicate column name '{}'", name),
-                ));
-            }
+            let name = name_decoder.read(data, &mut pos)?;
+            validate_column_name(&name, &mut seen_names)?;
 
             let field = types::deserialize_field(&name, data, &mut pos)?;
 
@@ -197,37 +148,102 @@ impl MosaicSchema {
             bucket_to_global[bucket_id].push(sorted_pos);
         }
 
-        // Read original column order (delta + zigzag encoded)
-        let original_order = if pos < data.len() {
-            let mut order = Vec::with_capacity(num_columns);
-            let mut prev = 0i64;
-            for _ in 0..num_columns {
-                let delta = varint::decode_zigzag(data, &mut pos)?;
-                prev += delta;
-                order.push(prev as usize);
-            }
-            order
-        } else {
-            (0..num_columns).collect()
-        };
-
-        // Validate that original_order is a permutation of 0..num_columns
-        if original_order.len() != num_columns {
+        let original_order = read_original_order(data, &mut pos, num_columns)?;
+        if pos != data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "original_order length mismatch",
+                "schema: trailing bytes after original_order",
             ));
         }
-        let mut seen = vec![false; num_columns];
-        for &idx in &original_order {
-            if idx >= num_columns || seen[idx] {
+        validate_original_order(&original_order, num_columns)?;
+
+        Ok(MosaicSchema {
+            num_buckets,
+            columns,
+            bucket_to_global,
+            original_order,
+        })
+    }
+
+    fn deserialize_legacy(data: &[u8]) -> io::Result<Self> {
+        struct LegacyColumn {
+            logical_index: usize,
+            sorted_pos: usize,
+            name: String,
+            data_type: DataType,
+            nullable: bool,
+        }
+
+        let mut pos = 0;
+        let (num_columns, num_buckets, bpe_rules) = read_header(data, &mut pos, false)?;
+
+        let mut entries = Vec::with_capacity(num_columns);
+        let mut bucket_to_global = vec![Vec::new(); num_buckets];
+        let mut name_decoder = NameDecoder::new(bpe_rules);
+        let mut seen_names = std::collections::HashSet::with_capacity(num_columns);
+        let mut seen_indices = vec![false; num_columns];
+
+        for sorted_pos in 0..num_columns {
+            let name = name_decoder.read(data, &mut pos)?;
+            validate_column_name(&name, &mut seen_names)?;
+
+            let logical_index = varint::decode(data, &mut pos)? as usize;
+            if logical_index >= num_columns {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    "original_order is not a valid permutation",
+                    "schema: logical_index out of range",
                 ));
             }
-            seen[idx] = true;
+            if seen_indices[logical_index] {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "schema: duplicate logical_index",
+                ));
+            }
+            seen_indices[logical_index] = true;
+
+            let field = types::deserialize_field(&name, data, &mut pos)?;
+
+            let bucket_id = spec::assign_bucket(sorted_pos, num_columns, num_buckets);
+            entries.push(LegacyColumn {
+                logical_index,
+                sorted_pos,
+                name,
+                data_type: field.data_type().clone(),
+                nullable: field.is_nullable(),
+            });
+            bucket_to_global[bucket_id].push(logical_index);
         }
+
+        if pos != data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: trailing bytes in legacy schema",
+            ));
+        }
+        if seen_indices.iter().any(|seen| !seen) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: missing logical_index",
+            ));
+        }
+
+        let mut columns = Vec::with_capacity(num_columns);
+        columns.resize_with(num_columns, || ColumnMeta {
+            name: String::new(),
+            data_type: DataType::Int32,
+            nullable: false,
+            bucket_id: 0,
+        });
+        for entry in entries {
+            columns[entry.logical_index] = ColumnMeta {
+                name: entry.name,
+                data_type: entry.data_type,
+                nullable: entry.nullable,
+                bucket_id: spec::assign_bucket(entry.sorted_pos, num_columns, num_buckets),
+            };
+        }
+        let original_order = (0..num_columns).collect();
 
         Ok(MosaicSchema {
             num_buckets,
@@ -270,9 +286,10 @@ impl MosaicSchema {
         let mut buf = Vec::new();
         varint::encode(&mut buf, num_columns as u32);
         varint::encode(&mut buf, self.num_buckets as u32);
+        buf.push(SCHEMA_LAYOUT_V2);
 
         if bpe_size < plain_size {
-            buf.push(1); // NAME_ENCODING_BPE
+            buf.push(NAME_ENCODING_BPE);
             varint::encode(&mut buf, bpe_rules.len() as u32);
             for rule in &bpe_rules {
                 buf.push(rule[0]);
@@ -281,7 +298,7 @@ impl MosaicSchema {
             let bpe_refs: Vec<&[u8]> = bpe_names.iter().map(|v| v.as_slice()).collect();
             write_front_coded(&mut buf, &bpe_refs, &self.columns);
         } else {
-            buf.push(0); // NAME_ENCODING_FRONT_CODE
+            buf.push(NAME_ENCODING_FRONT_CODE);
             write_front_coded(&mut buf, &raw_refs, &self.columns);
         }
 
@@ -295,6 +312,187 @@ impl MosaicSchema {
 
         buf
     }
+}
+
+fn has_current_layout_marker(data: &[u8]) -> io::Result<bool> {
+    let mut pos = 0;
+    let _num_columns = varint::decode(data, &mut pos)?;
+    let _num_buckets = varint::decode(data, &mut pos)?;
+    if pos >= data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "schema: missing layout or name encoding byte",
+        ));
+    }
+    Ok(data[pos] == SCHEMA_LAYOUT_V2)
+}
+
+fn read_header(
+    data: &[u8],
+    pos: &mut usize,
+    expect_current_layout_marker: bool,
+) -> io::Result<(usize, usize, Option<BpeRules>)> {
+    let num_columns = varint::decode(data, pos)? as usize;
+    let num_buckets = varint::decode(data, pos)? as usize;
+
+    if num_buckets == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "schema: num_buckets must be > 0",
+        ));
+    }
+
+    if expect_current_layout_marker {
+        if *pos >= data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "schema: missing layout marker",
+            ));
+        }
+        if data[*pos] != SCHEMA_LAYOUT_V2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: invalid layout marker",
+            ));
+        }
+        *pos += 1;
+    }
+
+    if *pos >= data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "schema: missing name encoding byte",
+        ));
+    }
+    let name_encoding = data[*pos];
+    *pos += 1;
+
+    let bpe_rules = match name_encoding {
+        NAME_ENCODING_FRONT_CODE => None,
+        NAME_ENCODING_BPE => {
+            let num_rules = varint::decode(data, pos)? as usize;
+            let mut rules = Vec::with_capacity(num_rules);
+            for _ in 0..num_rules {
+                if *pos + 2 > data.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "schema: truncated BPE rules",
+                    ));
+                }
+                let left = data[*pos];
+                let right = data[*pos + 1];
+                *pos += 2;
+                rules.push([left, right]);
+            }
+            Some(rules)
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("schema: invalid name encoding: {}", name_encoding),
+            ));
+        }
+    };
+
+    Ok((num_columns, num_buckets, bpe_rules))
+}
+
+struct NameDecoder {
+    bpe_rules: Option<BpeRules>,
+    prev_encoded: Vec<u8>,
+}
+
+impl NameDecoder {
+    fn new(bpe_rules: Option<BpeRules>) -> Self {
+        Self {
+            bpe_rules,
+            prev_encoded: Vec::new(),
+        }
+    }
+
+    fn read(&mut self, data: &[u8], pos: &mut usize) -> io::Result<String> {
+        let shared = varint::decode(data, pos)? as usize;
+        let suffix_len = varint::decode(data, pos)? as usize;
+
+        if shared > self.prev_encoded.len() || *pos + suffix_len > data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: corrupted column name encoding",
+            ));
+        }
+        let mut encoded = Vec::with_capacity(shared + suffix_len);
+        encoded.extend_from_slice(&self.prev_encoded[..shared]);
+        encoded.extend_from_slice(&data[*pos..*pos + suffix_len]);
+        *pos += suffix_len;
+        self.prev_encoded = encoded.clone();
+
+        let name_bytes = match &self.bpe_rules {
+            Some(rules) => bpe::decode(&encoded, rules),
+            None => encoded,
+        };
+        String::from_utf8(name_bytes).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "schema: invalid UTF-8 column name",
+            )
+        })
+    }
+}
+
+fn validate_column_name(
+    name: &str,
+    seen_names: &mut std::collections::HashSet<String>,
+) -> io::Result<()> {
+    if name.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "schema: empty column name",
+        ));
+    }
+    if !seen_names.insert(name.to_string()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("schema: duplicate column name '{}'", name),
+        ));
+    }
+    Ok(())
+}
+
+fn read_original_order(data: &[u8], pos: &mut usize, num_columns: usize) -> io::Result<Vec<usize>> {
+    let mut order = Vec::with_capacity(num_columns);
+    let mut prev = 0i64;
+    for _ in 0..num_columns {
+        let delta = varint::decode_zigzag(data, pos)?;
+        prev += delta;
+        if prev < 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "original_order is not a valid permutation",
+            ));
+        }
+        order.push(prev as usize);
+    }
+    Ok(order)
+}
+
+fn validate_original_order(original_order: &[usize], num_columns: usize) -> io::Result<()> {
+    if original_order.len() != num_columns {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "original_order length mismatch",
+        ));
+    }
+    let mut seen = vec![false; num_columns];
+    for &idx in original_order {
+        if idx >= num_columns || seen[idx] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "original_order is not a valid permutation",
+            ));
+        }
+        seen[idx] = true;
+    }
+    Ok(())
 }
 
 fn write_front_coded(buf: &mut Vec<u8>, name_bytes: &[&[u8]], columns: &[ColumnMeta]) {
@@ -334,6 +532,39 @@ fn common_prefix_length(a: &[u8], b: &[u8]) -> usize {
 mod tests {
     use super::*;
 
+    fn serialize_legacy_schema(
+        columns: Vec<(String, DataType, bool)>,
+        num_buckets: usize,
+    ) -> Vec<u8> {
+        let mut sorted_indices: Vec<usize> = (0..columns.len()).collect();
+        sorted_indices.sort_by(|&a, &b| columns[a].0.cmp(&columns[b].0));
+
+        let mut buf = Vec::new();
+        varint::encode(&mut buf, columns.len() as u32);
+        varint::encode(&mut buf, num_buckets as u32);
+        buf.push(NAME_ENCODING_FRONT_CODE);
+
+        let mut prev: &[u8] = &[];
+        for &global_idx in &sorted_indices {
+            let name = columns[global_idx].0.as_bytes();
+            let shared = common_prefix_length(prev, name);
+            varint::encode(&mut buf, shared as u32);
+            varint::encode(&mut buf, (name.len() - shared) as u32);
+            buf.extend_from_slice(&name[shared..]);
+            prev = name;
+
+            varint::encode(&mut buf, global_idx as u32);
+            let field = Field::new(
+                &columns[global_idx].0,
+                columns[global_idx].1.clone(),
+                columns[global_idx].2,
+            );
+            types::serialize_field(&field, &mut buf);
+        }
+
+        buf
+    }
+
     #[test]
     fn test_bucket_assignment() {
         let columns: Vec<(String, DataType, bool)> = (0..1000)
@@ -354,6 +585,42 @@ mod tests {
         let schema = MosaicSchema::new(columns, 2);
         let data = schema.serialize();
         assert!(!data.is_empty());
+    }
+
+    #[test]
+    fn test_deserializes_legacy_v1_schema_layout() {
+        let data = serialize_legacy_schema(vec![("value".to_string(), DataType::Int32, false)], 1);
+
+        let restored = MosaicSchema::deserialize(&data).unwrap();
+
+        assert_eq!(restored.columns.len(), 1);
+        assert_eq!(restored.columns[0].name, "value");
+        assert_eq!(restored.columns[0].data_type, DataType::Int32);
+        assert!(!restored.columns[0].nullable);
+        assert_eq!(restored.original_order, vec![0]);
+    }
+
+    #[test]
+    fn test_deserializes_legacy_v1_schema_order() {
+        let data = serialize_legacy_schema(
+            vec![
+                ("name".to_string(), DataType::Utf8, true),
+                ("age".to_string(), DataType::Int32, false),
+                ("score".to_string(), DataType::Float64, true),
+            ],
+            2,
+        );
+
+        let restored = MosaicSchema::deserialize_for_version(spec::LEGACY_VERSION, &data).unwrap();
+
+        assert_eq!(restored.columns.len(), 3);
+        assert_eq!(restored.columns[0].name, "name");
+        assert_eq!(restored.columns[1].name, "age");
+        assert_eq!(restored.columns[2].name, "score");
+        assert_eq!(restored.columns[1].data_type, DataType::Int32);
+        assert!(!restored.columns[1].nullable);
+        assert_eq!(restored.original_order, vec![0, 1, 2]);
+        assert_eq!(restored.bucket_to_global, vec![vec![1, 0], vec![2]]);
     }
 
     #[test]

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -16,7 +16,8 @@
 // under the License.
 
 pub const MAGIC: [u8; 4] = [b'M', b'O', b'S', b'A'];
-pub const VERSION: u8 = 1;
+pub const LEGACY_VERSION: u8 = 1;
+pub const VERSION: u8 = 2;
 pub const FOOTER_SIZE: usize = 32;
 
 pub const COMPRESSION_NONE: u8 = 0;


### PR DESCRIPTION
## Problem

Schema block layout changed while the file footer version stayed at v1. Existing v1 files can be parsed with the new layout, causing the legacy logical index to be read as a type header and potentially corrupting schema metadata silently.

## Fix

Bump the current file version to v2 and keep v1 as the legacy format. Route schema deserialization by footer version, parse v1 with the legacy logical-index layout, and add a v2 schema layout marker for the current format.

Also add regression coverage for legacy v1 schema decoding.