### PR TITLE
fix: alter readme crates.io badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/apache/paimon-mosaic/ci.yml
 [actions]: https://github.com/apache/paimon-mosaic/actions?query=branch%3Amain
-[Latest Version]: https://img.shields.io/crates/v/paimon.svg
-[crates.io]: https://crates.io/crates/mosaic
+[Latest Version]: https://img.shields.io/crates/v/paimon-mosaic.svg
+[crates.io]: https://crates.io/crates/paimon-mosaic
 
 A columnar-bucket hybrid format optimized for wide tables of Apache Paimon. 
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the crates.io badge and link in the README.

The previous link pointed to the already-registered `mosaic` crate, while the project crate page should point to `paimon-mosaic`.

## Brief change log

- Update the latest version badge to use `paimon-mosaic`
- Update the crates.io link to `https://crates.io/crates/paimon-mosaic`

## Verifying this change

- Checked that the README link now points to the expected crates.io page