### PR TITLE
release: fix Java NOTICE year

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Paimon Mosaic
-Copyright 2024-2026 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <name>Mosaic</name>
     <description>Mosaic file format for Java (backed by Rust via JNI)</description>
     <url>https://paimon.apache.org</url>
-    <inceptionYear>2025</inceptionYear>
+    <inceptionYear>2026</inceptionYear>
 
     <licenses>
         <license>
@@ -64,6 +64,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- Used by maven-remote-resources-plugin when generating META-INF/NOTICE. -->
+        <project.build.outputTimestamp>2026-01-01T00:00:00Z</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>15.0.0</arrow.version>
     </properties>


### PR DESCRIPTION
The Java release artifact generated META-INF/NOTICE from maven-remote-resources-plugin. The project inherited Apache parent 23's default output timestamp from 2020 while java/pom.xml declared inceptionYear as 2025, which produced an invalid copyright range: 2025-2020.

This PR aligns the project NOTICE year with the first Apache Paimon Mosaic release year and sets the Maven output timestamp to 2026 so generated Java artifacts contain a valid NOTICE file.