### PR TITLE
ci: gate PyPI publish on successful rust and java releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
 
   python-publish:
     name: Python publish
-    needs: [python-wheels]
+    needs: [rust, java, python-wheels]
     if: startsWith(github.ref, 'refs/tags/')
     uses: ./.github/workflows/release-python-publish.yml
     secrets: inherit


### PR DESCRIPTION
### Problem
`python-publish` only declares `needs: [python-wheels]`. If the rust (crates.io) or java (Nexus) release job fails, the PyPI wheels are still published. PyPI uploads are irreversible, so a partial release leaves the three languages on mismatched versions — the only recovery is to burn the version and cut a new one.

### Fix
Gate the publish on all three upstream jobs:
```yaml
needs: [rust, java, python-wheels]
```
If rust or java fails, python-publish is skipped — no half-released version. rust / java / python-wheels still run in parallel; only the final upload waits, so there is no measurable slowdown.
