### PR TITLE
ci: fix update_branch_version.sh skipping Cargo.toml on snapshot bumps

### DIFF
--- a/tools/update_branch_version.sh
+++ b/tools/update_branch_version.sh
@@ -52,17 +52,19 @@ fi
 
 cd ..
 
-# For Cargo.toml and pyproject.toml, strip any -SNAPSHOT suffix (not valid in those ecosystems)
+# Cargo.toml and pyproject.toml never carry the -SNAPSHOT suffix, so strip it
+# from both old and new versions when matching/replacing there.
+OLD_VERSION_CLEAN=$(echo "$OLD_VERSION" | sed 's/-SNAPSHOT//')
 NEW_VERSION_CLEAN=$(echo "$NEW_VERSION" | sed 's/-SNAPSHOT//')
 
 #change version in all pom files (match both exact and -SNAPSHOT suffix)
 find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>'$OLD_VERSION'(-SNAPSHOT)?</version>#<version>'$NEW_VERSION'</version>#' {} \;
 
 #change version in Cargo.toml files
-find . -name 'Cargo.toml' -not -path '*/target/*' -type f -exec perl -pi -e 's#^version = "'$OLD_VERSION'"#version = "'$NEW_VERSION_CLEAN'"#' {} \;
+find . -name 'Cargo.toml' -not -path '*/target/*' -type f -exec perl -pi -e 's#^version = "'$OLD_VERSION_CLEAN'"#version = "'$NEW_VERSION_CLEAN'"#' {} \;
 
 #change version in pyproject.toml
-perl -pi -e 's#^version = "'$OLD_VERSION'"#version = "'$NEW_VERSION_CLEAN'"#' python/pyproject.toml
+perl -pi -e 's#^version = "'$OLD_VERSION_CLEAN'"#version = "'$NEW_VERSION_CLEAN'"#' python/pyproject.toml
 
 git commit -am "Update version to $NEW_VERSION"
 


### PR DESCRIPTION
update_branch_version.sh bumps the version across the pom, the three Cargo.toml crates, and pyproject.toml. The pom regex tolerates an optional -SNAPSHOT suffix, but Cargo.toml and pyproject.toml are matched against OLD_VERSION verbatim — and those files never carry -SNAPSHOT.

So when OLD_VERSION is 0.2.0-SNAPSHOT (the normal "bump main to 0.3.0-SNAPSHOT" case), the perl match fails on the Rust crates and the Python package: they stay at the old version while the pom moves. main is already in this split state today (pom 0.2.0-SNAPSHOT, crates 0.2.0).

Strip -SNAPSHOT from OLD_VERSION too, mirroring NEW_VERSION_CLEAN. After this, OLD=0.2.0-SNAPSHOT NEW=0.3.0-SNAPSHOT moves all five files in one run — verified locally: pom → 0.3.0-SNAPSHOT, crates + pyproject → 0.3.0.