### PR TITLE
ci: trigger CI for release branch pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,13 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-*
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - release-*
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Trigger CI on `release-*` branch pushes.
- Trigger CI for pull requests targeting `release-*` branches.

## Why

This matches the release branch CI behavior used by `apache/paimon-rust` and helps validate Paimon Mosaic release branches before cutting 0.1.0 RCs.

## Testing

- `python3 tools/validate_asf_yaml.py`
- `git diff --check`