### PR TITLE
chore: bump main version to 0.3.0-SNAPSHOT

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Mosaic file format — core Rust library"
 license = "Apache-2.0"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-ffi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Mosaic file format — C/C++ FFI bindings"
 license = "Apache-2.0"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.apache.paimon</groupId>
     <artifactId>mosaic</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Mosaic</name>

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-mosaic-jni"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Mosaic file format — JNI bindings for Java"
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paimon-mosaic"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python bindings for the Mosaic columnar-bucket hybrid file format"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.9"


### PR DESCRIPTION
main carries the 0.2.0 development version; with 0.2.0 entering release, advance main to the next development cycle.

Bumps all five version files: java/pom.xml to 0.3.0-SNAPSHOT, and the three Cargo.toml crates plus python/pyproject.toml to 0.3.0.

No functional change.