### PR TITLE
fix: preserve empty projection in read_table

### DIFF
--- a/python/mosaic/mosaic.py
+++ b/python/mosaic/mosaic.py
@@ -411,6 +411,6 @@ def write_table(table, stream, options=None):
 
 def read_table(read_at_fn, file_length, columns=None):
     with MosaicReader.from_input_file(read_at_fn, file_length) as reader:
-        if columns:
+        if columns is not None:
             reader.project(columns)
         return reader.read_all()

--- a/python/tests/test_mosaic.py
+++ b/python/tests/test_mosaic.py
@@ -657,6 +657,28 @@ class TestConvenience:
         assert result.column("id").to_pylist() == list(range(30))
         assert result.column("name").to_pylist() == [f"user_{i}" for i in range(30)]
 
+    def test_read_table_empty_projection(self):
+        table = pa.table(
+            {
+                "id": pa.array(list(range(30)), type=pa.int32()),
+                "name": pa.array([f"user_{i}" for i in range(30)]),
+            }
+        )
+
+        buf = io.BytesIO()
+        write_table(table, buf)
+
+        data = buf.getvalue()
+        result = read_table(
+            lambda offset, length: data[offset : offset + length],
+            len(data),
+            columns=[],
+        )
+
+        assert result.num_columns == 0
+        assert result.num_rows == 30
+        assert result.schema.names == []
+
     def test_read_all(self):
         pa_schema = pa.schema(
             [pa.field("x", pa.int32()), pa.field("y", pa.utf8())]


### PR DESCRIPTION
## Problem

`read_table(..., columns=[])` currently skips projection because the Python wrapper checks `if columns:`. This makes an explicit empty projection behave the same as `columns=None`, so the convenience API returns all columns instead of a zero-column table with the row count preserved.

## Fix

Change the wrapper to call `reader.project(columns)` whenever `columns is not None`, preserving the existing three-state projection semantics:

- `None`: read all columns
- non-empty list: read selected columns
- empty list: read zero columns and preserve row count

Add a regression test for `read_table(..., columns=[])`.