### PR TITLE
ci: bump cibuildwheel to v4.1.0 (allowlisted SHA)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55
         with:
           package-dir: python
           output-dir: wheelhouse


### PR DESCRIPTION
**DO NOT MERGE until 0.2.0 vote passes** — hold so the voted source tree is untouched; merge right before cutting the final v0.2.0 tag.

**Problem:** release-python.yml pins cibuildwheel at a 5-month-old v3.3.1 SHA. ASF tightened the Actions allowlist and dropped that SHA, so Release startup_failures on tags. 0.2.0-rc1 wheels predate the change, so the vote is unaffected.

**Fix:** bump to v4.1.0, a current allowlisted SHA. One line; mac/win unchanged.