### PR TITLE
ci: pin Python release actions to approved SHAs

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e
         with:
           package-dir: python
           output-dir: wheelhouse
@@ -199,7 +199,7 @@ jobs:
 
       - name: Publish to TestPyPI
         if: contains(github.ref, '-')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -208,7 +208,7 @@ jobs:
 
       - name: Publish to PyPI
         if: ${{ !contains(github.ref, '-') }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           skip-existing: true
           packages-dir: dist


### PR DESCRIPTION
## Summary

- Pinned Python release workflow actions to ASF-approved commit SHAs.
- Updated `pypa/cibuildwheel` from `v2.23` to the ASF-approved `v3.3.1` commit SHA.
- Replaced floating `pypa/gh-action-pypi-publish@release/v1` references with the ASF-approved `v1.13.0` commit SHA.
- Kept the existing Mosaic Python packaging model unchanged (`setuptools` + prebuilt FFI shared library); this PR does not migrate the build to `maturin`.

## Notes

- `cibuildwheel` is a major-version upgrade from `v2` to `v3`. The existing workflow uses explicit `CIBW_BUILD` selectors and existing `CIBW_MANYLINUX_*` / `CIBW_BEFORE_ALL_LINUX` settings, which are intended to preserve the current wheel build targets.
- This change is needed because the previous floating third-party action references are blocked by the ASF GitHub Actions allowlist before any jobs are created.

## Test Plan

- [x] `git diff --check`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-python.yml`
- [x] PR CI passed: https://github.com/apache/paimon-mosaic/actions/runs/26328974611
- [ ] Release Python workflow succeeds after this change is merged and run from `main` / a new release tag.
