### PR TITLE
ci: set staging repo description for Java release

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -170,9 +170,17 @@ jobs:
       - name: Deploy to Apache Nexus staging
         working-directory: java
         run: |
+          REF="${{ github.ref_name }}"
+          VERSION="${REF#v}"
+          if [[ "$VERSION" == *-rc* ]]; then
+            DESC="Apache Paimon Mosaic, version ${VERSION%-rc*}, release candidate ${VERSION#*-rc}"
+          else
+            DESC="Apache Paimon Mosaic, version ${VERSION}"
+          fi
           mvn clean deploy \
             -Prelease \
-            -DskipTests
+            -DskipTests \
+            -DstagingDescription="$DESC"
         env:
           MAVEN_USERNAME: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}


### PR DESCRIPTION
The Java release CI did not set a staging repository description, so Nexus showed the default "org.apache.paimon:mosaic:0.2.0". This derives the description from the release tag instead, matching how the rest of Paimon names its staging repos:

  v0.2.0-rc1  ->  Apache Paimon Mosaic, version 0.2.0, release candidate 1
  v0.2.0      ->  Apache Paimon Mosaic, version 0.2.0

Display-only label in the Nexus UI; no effect on artifacts.