### PR TITLE
release: fix source tarball and Java verification paths

### DIFF
--- a/docs/creating-a-release.html
+++ b/docs/creating-a-release.html
@@ -178,7 +178,7 @@ python3 tools/dependencies.py generate
 git add DEPENDENCIES.rust.tsv core/DEPENDENCIES.rust.tsv ffi/DEPENDENCIES.rust.tsv jni/DEPENDENCIES.rust.tsv
 git commit -m "chore: update dependency list for release ${RELEASE_VERSION}"
 git push origin main</code></pre>
-            <p>Fix any license violations before proceeding. The generated files must be committed before tagging because <code>create_source_release.sh</code> builds the archive from a git clone.</p>
+            <p>Fix any license violations before proceeding. The generated files must be committed before tagging because <code>create_source_release.sh</code> builds the archive from the committed Git tree.</p>
 
             <h3>Create a Release Branch</h3>
             <p>Create one stable release branch for the release line. Do not include the RC number in the branch name; RC attempts are represented by tags such as <code>v0.1.0-rc1</code> and <code>v0.1.0-rc2</code>.</p>

--- a/docs/verifying-a-release-candidate.html
+++ b/docs/verifying-a-release-candidate.html
@@ -102,7 +102,7 @@ cargo test --workspace</code></pre>
             <h3>Java</h3>
             <p>Build the Java binding (requires JDK 8+ and Maven):</p>
 <pre><code>cargo build --release -p paimon-mosaic-jni</code></pre>
-            <p>Copy the built native library into the resource directory for the platform being verified.</p>
+            <p>Copy the built native library into the resource directory for the platform being verified. Run only the snippet for your current platform.</p>
             <p><strong>Linux x86_64:</strong></p>
 <pre><code>mkdir -p java/src/main/resources/native/linux/x86_64
 cp target/release/libpaimon_mosaic_jni.so \

--- a/docs/verifying-a-release-candidate.html
+++ b/docs/verifying-a-release-candidate.html
@@ -101,9 +101,25 @@ cargo test --workspace</code></pre>
 
             <h3>Java</h3>
             <p>Build the Java binding (requires JDK 8+ and Maven):</p>
-<pre><code>cargo build --release -p paimon-mosaic-jni
-cp target/release/libpaimon_mosaic_jni.* java/src/main/resources/native/
-cd java
+<pre><code>cargo build --release -p paimon-mosaic-jni</code></pre>
+            <p>Copy the built native library into the resource directory for the platform being verified.</p>
+            <p><strong>Linux x86_64:</strong></p>
+<pre><code>mkdir -p java/src/main/resources/native/linux/x86_64
+cp target/release/libpaimon_mosaic_jni.so \
+  java/src/main/resources/native/linux/x86_64/</code></pre>
+            <p><strong>Linux aarch64:</strong></p>
+<pre><code>mkdir -p java/src/main/resources/native/linux/aarch64
+cp target/release/libpaimon_mosaic_jni.so \
+  java/src/main/resources/native/linux/aarch64/</code></pre>
+            <p><strong>macOS aarch64:</strong></p>
+<pre><code>mkdir -p java/src/main/resources/native/macos/aarch64
+cp target/release/libpaimon_mosaic_jni.dylib \
+  java/src/main/resources/native/macos/aarch64/</code></pre>
+            <p><strong>Windows x86_64:</strong></p>
+<pre><code>mkdir -p java/src/main/resources/native/windows/x86_64
+cp target/release/paimon_mosaic_jni.dll \
+  java/src/main/resources/native/windows/x86_64/</code></pre>
+<pre><code>cd java
 mvn clean package</code></pre>
 
             <h3>Python</h3>

--- a/tools/create_source_release.sh
+++ b/tools/create_source_release.sh
@@ -32,6 +32,7 @@ MVN=${MVN:-mvn}
 # fail immediately
 set -o errexit
 set -o nounset
+set -o pipefail
 # print command before executing
 set -o xtrace
 
@@ -62,32 +63,25 @@ cd ..
 
 echo "Creating source package"
 
-# create a temporary git clone to ensure that we have a pristine source release
-git clone . tools/release/paimon-mosaic-tmp-clone
-cd tools/release/paimon-mosaic-tmp-clone
+ARCHIVE="apache-paimon-mosaic-${RELEASE_VERSION}-src.tgz"
+# Archive from Git objects so filesystem metadata such as macOS xattrs is not included.
+git archive --format=tar --prefix="paimon-mosaic-${RELEASE_VERSION}/" 'HEAD^{tree}' . \
+  ':(exclude).gitignore' ':(exclude).gitattributes' \
+  ':(exclude).asf.yaml' ':(exclude).github' \
+  ':(exclude)deploysettings.xml' ':(exclude)target' \
+  ':(exclude).idea' ':(exclude)*.iml' ':(exclude).DS_Store' \
+  | gzip -n > "tools/release/${ARCHIVE}"
 
-trap 'cd ${CURR_DIR}/release;rm -rf paimon-mosaic-tmp-clone' ERR
+cd tools/release
 
-rsync -a \
-  --exclude ".git" --exclude ".gitignore" --exclude ".gitattributes" \
-  --exclude ".asf.yaml" --exclude ".github" \
-  --exclude "deploysettings.xml" --exclude "target" \
-  --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" \
-  . paimon-mosaic-$RELEASE_VERSION
-
-tar czf apache-paimon-mosaic-${RELEASE_VERSION}-src.tgz paimon-mosaic-$RELEASE_VERSION
-gpg --armor --detach-sig apache-paimon-mosaic-$RELEASE_VERSION-src.tgz
-$SHASUM apache-paimon-mosaic-$RELEASE_VERSION-src.tgz > apache-paimon-mosaic-$RELEASE_VERSION-src.tgz.sha512
+gpg --armor --detach-sig "${ARCHIVE}"
+$SHASUM "${ARCHIVE}" > "${ARCHIVE}.sha512"
 
 echo "Verifying GPG signature"
-gpg --verify apache-paimon-mosaic-$RELEASE_VERSION-src.tgz.asc apache-paimon-mosaic-$RELEASE_VERSION-src.tgz
+gpg --verify "${ARCHIVE}.asc" "${ARCHIVE}"
 
 echo "Verifying tarball integrity"
-tar tzf apache-paimon-mosaic-${RELEASE_VERSION}-src.tgz > /dev/null
-
-mv apache-paimon-mosaic-$RELEASE_VERSION-src.* ../
-cd ..
-rm -rf paimon-mosaic-tmp-clone
+tar tzf "${ARCHIVE}" > /dev/null
 
 echo ""
 echo "Source release created successfully. Artifacts in tools/release/:"


### PR DESCRIPTION
The source release script used rsync and the platform tar command, which can include macOS filesystem metadata such as AppleDouble files, pax headers, and com.apple.* extended attributes in the source tarball.

This PR generates the source archive from the committed Git tree with git archive and gzip -n, avoiding filesystem metadata in the release tarball.

The release verification guide also copied the JNI library into java/src/main/resources/native/, but NativeLib loads libraries from /native/{os}/{arch}/. This PR updates the guide to copy each platform library into the directory layout used by NativeLib and the Java release workflow.