### PR TITLE
docs: add 0.2.0 to releases page

### DIFF
--- a/docs/releases.html
+++ b/docs/releases.html
@@ -73,6 +73,22 @@
 
             <h2>Past Releases</h2>
 
+            <h3>0.2.0</h3>
+            <p>Apache Paimon Mosaic 0.2.0. Key changes:</p>
+            <ul>
+                <li>MAP type support with flattened columnar storage</li>
+                <li>Refactored child column layout metadata for complex types</li>
+                <li>Deterministic BPE name encoding with expanded test coverage</li>
+                <li>Java native library glibc baseline fix for broader Linux compatibility</li>
+            </ul>
+            <p>
+                <a href="https://downloads.apache.org/paimon/paimon-mosaic-0.2.0/">Source release</a> |
+                <a href="https://github.com/apache/paimon-mosaic/releases/tag/v0.2.0">Release notes</a> |
+                <a href="https://crates.io/crates/paimon-mosaic-core/0.2.0">Rust crate</a> |
+                <a href="https://repo.maven.apache.org/maven2/org/apache/paimon/mosaic/0.2.0/">Java artifacts</a> |
+                <a href="https://pypi.org/project/paimon-mosaic/0.2.0/">Python package</a>
+            </p>
+
             <h3>0.1.0</h3>
             <p>The first release of Apache Paimon Mosaic. Key features:</p>
             <ul>


### PR DESCRIPTION
Add the 0.2.0 entry to docs/releases.html (links: source/notes/crates/maven/pypi, all live). Mirrors the 0.1.0 block.