### PR TITLE
ci: check Rust dependency licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Validate .asf.yaml
         run: pip install pyyaml -q && python3 tools/validate_asf_yaml.py
 
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.19.0
+
+      - name: Check dependency licenses (Apache-compatible)
+        run: cargo deny check licenses
+
       - name: Format
         run: cargo fmt --all -- --check
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "MIT",
+    "Unicode-3.0",
+]
+
+exceptions = [
+    # Used as a Rust build dependency to generate C headers for the FFI crate.
+    # MPL-2.0 is ASF Category B and this crate is not linked into artifacts.
+    { crate = "cbindgen", allow = ["MPL-2.0"] },
+]


### PR DESCRIPTION
## Summary

- Add a cargo-deny license policy for Rust dependencies.
- Run `cargo deny check licenses` in CI.

## Testing

- `cargo deny check licenses`
- `python3 tools/validate_asf_yaml.py`