### PR TITLE
ci: build linux wheels in manylinux container, drop cibuildwheel

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -37,6 +37,10 @@ permissions:
 jobs:
   wheels-linux:
     runs-on: ${{ matrix.os }}
+    # Build inside the manylinux image directly. Container images are not subject
+    # to the ASF GitHub Actions allowlist, so this avoids depending on any
+    # third-party action (cibuildwheel was removed from the allowlist).
+    container: quay.io/pypa/manylinux_2_28_${{ matrix.arch }}
     strategy:
       fail-fast: false
       matrix:
@@ -56,31 +60,24 @@ jobs:
           PEP440_VERSION=$(echo "$TAG" | sed 's/-rc/rc/')
           sed -i "s/^version = .*/version = \"${PEP440_VERSION}\"/" python/pyproject.toml
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Build native library
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          cargo build --release -p paimon-mosaic-ffi
+          cp target/release/libpaimon_mosaic_ffi.so python/mosaic/
 
-      - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e
-        with:
-          package-dir: python
-          output-dir: wheelhouse
-        env:
-          CIBW_BUILD: "cp39-manylinux_${{ matrix.arch }}"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_ALL_LINUX: >
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y &&
-            source $HOME/.cargo/env &&
-            cargo build --release -p paimon-mosaic-ffi &&
-            cp target/release/libpaimon_mosaic_ffi.so {package}/mosaic/
+      - name: Build and repair wheel
+        run: |
+          /opt/python/cp39-cp39/bin/python -m build --wheel python -o wheelhouse
+          auditwheel repair wheelhouse/*.whl -d wheelhouse
+          rm wheelhouse/*-linux_*.whl
 
       - name: Upload wheels
         uses: actions/upload-artifact@v5
         with:
           name: wheels-linux-${{ matrix.arch }}
-          path: wheelhouse/*.whl
+          path: wheelhouse/*manylinux*.whl
 
   wheels-macos:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
**Problem:** the Release workflow will startup_failure on release tags — ASF removed `pypa/cibuildwheel` from the org Actions allowlist. The 0.2.0-rc1 wheels were built before the change, but cutting the final v0.2.0 tag would now fail (same issue already hit paimon-vector-index rc3).

**Fix:** build linux wheels inside the `manylinux_2_28` image. Container images aren't subject to the allowlist, so the python release path no longer depends on any third-party action (publish already uses allowlisted gh-action-pypi-publish). manylinux_2_28 / cp39 / ffi.so / auditwheel preserved; mac/win unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)