### PR TITLE
Add support for LZ4 codec

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,6 +27,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 zstd = "0.13"
+lz4 = "1.28"
 arrow-schema = "58"
 arrow-array = "58"
 arrow-buffer = "58"

--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -313,6 +313,10 @@ impl<I: InputFile> MosaicReader<I> {
             COMPRESSION_NONE => schema_compressed.to_vec(),
             COMPRESSION_ZSTD => zstd::bulk::decompress(schema_compressed, schema_uncompressed_size)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            COMPRESSION_LZ4 => {
+                lz4::block::decompress(schema_compressed, Some(schema_uncompressed_size as i32))
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            }
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -448,6 +452,7 @@ impl<I: InputFile> MosaicReader<I> {
     }
 
     fn parse_column_slot(
+        compression: u8,
         slot_data: &[u8],
         col_type: &DataType,
         num_rows: usize,
@@ -455,8 +460,20 @@ impl<I: InputFile> MosaicReader<I> {
         let mut spos = 0usize;
         let uncompressed_size = varint::decode(slot_data, &mut spos)? as usize;
         let compressed_data = &slot_data[spos..];
-        let page_content = zstd::bulk::decompress(compressed_data, uncompressed_size)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let page_content = match compression {
+            COMPRESSION_ZSTD => zstd::bulk::decompress(compressed_data, uncompressed_size)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            COMPRESSION_LZ4 => {
+                lz4::block::decompress(compressed_data, Some(uncompressed_size as i32))
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "paged bucket: unsupported compression",
+                ))
+            }
+        };
 
         if page_content.len() < 2 {
             return Err(io::Error::new(
@@ -609,10 +626,10 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
                     bucket_kinds.push(BucketLayout::Empty);
                 }
                 BucketLayout::Paged { total_size } => {
-                    if self.compression != COMPRESSION_ZSTD {
+                    if self.compression == COMPRESSION_NONE {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            "paged bucket requires ZSTD compression",
+                            "paged bucket requires compression",
                         ));
                     }
                     let dir_size = self.schema.bucket_to_global[b].len() * 4;
@@ -673,6 +690,10 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
                         COMPRESSION_NONE => buf.to_vec(),
                         COMPRESSION_ZSTD => zstd::bulk::decompress(buf, uncompressed_size)
                             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                        COMPRESSION_LZ4 => {
+                            lz4::block::decompress(buf, Some(uncompressed_size as i32))
+                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                        }
                         _ => {
                             return Err(io::Error::new(
                                 io::ErrorKind::InvalidData,
@@ -735,8 +756,12 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
                                 )?));
                             } else {
                                 let slot_data = &buf[data_offset..data_offset + slot_sizes[i]];
-                                let column_reader =
-                                    Self::parse_column_slot(slot_data, &col_type, meta.num_rows)?;
+                                let column_reader = Self::parse_column_slot(
+                                    self.compression,
+                                    slot_data,
+                                    &col_type,
+                                    meta.num_rows,
+                                )?;
                                 column_readers.push(Some(column_reader));
                             }
                             data_offset += slot_sizes[i];
@@ -878,8 +903,12 @@ impl<I: InputFile> ReaderAccess for MosaicReader<I> {
                     })?;
                     let group_buffer = r2_buffers[location.group_idx].as_slice();
                     let slot_data = &group_buffer[location.start..location.start + location.len];
-                    let column_reader =
-                        Self::parse_column_slot(slot_data, &col_type, meta.num_rows)?;
+                    let column_reader = Self::parse_column_slot(
+                        self.compression,
+                        slot_data,
+                        &col_type,
+                        meta.num_rows,
+                    )?;
                     column_readers.push(Some(column_reader));
                 }
                 bucket_states[b] = Some(BucketState::Paged { column_readers });

--- a/core/src/reader_tests.rs
+++ b/core/src/reader_tests.rs
@@ -612,6 +612,45 @@ fn test_roundtrip_with_zstd() {
 }
 
 #[test]
