### PR TITLE
chore: update 0.1.0 release links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/apache/paimon-mosaic/ci.yml
 [actions]: https://github.com/apache/paimon-mosaic/actions?query=branch%3Amain
-[Latest Version]: https://img.shields.io/crates/v/paimon-mosaic.svg
-[crates.io]: https://crates.io/crates/paimon-mosaic
+[Latest Version]: https://img.shields.io/crates/v/paimon-mosaic-core.svg
+[crates.io]: https://crates.io/crates/paimon-mosaic-core
 
 A columnar-bucket hybrid format optimized for wide tables of Apache Paimon. 
 

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -69,9 +69,12 @@
             </table>
 
             <h2>Upcoming</h2>
+            <p>(None yet)</p>
 
-            <h3>0.1.0 (In Development)</h3>
-            <p>The first release of Apache Paimon Mosaic. Planned features:</p>
+            <h2>Past Releases</h2>
+
+            <h3>0.1.0</h3>
+            <p>The first release of Apache Paimon Mosaic. Key features:</p>
             <ul>
                 <li>Mosaic columnar-bucket hybrid format core implementation</li>
                 <li>High-performance reader and writer with ZSTD compression</li>
@@ -80,9 +83,13 @@
                 <li>Python binding with FFI</li>
                 <li>C++ headers for native integration</li>
             </ul>
-
-            <h2>Past Releases</h2>
-            <p>(None yet)</p>
+            <p>
+                <a href="https://downloads.apache.org/paimon/paimon-mosaic-0.1.0/">Source release</a> |
+                <a href="https://github.com/apache/paimon-mosaic/releases/tag/v0.1.0">Release notes</a> |
+                <a href="https://crates.io/crates/paimon-mosaic-core/0.1.0">Rust crate</a> |
+                <a href="https://repo.maven.apache.org/maven2/org/apache/paimon/mosaic/0.1.0/">Java artifacts</a> |
+                <a href="https://pypi.org/project/paimon-mosaic/0.1.0/">Python package</a>
+            </p>
 
             <h2>Download</h2>
             <p>Official source releases are available from the <a href="https://downloads.apache.org/paimon/">ASF distribution</a>.</p>


### PR DESCRIPTION
## What changed

This updates the release-facing documentation after Apache Paimon Mosaic 0.1.0 was published.

The previous README badge linked to the non-existent `paimon-mosaic` crate, while the actual Rust crate is `paimon-mosaic-core`. The releases page also still listed 0.1.0 as an in-development upcoming release.

This PR:
- Points the README version badge and crates.io link to `paimon-mosaic-core`
- Moves 0.1.0 to past releases
- Adds links to the source release, GitHub release notes, Rust crate, Java artifacts, and Python package

## Verification

- `git diff --check -- README.md docs/releases.html`
- `cargo fmt --all -- --check`
- `python3 tools/validate_asf_yaml.py`