### PR TITLE
chore: bump main version to 0.2.0

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Mosaic file format — core Rust library"
 license = "Apache-2.0"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-ffi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Mosaic file format — C/C++ FFI bindings"
 license = "Apache-2.0"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.apache.paimon</groupId>
     <artifactId>mosaic</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mosaic</name>

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-jni"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Mosaic file format — JNI bindings for Java"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paimon-mosaic"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python bindings for the Mosaic columnar-bucket hybrid file format"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- Bumped main branch versions for the next development cycle after cutting the `release-0.1` branch.
- Updated Rust and Python package versions to `0.2.0`.
- Updated the Java Maven version to `0.2.0-SNAPSHOT`.
