### PR TITLE
release: decouple Python publish from Rust and Java release jobs

### DIFF
--- a/.github/workflows/release-python-publish.yml
+++ b/.github/workflows/release-python-publish.yml
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Publish Python wheels after the orchestrator has confirmed Rust and Java
-# release jobs completed successfully.
+# Publish Python wheels after the orchestrator has confirmed the wheel
+# build completed successfully.
 
 name: Release Python Publish
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -18,8 +18,7 @@
 # Build the paimon-mosaic Python release wheels.
 #
 # Trigger: called by release.yml or manually dispatched.
-# Publishing is handled by release-python-publish.yml after Rust and Java
-# release jobs complete successfully.
+# Publishing is handled by release-python-publish.yml after wheels are built.
 
 name: Release Python Wheels
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   python-publish:
     name: Python publish
-    needs: [rust, java, python-wheels]
+    needs: [python-wheels]
     if: startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/release-python-publish.yml
     secrets: inherit


### PR DESCRIPTION
Python wheels have no runtime dependency on Rust or Java artifacts, so the publish step only needs to wait for the wheel build to finish.