+fn test_roundtrip_with_lz4() {
+    let columns = vec![
+        ("a".to_string(), DataType::Int64, true),
+        ("b".to_string(), DataType::Int64, true),
+    ];
+    let out = MemOutputFile::new();
+    let mut writer = MosaicWriter::new(
+        out,
+        &columns_to_arrow_schema(&columns),
+        WriterOptions {
+            compression: COMPRESSION_LZ4,
+            num_buckets: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let rows: Vec<Vec<Value>> = (0..1000)
+        .map(|i| vec![Value::BigInt(i), Value::BigInt(i * 2)])
+        .collect();
+    write_values(&mut writer, &columns, &rows);
+    writer.close().unwrap();
+    let data = writer.output().buf.clone();
+    let len = data.len() as u64;
+    let reader = MosaicReader::new(ByteArrayInputFile::new(data), len).unwrap();
+    let mut rg = reader.row_group_reader(0).unwrap();
+    let batch = rg.read_columns().unwrap();
+    assert_eq!(batch.num_rows(), 1000);
+
+    let col_a = batch_col_i64(&batch, "a");
+    let col_b = batch_col_i64(&batch, "b");
+
+    for i in 0..1000usize {
+        assert_eq!(col_a.value(i), i as i64);
+        assert_eq!(col_b.value(i), i as i64 * 2);
+    }
+}
+
+#[test]
 fn test_roundtrip_all_types() {
     let columns = vec![
         ("f_boolean".to_string(), DataType::Boolean, true),
@@ -2671,6 +2710,56 @@ fn test_paged_roundtrip_basic() {
         .collect();
 
     let (reader, _) = write_and_read_paged(columns, &rows);
+    let mut rg = reader.row_group_reader(0).unwrap();
+    let batch = rg.read_columns().unwrap();
+    assert_eq!(batch.num_rows(), 200);
+
+    let ids = batch_col_i32(&batch, "id");
+    let names = batch_col_string(&batch, "name");
+    let scores = batch_col_f64(&batch, "score");
+
+    for i in 0..200usize {
+        assert_eq!(ids.value(i), i as i32);
+        assert_eq!(names.value(i), format!("user_{}", i));
+        assert!((scores.value(i) - i as f64 * 1.5).abs() < 1e-10);
+    }
+}
+
+#[test]
+fn test_paged_roundtrip_with_lz4() {
+    let columns = vec![
+        ("id".to_string(), DataType::Int32, true),
+        ("name".to_string(), DataType::Utf8, true),
+        ("score".to_string(), DataType::Float64, true),
+    ];
+    let rows: Vec<Vec<Value>> = (0..200)
+        .map(|i| {
+            vec![
+                Value::Integer(i),
+                Value::String(format!("user_{}", i).into_bytes()),
+                Value::Double(i as f64 * 1.5),
+            ]
+        })
+        .collect();
+
+    let out = MemOutputFile::new();
+    let mut writer = MosaicWriter::new(
+        out,
+        &columns_to_arrow_schema(&columns),
+        WriterOptions {
+            compression: COMPRESSION_LZ4,
+            page_size_threshold: 1,
+            num_buckets: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    write_values(&mut writer, &columns, &rows);
+    writer.close().unwrap();
+    let data = writer.output().buf.clone();
+    let len = data.len() as u64;
+    let reader = MosaicReader::new(ByteArrayInputFile::new(data.clone()), len).unwrap();
+
     let mut rg = reader.row_group_reader(0).unwrap();
     let batch = rg.read_columns().unwrap();
     assert_eq!(batch.num_rows(), 200);

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -21,6 +21,7 @@ pub const FOOTER_SIZE: usize = 32;
 
 pub const COMPRESSION_NONE: u8 = 0;
 pub const COMPRESSION_ZSTD: u8 = 1;
+pub const COMPRESSION_LZ4: u8 = 2;
 
 pub const ENCODING_PLAIN: u8 = 0;
 pub const ENCODING_CONST: u8 = 1;

--- a/core/src/writer.rs
+++ b/core/src/writer.rs
@@ -313,7 +313,7 @@ impl<S: OutputFile> MosaicWriter<S> {
             }
             let est_size = bw.estimated_raw_size();
             let try_paged =
-                self.compression == COMPRESSION_ZSTD && est_size >= self.page_size_threshold;
+                self.compression != COMPRESSION_NONE && est_size >= self.page_size_threshold;
 
             let paged_output = if try_paged {
                 let paged = bw.finish_paged();
@@ -407,6 +407,12 @@ impl<S: OutputFile> MosaicWriter<S> {
                 self.out.write(&compressed)?;
                 Ok(compressed.len())
             }
+            COMPRESSION_LZ4 => {
+                let compressed =
+                    lz4::block::compress(raw, None, false).map_err(io::Error::other)?;
+                self.out.write(&compressed)?;
+                Ok(compressed.len())
+            }
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("Unsupported compression: {}", self.compression),
@@ -451,8 +457,19 @@ impl<S: OutputFile> MosaicWriter<S> {
 
             // Compress and build on-disk slot: uncompressed_size varint + compressed data
             let uncompressed_size = page_content.len();
-            let compressed =
-                zstd::bulk::compress(&page_content, self.zstd_level).map_err(io::Error::other)?;
+            let compressed = match self.compression {
+                COMPRESSION_ZSTD => zstd::bulk::compress(&page_content, self.zstd_level)
+                    .map_err(io::Error::other)?,
+                COMPRESSION_LZ4 => {
+                    lz4::block::compress(&page_content, None, false).map_err(io::Error::other)?
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "paged bucket: unsupported compression",
+                    ))
+                }
+            };
             let mut slot = Vec::new();
             varint::encode(
                 &mut slot,
@@ -503,6 +520,11 @@ impl<S: OutputFile> MosaicWriter<S> {
             COMPRESSION_ZSTD => {
                 let compressed =
                     zstd::bulk::compress(&schema_raw, self.zstd_level).map_err(io::Error::other)?;
+                self.out.write(&compressed)?;
+            }
+            COMPRESSION_LZ4 => {
+                let compressed =
+                    lz4::block::compress(&schema_raw, None, false).map_err(io::Error::other)?;
                 self.out.write(&compressed)?;
             }
             _ => {
@@ -680,6 +702,43 @@ mod tests {
         writer.close().unwrap();
         let magic = &writer.out.buf[writer.out.buf.len() - 4..];
         assert_eq!(magic, &MAGIC);
+    }
+
+    #[test]
+    fn test_write_with_lz4() {
+        let arrow_schema = Schema::new(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Int64, true),
+        ]);
+        let out = MemOutputFile::new();
+        let mut writer = MosaicWriter::new(
+            out,
+            &arrow_schema,
+            WriterOptions {
+                num_buckets: 1,
+                compression: COMPRESSION_LZ4,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let a_vals: Vec<i64> = (0..1000).collect();
+        let b_vals: Vec<i64> = (0..1000).map(|i| i * 2).collect();
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(Int64Array::from(a_vals)),
+                Arc::new(Int64Array::from(b_vals)),
+            ],
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+
+        writer.close().unwrap();
+        let data = &writer.out.buf;
+        assert!(data.len() >= FOOTER_SIZE);
+        assert_eq!(&data[data.len() - 4..], &MAGIC);
+        assert_eq!(data[data.len() - 8], COMPRESSION_LZ4);
     }
 
     #[test]

--- a/cpp/test_mosaic.cpp
+++ b/cpp/test_mosaic.cpp
@@ -420,7 +420,7 @@ static void test_compression_zstd() {
     });
 
     mosaic::WriterOptions opts;
-    opts.compression = 1;
+    opts.compression = mosaic::kCompressionZstd;
     opts.zstd_level = 3;
     auto data_vec = write_and_get(schema, batch, opts);
 
@@ -435,6 +435,39 @@ static void test_compression_zstd() {
         ASSERT_EQ(xs->Value(i), i);
     }
     printf("  PASS test_compression_zstd\n");
+}
+
+static void test_compression_lz4() {
+    auto schema = arrow::schema({
+        arrow::field("x", arrow::int32()),
+        arrow::field("y", arrow::utf8()),
+    });
+
+    arrow::Int32Builder xb;
+    arrow::StringBuilder yb;
+    for (int i = 0; i < 100; i++) {
+        assert(xb.Append(i).ok());
+        assert(yb.Append("v_" + std::to_string(i)).ok());
+    }
+    auto batch = arrow::RecordBatch::Make(schema, 100, {
+        xb.Finish().ValueUnsafe(), yb.Finish().ValueUnsafe(),
+    });
+
+    mosaic::WriterOptions opts;
+    opts.compression = mosaic::kCompressionLz4;
+    auto data_vec = write_and_get(schema, batch, opts);
+
+    MemBuffer buf;
+    buf.data = data_vec;
+    auto reader = mosaic::make_reader(make_input(buf), buf.data.size());
+    auto rb = read_row_group(reader, 0);
+    ASSERT_EQ(rb->num_rows(), 100);
+
+    auto xs = std::static_pointer_cast<arrow::Int32Array>(rb->GetColumnByName("x"));
+    for (int i = 0; i < 100; i++) {
+        ASSERT_EQ(xs->Value(i), i);
+    }
+    printf("  PASS test_compression_lz4\n");
 }
 
 static void test_schema_roundtrip() {
@@ -834,6 +867,7 @@ int main() {
     test_projection_empty();
     test_statistics();
     test_compression_zstd();
+    test_compression_lz4();
     test_schema_roundtrip();
     test_multiple_row_groups();
     test_writer_stats();
@@ -841,6 +875,6 @@ int main() {
     test_writer_stats_all_null();
     test_writer_stats_matches_reader();
     test_stats_empty_string_min();
-    printf("All %d tests passed.\n", 15);
+    printf("All %d tests passed.\n", 16);
     return 0;
 }

--- a/docs/cpp-api.html
+++ b/docs/cpp-api.html
@@ -155,7 +155,7 @@ g++ -std=c++17 -I include/ example.cpp \
                 </thead>
                 <tbody>
                     <tr><td><code>num_buckets</code></td><td>uint32_t</td><td>0</td><td>Number of buckets (0 = auto)</td></tr>
-                    <tr><td><code>compression</code></td><td>uint8_t</td><td>1</td><td>0=none, 1=zstd</td></tr>
+                    <tr><td><code>compression</code></td><td>uint8_t</td><td>1</td><td>0=none, 1=zstd, 2=lz4 (use <code>mosaic::kCompression*</code> constants)</td></tr>
                     <tr><td><code>zstd_level</code></td><td>int32_t</td><td>1</td><td>Zstd compression level</td></tr>
                     <tr><td><code>row_group_max_size</code></td><td>uint64_t</td><td>256 MB</td><td>Max row group size</td></tr>
                     <tr><td><code>max_dict_total_bytes</code></td><td>uint32_t</td><td>32 KB</td><td>Max dict size per column</td></tr>

--- a/docs/design.html
+++ b/docs/design.html
@@ -556,7 +556,7 @@ page_content (after decompression):
             </p>
             <h5>Validation Invariants</h5>
             <ul>
-                <li>Paged buckets require <code>compression == ZSTD</code>.</li>
+                <li>Paged buckets require compression (<code>ZSTD</code> or <code>LZ4</code>); <code>NONE</code> is rejected.</li>
                 <li>The paged directory size is <code>num_cols &times; 4</code> bytes;
                     <code>dir_size + sum(slot_sizes) == compressed_size</code> must hold exactly.</li>
                 <li>All varint-encoded sizes (<code>compressed_size</code>,
@@ -575,13 +575,14 @@ page_content (after decompression):
                 <tbody>
                     <tr><td>0</td><td>None</td><td>No compression</td></tr>
                     <tr><td>1</td><td>Zstd</td><td>Zstandard compression (default level 1)</td></tr>
+                    <tr><td>2</td><td>LZ4</td><td>LZ4 block compression (faster decode, lower ratio than Zstd)</td></tr>
                 </tbody>
             </table>
             <p>
                 In monolithic mode, compression is applied to the entire bucket as one block.
                 In paged mode, the page directory is uncompressed (fixed-length, enabling direct offset computation),
-                while each column slot is independently zstd-compressed.
-                Paged mode is only used when the compression method is Zstd.
+                while each column slot is independently compressed with the file's compression method.
+                Paged mode is supported for <code>Zstd</code> and <code>LZ4</code>; <code>None</code> falls back to monolithic.
             </p>
 
             <!-- ============================================================ -->
@@ -604,7 +605,7 @@ page_content (after decompression):
                     <tr><td>8</td><td>8</td><td><code>schemaBlockOffset</code></td><td>Absolute offset of Schema Block</td></tr>
                     <tr><td>16</td><td>4</td><td><code>numBuckets</code></td><td>Total number of buckets</td></tr>
                     <tr><td>20</td><td>4</td><td><code>numRowGroups</code></td><td>Total number of row groups</td></tr>
-                    <tr><td>24</td><td>1</td><td><code>compression</code></td><td>0 = none, 1 = zstd</td></tr>
+                    <tr><td>24</td><td>1</td><td><code>compression</code></td><td>0 = none, 1 = zstd, 2 = lz4</td></tr>
                     <tr><td>25</td><td>1</td><td><code>version</code></td><td>Format version (currently 1)</td></tr>
                     <tr><td>26</td><td>2</td><td><em>(reserved)</em></td><td>Padding, set to 0</td></tr>
                     <tr><td>28</td><td>4</td><td><code>magic</code></td><td><code>MOSA</code> (0x4D4F5341)</td></tr>

--- a/docs/java-api.html
+++ b/docs/java-api.html
@@ -167,7 +167,7 @@
                 </thead>
                 <tbody>
                     <tr><td><code>numBuckets(int)</code></td><td>0</td><td>Number of buckets (0 = auto)</td></tr>
-                    <tr><td><code>compression(int)</code></td><td>ZSTD (1)</td><td>0 = none, 1 = Zstd</td></tr>
+                    <tr><td><code>compression(int)</code></td><td>ZSTD (1)</td><td>0 = none, 1 = Zstd, 2 = LZ4 (constants on <code>WriterOptions</code>)</td></tr>
                     <tr><td><code>zstdLevel(int)</code></td><td>1</td><td>Zstd compression level</td></tr>
                     <tr><td><code>rowGroupMaxSize(long)</code></td><td>256 MB</td><td>Max uncompressed bytes per row group</td></tr>
                     <tr><td><code>maxDictTotalBytes(int)</code></td><td>32 KB</td><td>Max dictionary size per column</td></tr>

--- a/docs/python-api.html
+++ b/docs/python-api.html
@@ -138,7 +138,7 @@ data = buf.getvalue()</code></pre>
                 </thead>
                 <tbody>
                     <tr><td><code>num_buckets</code></td><td>0</td><td>Number of buckets (0 = auto)</td></tr>
-                    <tr><td><code>compression</code></td><td>ZSTD (1)</td><td>0 = none, 1 = Zstd</td></tr>
+                    <tr><td><code>compression</code></td><td>ZSTD (1)</td><td>0 = none, 1 = Zstd, 2 = LZ4 (constants on <code>WriterOptions</code>)</td></tr>
                     <tr><td><code>zstd_level</code></td><td>1</td><td>Zstd compression level</td></tr>
                     <tr><td><code>row_group_max_size</code></td><td>256 MB</td><td>Max uncompressed bytes per row group</td></tr>
                     <tr><td><code>max_dict_total_bytes</code></td><td>32 KB</td><td>Max dictionary size per column</td></tr>

--- a/include/mosaic.hpp
+++ b/include/mosaic.hpp
@@ -82,8 +82,13 @@ inline int64_t stream_get_pos(void* ctx) noexcept {
 
 } // namespace detail
 
+// Compression codec IDs (match the on-disk format byte in the file footer).
+constexpr uint8_t kCompressionNone = 0;
+constexpr uint8_t kCompressionZstd = 1;
+constexpr uint8_t kCompressionLz4 = 2;
+
 struct WriterOptions {
-    uint8_t compression = 1;  // ZSTD
+    uint8_t compression = kCompressionZstd;
     int zstd_level = 1;
     uint32_t num_buckets = 0;
     uint64_t row_group_max_size = 256ULL * 1024 * 1024;

--- a/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/WriterOptions.java
@@ -22,6 +22,7 @@ package org.apache.paimon.mosaic;
 public class WriterOptions {
 
     public static final int COMPRESSION_ZSTD = 1;
+    public static final int COMPRESSION_LZ4 = 2;
 
     private int compression = COMPRESSION_ZSTD;
     private int zstdLevel = 1;

--- a/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
+++ b/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
@@ -534,6 +534,41 @@ public class MosaicRoundtripTest {
     }
 
     @Test
+    public void testCompressionLz4() {
+        Schema arrowSchema = new Schema(Arrays.asList(
+                Field.nullable("x", new ArrowType.Int(32, true)),
+                Field.nullable("y", ArrowType.Utf8.INSTANCE)
+        ));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            IntVector xVec = (IntVector) root.getVector("x");
+            VarCharVector yVec = (VarCharVector) root.getVector("y");
+            int n = 100;
+            xVec.allocateNew(n);
+            yVec.allocateNew(n);
+            for (int i = 0; i < n; i++) {
+                xVec.set(i, i);
+                yVec.setSafe(i, ("v_" + i).getBytes());
+            }
+            root.setRowCount(n);
+            data = writeToBytes(
+                    arrowSchema,
+                    new WriterOptions().compression(WriterOptions.COMPRESSION_LZ4),
+                    writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data)) {
+            try (VectorSchemaRoot batch = reader.readRowGroup(0, allocator)) {
+                assertEquals(100, batch.getRowCount());
+                for (int i = 0; i < 100; i++) {
+                    assertEquals(i, ((IntVector) batch.getVector("x")).get(i));
+                }
+            }
+        }
+    }
+
+    @Test
     public void testCompressionNone() {
         Schema arrowSchema = new Schema(Arrays.asList(
                 Field.nullable("x", new ArrowType.Int(32, true)),

--- a/python/mosaic/mosaic.py
+++ b/python/mosaic/mosaic.py
@@ -88,6 +88,7 @@ def _fetch_rg_stats(num_stats_fn, stats_fn, handle, rg_index):
 class WriterOptions:
     COMPRESSION_NONE = 0
     COMPRESSION_ZSTD = 1
+    COMPRESSION_LZ4 = 2
 
     def __init__(
         self,

--- a/python/tests/test_mosaic.py
+++ b/python/tests/test_mosaic.py
@@ -161,6 +161,25 @@ class TestRoundtrip:
             assert rb.num_rows == 100
             assert rb.column("x").to_pylist() == list(range(100))
 
+    def test_compression_lz4(self):
+        pa_schema = pa.schema(
+            [pa.field("x", pa.int32()), pa.field("y", pa.utf8())]
+        )
+        batch = pa.record_batch(
+            [
+                pa.array(list(range(100)), type=pa.int32()),
+                pa.array([f"v_{i}" for i in range(100)]),
+            ],
+            names=["x", "y"],
+        )
+        opts = WriterOptions(compression=WriterOptions.COMPRESSION_LZ4)
+        data = _write_to_bytes(pa_schema, batch, opts)
+
+        with _reader_from_bytes(data) as reader:
+            rb = reader.read_row_group(0)
+            assert rb.num_rows == 100
+            assert rb.column("x").to_pylist() == list(range(100))
+
     def test_all_types(self):
         pa_schema = pa.schema(
             [


### PR DESCRIPTION
 - Currently only zstd is supported, however LZ4 may be preferred for GPU workloads for fast decode/encode
 - Add support for the same. 