### PR TITLE
ci: print line coverage summary in CI logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,11 @@ jobs:
       - name: Build
         run: cargo build --all-targets
 
-      - name: Test
-        run: cargo test -- --skip test_read_java_written_file --skip test_read_python_written_file
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Test with coverage
+        run: cargo llvm-cov --summary-only -- --skip test_read_java_written_file --skip test_read_python_written_file
 
   cpp-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Replace `cargo test` with `cargo llvm-cov --summary-only` in the rust-test job so each CI run prints a per-file line/region/function coverage table directly in the Actions log.
- Install `cargo-llvm-cov` via `taiki-e/install-action` before running coverage.
- No external service (Codecov etc.) dependency — coverage is visible by reading the workflow output.