### PR TITLE
build: exclude native libs from sources jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -147,6 +147,11 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <excludes>
+                                <exclude>native/**</exclude>
+                            </excludes>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Problem
`maven-source-plugin` bundles `src/main/resources/` wholesale, so the 4 platform native libs (~5.5MB) dropped into `src/main/resources/native/` during the release build leak into the `-sources.jar`, making it nearly as large as the main jar (sources should be source-only).

## Fix
Exclude `native/**` from the source plugin so the sources jar carries source only. Main jar unchanged.

## Verification
Local `mvn -Prelease clean package -DskipTests -Dgpg.skip=true`: sources jar contains 0 native libs, source files intact. Same fix as paimon-vector-index #50.