### PR TITLE
ci: fix release signing and macOS wheel repair

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Repair wheel
         run: |
-          delocate-wheel -w python/dist/repaired python/dist/*.whl
+          delocate-wheel --require-archs arm64 -w python/dist/repaired python/dist/*.whl
           rm python/dist/*.whl
           mv python/dist/repaired/*.whl python/dist/
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -123,6 +123,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
## Summary

- Added loopback pinentry arguments for Java release artifact signing in CI.
- Updated the macOS Python wheel repair step to require the `arm64` architecture explicitly.
- Kept the release workflow scope limited to the two failures observed in RC1.
