### PR TITLE
ci: switch Java release deploy to nexus-staging-maven-plugin

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -172,9 +172,7 @@ jobs:
         run: |
           mvn clean deploy \
             -Prelease \
-            -DskipTests \
-            -DretryFailedDeploymentCount=10 \
-            -Daether.connector.basic.parallelPut=false
+            -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -186,6 +186,17 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>apache.releases.https</serverId>
+                            <nexusUrl>https://repository.apache.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
release-java.yml deploy-staging has failed all 7 times for 0.1.0 (rc1, rc2 ×5, rc3, v0.1.0 final) with HTTP 502 from repository.apache.org on the jar PUT. The retry from #44 walks all 10 attempts and every one returns 502, so the failure is systematic. The vanilla maven-deploy-plugin 2.8.2 inherited from Apache Parent POM v23 sends the PUT through Maven Wagon, and that path is the one being rejected.

Replace the deploy execution with nexus-staging-maven-plugin 1.7.0 (extensions=true). It uses Sonatypes own HttpClient transport and gathers artifacts into a local staging directory before pushing them atomically — a different code path, used by other Apache projects against repository.apache.org without 502s. autoReleaseAfterClose=false keeps the existing Close + Release manual gate.

Drops -DretryFailedDeploymentCount and -Daether.connector.basic.parallelPut from release-java.yml since both apply only to the vanilla deploy plugin.