### PR TITLE
ci: attach Java release source and javadoc jars

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -135,6 +135,35 @@
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <configuration>
+                            <quiet>true</quiet>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
                         <executions>
                             <execution>


### PR DESCRIPTION
## What

Attach Java source and javadoc artifacts in the release profile.

## Why

The Java release currently only builds the main jar and pom. Maven Central release artifacts should also include sources and javadocs.

## Changes

- Add `maven-source-plugin` to attach `mosaic-*-sources.jar`
- Add `maven-javadoc-plugin` to attach `mosaic-*-javadoc.jar`
