### PR TITLE
ci: fix Java Linux native glibc baseline

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -77,14 +77,60 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-cargo-
 
+      - name: Setup Python
+        if: matrix.os_name == 'linux'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Linux zigbuild
+        if: matrix.os_name == 'linux'
+        run: pip install cargo-zigbuild
+
+      - name: Build Linux JNI library
+        if: matrix.os_name == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rustup target add "${{ matrix.target }}"
+          unset ZSTD_SYS_USE_PKG_CONFIG
+
+          cargo zigbuild --release -p paimon-mosaic-jni --target "${{ matrix.target }}.2.17"
+
+          artifact="target/${{ matrix.target }}/release/${{ matrix.lib_name }}"
+          test -f "$artifact"
+
+          version_info="$(readelf --version-info "$artifact")"
+          max_glibc="$(
+            printf '%s\n' "$version_info" \
+              | grep -Eo 'GLIBC_[0-9][0-9.]*' \
+              | sort -Vu \
+              | tail -n1 \
+              || true
+          )"
+          echo "Maximum required GLIBC version: ${max_glibc:-none}"
+
+          if [[ -n "$max_glibc" ]]; then
+            allowed_glibc="GLIBC_2.17"
+            highest_glibc="$(printf '%s\n%s\n' "$allowed_glibc" "$max_glibc" | sort -Vu | tail -n1)"
+            if [[ "$highest_glibc" != "$allowed_glibc" ]]; then
+              echo "Linux GNU artifact requires $max_glibc, expected <= $allowed_glibc" >&2
+              exit 1
+            fi
+          fi
+
       - name: Build JNI library
-        run: cargo build --release -p paimon-mosaic-jni
+        if: matrix.os_name != 'linux'
+        run: |
+          rustup target add "${{ matrix.target }}"
+          cargo build --release -p paimon-mosaic-jni --target "${{ matrix.target }}"
 
       - name: Upload native library
         uses: actions/upload-artifact@v5
         with:
           name: native-${{ matrix.os_name }}-${{ matrix.arch }}
-          path: target/release/${{ matrix.lib_name }}
+          path: target/${{ matrix.target }}/release/${{ matrix.lib_name }}
 
   publish-snapshot:
     if: github.repository == 'apache/paimon-mosaic'

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -64,14 +64,60 @@ jobs:
           rustup update stable
           rustup default stable
 
+      - name: Setup Python
+        if: matrix.os_name == 'linux'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Linux zigbuild
+        if: matrix.os_name == 'linux'
+        run: pip install cargo-zigbuild
+
+      - name: Build Linux JNI library
+        if: matrix.os_name == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rustup target add "${{ matrix.target }}"
+          unset ZSTD_SYS_USE_PKG_CONFIG
+
+          cargo zigbuild --release -p paimon-mosaic-jni --target "${{ matrix.target }}.2.17"
+
+          artifact="target/${{ matrix.target }}/release/${{ matrix.lib_name }}"
+          test -f "$artifact"
+
+          version_info="$(readelf --version-info "$artifact")"
+          max_glibc="$(
+            printf '%s\n' "$version_info" \
+              | grep -Eo 'GLIBC_[0-9][0-9.]*' \
+              | sort -Vu \
+              | tail -n1 \
+              || true
+          )"
+          echo "Maximum required GLIBC version: ${max_glibc:-none}"
+
+          if [[ -n "$max_glibc" ]]; then
+            allowed_glibc="GLIBC_2.17"
+            highest_glibc="$(printf '%s\n%s\n' "$allowed_glibc" "$max_glibc" | sort -Vu | tail -n1)"
+            if [[ "$highest_glibc" != "$allowed_glibc" ]]; then
+              echo "Linux GNU artifact requires $max_glibc, expected <= $allowed_glibc" >&2
+              exit 1
+            fi
+          fi
+
       - name: Build JNI library
-        run: cargo build --release -p paimon-mosaic-jni
+        if: matrix.os_name != 'linux'
+        run: |
+          rustup target add "${{ matrix.target }}"
+          cargo build --release -p paimon-mosaic-jni --target "${{ matrix.target }}"
 
       - name: Upload native library
         uses: actions/upload-artifact@v5
         with:
           name: native-${{ matrix.os_name }}-${{ matrix.arch }}
-          path: target/release/${{ matrix.lib_name }}
+          path: target/${{ matrix.target }}/release/${{ matrix.lib_name }}
 
   deploy-staging:
     if: github.repository == 'apache/paimon-mosaic' && startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 A columnar-bucket hybrid format optimized for wide tables of Apache Paimon. 
 
+## Java Linux compatibility
+
+Published Java artifacts include JNI libraries for Linux. The Linux GNU
+libraries are built with a `glibc` 2.17 baseline, so they can run on Linux
+distributions with `glibc` 2.17 or newer.
+
 ## Contributing
 
 Apache Paimon Mosaic is an exciting project currently under active development. Whether you're looking to use it in your projects or contribute to its growth, there are several ways you can get involved:


### PR DESCRIPTION
### What changed

This updates Java native release and snapshot workflows to build Linux GNU JNI artifacts with `cargo-zigbuild` using a fixed glibc baseline:

- `x86_64-unknown-linux-gnu.2.17`
- `aarch64-unknown-linux-gnu.2.17`

The workflows now also verify the generated Linux native library with `readelf --version-info` and fail if the required `GLIBC_*` version is higher than `GLIBC_2.17`.

Non-Linux artifacts continue to use regular `cargo build --target`.

### Why

The previous workflows built Linux JNI libraries directly on the GitHub runner. On newer Ubuntu runners, this can produce `.so` artifacts requiring newer glibc symbols, making them fail to load on common enterprise Linux distributions with older glibc versions.