### PR TITLE
Move Java staging deployment to a hardened local release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-script-test:
+    name: Release script (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check shell syntax
+        run: |
+          /bin/bash -n tools/deploy_java_staging.sh
+          /bin/bash -n tools/validate_java_staging_artifacts.sh
+          /bin/bash -n tools/tests/deploy_java_staging_test.sh
+
+      - name: Test Java staging deploy safety
+        run: /bin/bash tools/tests/deploy_java_staging_test.sh
+
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -119,7 +119,7 @@ jobs:
           name: native-${{ matrix.os_name }}-${{ matrix.arch }}
           path: target/${{ matrix.target }}/release/${{ matrix.lib_name }}
 
-  deploy-staging:
+  package-java:
     if: github.repository == 'apache/paimon-mosaic' && startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc')
     runs-on: ubuntu-latest
     needs: [build-native]
@@ -158,30 +158,17 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
-          server-id: apache.releases.https
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: maven
 
       - name: Show Maven version
         run: mvn --version
 
-      - name: Deploy to Apache Nexus staging
+      - name: Package Java artifact
         working-directory: java
-        run: |
-          REF="${{ github.ref_name }}"
-          VERSION="${REF#v}"
-          if [[ "$VERSION" == *-rc* ]]; then
-            DESC="Apache Paimon Mosaic, version ${VERSION%-rc*}, release candidate ${VERSION#*-rc}"
-          else
-            DESC="Apache Paimon Mosaic, version ${VERSION}"
-          fi
-          mvn clean deploy \
-            -Prelease \
-            -DskipTests \
-            -DstagingDescription="$DESC"
-        env:
-          MAVEN_USERNAME: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn clean verify -Prelease -Dgpg.skip=true -DskipTests
+
+      - name: Upload Java package
+        uses: actions/upload-artifact@v5
+        with:
+          name: java-package
+          path: java/target/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
   java:
     name: Java release
     uses: ./.github/workflows/release-java.yml
-    secrets: inherit
 
   python-wheels:
     name: Python wheels

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub const MAGIC: [u8; 4] = [b'M', b'O', b'S', b'A'];
+pub const MAGIC: [u8; 4] = *b"MOSA";
 pub const VERSION: u8 = 1;
 pub const FOOTER_SIZE: usize = 32;
 

--- a/docs/creating-a-release.html
+++ b/docs/creating-a-release.html
@@ -69,19 +69,19 @@
                 <li><a href="#promote-the-release">Promote the release</a></li>
             </ol>
 
-            <h3>Automated Publishing</h3>
-            <p>When a version tag is pushed, the <code>Release</code> workflow orchestrates language-specific release jobs:</p>
+            <h3>Automated and Local Publishing</h3>
+            <p>When a version tag is pushed, the <code>Release</code> workflow orchestrates language-specific release jobs. Java signing and Nexus deployment are intentionally completed on the Release Manager's machine:</p>
             <table>
                 <thead>
                     <tr><th>Component</th><th>Tag Pattern</th><th>Published To</th><th>Pre-release (<code>-rc</code>) Behavior</th><th>Ordering</th></tr>
                 </thead>
                 <tbody>
                     <tr><td>Rust crate</td><td><code>v0.1.0</code></td><td>crates.io</td><td>Dry-run only</td><td>Runs in parallel</td></tr>
-                    <tr><td>Java binding</td><td><code>v0.1.0</code></td><td>Apache Nexus staging</td><td>Deploys to staging</td><td>Runs in parallel</td></tr>
+                    <tr><td>Java binding</td><td><code>v0.1.0</code></td><td>CI artifacts, then Apache Nexus staging</td><td>CI packages only; the Release Manager deploys locally</td><td>CI runs in parallel; local deploy follows a successful run</td></tr>
                     <tr><td>Python binding</td><td><code>v0.1.0</code></td><td>PyPI</td><td>Publishes to TestPyPI</td><td>Publishes only after Rust and Java jobs succeed</td></tr>
                 </tbody>
             </table>
-            <p>The Release Manager's primary responsibility is managing the <strong>source release</strong> (tarball + signature) and coordinating the community vote. Language artifact publishing is handled by CI once the tag is pushed.</p>
+            <p>The Release Manager manages the <strong>source release</strong> (tarball + signature), performs the local signed Java staging deployment, and coordinates the community vote. Rust and Python publishing remain handled by CI.</p>
 
             <!-- ============================================================ -->
             <h2 id="decide-to-release">Decide to Release</h2>
@@ -140,14 +140,11 @@ svn ci -m "Add &lt;YOUR_NAME&gt;'s public key"</code></pre>
                 </thead>
                 <tbody>
                     <tr><td><code>CARGO_REGISTRY_TOKEN</code></td><td>crates.io publishing</td></tr>
-                    <tr><td><code>NEXUS_STAGE_DEPLOYER_USER</code></td><td>Apache Nexus staging</td></tr>
-                    <tr><td><code>NEXUS_STAGE_DEPLOYER_PW</code></td><td>Apache Nexus staging</td></tr>
-                    <tr><td><code>GPG_SECRET_KEY</code></td><td>Java artifact signing</td></tr>
-                    <tr><td><code>GPG_PASSPHRASE</code></td><td>Java artifact signing</td></tr>
                     <tr><td><code>PYPI_API_TOKEN</code></td><td>PyPI publishing</td></tr>
                     <tr><td><code>TEST_PYPI_API_TOKEN</code></td><td>TestPyPI publishing</td></tr>
                 </tbody>
             </table>
+            <p>Do not store the Java signing key or Nexus credentials in GitHub Actions secrets. Configure them only on the Release Manager's machine as described in <a href="https://github.com/apache/paimon-mosaic/blob/main/tools/README.md">the release tools guide</a>.</p>
 
             <h3>Clone into a Fresh Workspace</h3>
 <pre><code>git clone https://github.com/apache/paimon-mosaic.git
@@ -219,11 +216,30 @@ git push origin ${RC_TAG}</code></pre>
             <p>After pushing, verify in <a href="https://github.com/apache/paimon-mosaic/actions">GitHub Actions</a> that the <code>Release</code> workflow succeeds:</p>
             <ul>
                 <li><strong>Rust release</strong> &mdash; dry-run check (does not publish for RC tags)</li>
-                <li><strong>Java release</strong> &mdash; builds native JNI libraries for 4 platforms, deploys JAR to Apache Nexus staging</li>
+                <li><strong>Java release</strong> &mdash; builds native JNI libraries for 4 platforms, verifies the release profile without signing, and uploads the JARs as workflow artifacts</li>
                 <li><strong>Python wheels</strong> &mdash; builds wheels for 4 platforms</li>
                 <li><strong>Python publish</strong> &mdash; publishes to TestPyPI only after the Rust, Java, and Python wheel jobs succeed</li>
             </ul>
             <p>If only the Python publish job fails due to a transient PyPI or TestPyPI issue, use <strong>Re-run failed jobs</strong> on the <code>Release</code> workflow. The successful Rust, Java, and Python wheel jobs do not need to be repeated.</p>
+
+            <h3>Deploy Java Artifacts to Nexus Staging</h3>
+            <p>Open the successful <code>Release</code> workflow run for <code>${RC_TAG}</code> and copy its run id from the URL. Then check out the exact RC tag and perform a dry-run before the signed deployment:</p>
+<pre><code>RELEASE_RUN_ID="12345678901"
+
+git checkout ${RC_TAG}
+git tag -v ${RC_TAG}
+
+./tools/deploy_java_staging.sh \
+  --release-version ${RELEASE_VERSION} \
+  --rc ${RC_NUM} \
+  --run-id ${RELEASE_RUN_ID} \
+  --dry-run
+
+./tools/deploy_java_staging.sh \
+  --release-version ${RELEASE_VERSION} \
+  --rc ${RC_NUM} \
+  --run-id ${RELEASE_RUN_ID}</code></pre>
+            <p>The script requires the workflow run ref, RC tag, release version, RC number, commit SHA, and local checkout to agree. It rejects tracked, untracked, or ignored Java package and release-tool inputs and validates the generated JARs during Maven's <code>verify</code> phase before the same lifecycle reaches Nexus deployment. Record the resulting <code>orgapachepaimon-XXXX</code> staging repository id for the vote email. See <a href="https://github.com/apache/paimon-mosaic/blob/main/tools/README.md">the release tools guide</a> for local GPG and Maven credential setup.</p>
 
             <h3>Create Source Release Artifacts</h3>
             <p>Create source release artifacts from the same commit as the RC tag:</p>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -205,5 +205,38 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>staging-artifact-validation</id>
+            <activation>
+                <property>
+                    <name>stagingValidationScript</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.5.0</version>
+                        <executions>
+                            <execution>
+                                <id>validate-staging-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${stagingValidationScript}</executable>
+                                    <arguments>
+                                        <argument>${project.build.directory}</argument>
+                                        <argument>${project.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,185 @@
+# Release tools
+
+This directory contains helper scripts used by release managers and committers.
+
+## Java staging deploy
+
+`deploy_java_staging.sh` deploys the Java release candidate artifacts to Apache
+Nexus staging from a committer/RM machine.
+
+GitHub Actions does **not** sign or deploy the Java staging artifacts. The
+release workflow only:
+
+1. builds the four JNI native libraries;
+2. verifies the Java release profile with GPG disabled; and
+3. uploads the native libraries and verified Java jars as workflow artifacts.
+
+The committer then runs this script locally. The script checks that the release
+workflow run succeeded for the current RC tag, downloads the native libraries,
+verifies their platform formats, places them into the Java resource tree, and
+runs Maven locally.
+
+### Required local setup
+
+- `gh` GitHub CLI, authenticated with access to `apache/paimon-mosaic`;
+- JDK and Maven;
+- local GPG setup for the release signing key;
+- Maven credentials for server id `apache.releases.https`.
+
+Maven credentials can be supplied by one of these methods:
+
+- configure `~/.m2/settings.xml`;
+- pass `--maven-settings /path/to/settings.xml`;
+- set `NEXUS_STAGE_DEPLOYER_USER` and `NEXUS_STAGE_DEPLOYER_PW` so the script can
+  create a temporary Maven settings file.
+
+### Pre-flight checks
+
+Run these checks before the first dry-run:
+
+```bash
+gh auth status
+gpg --list-secret-keys --keyid-format LONG
+mvn --version
+```
+
+Confirm the signing key's public key is already published in Paimon KEYS:
+
+```text
+https://downloads.apache.org/paimon/KEYS
+```
+
+Confirm Maven can use server id `apache.releases.https`. A typical
+`~/.m2/settings.xml` entry is:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>apache.releases.https</id>
+      <username>YOUR_NEXUS_TOKEN_USER</username>
+      <password>YOUR_NEXUS_TOKEN_PASSWORD</password>
+    </server>
+  </servers>
+</settings>
+```
+
+The Nexus token is from:
+
+```text
+https://repository.apache.org/ -> Profile -> User Token
+```
+
+### Find the run id
+
+After pushing the RC tag, open the GitHub Actions run for that RC tag. Use the
+`Release` workflow run triggered by the tag, for example `v0.3.0-rc1`.
+
+The run id is the number in the workflow run URL:
+
+```text
+https://github.com/apache/paimon-mosaic/actions/runs/12345678901
+```
+
+The run id is:
+
+```text
+12345678901
+```
+
+Do not use the job id, artifact id, PR number, or commit SHA. The script checks
+that this run completed successfully and that the run's commit matches the RC tag
+checked out locally.
+
+### Parameters
+
+Required for the normal release flow:
+
+- `--release-version 0.3.0`: Java artifact version in `java/pom.xml`. This does
+  not include the RC suffix.
+- `--rc 1`: RC number. Together with `--release-version`, this derives the tag
+  `v0.3.0-rc1`.
+- `--run-id 12345678901`: GitHub Actions run id from the RC tag's `Release`
+  workflow URL. The script uses it to download the four `native-*` artifacts.
+
+Common options:
+
+- `--dry-run`: verify locally without signing or deploying to Nexus.
+- `--maven-settings FILE`: use a specific Maven `settings.xml` containing server
+  id `apache.releases.https`.
+- `--staging-description TEXT`: override the Nexus staging description.
+- `--no-skip-tests`: run Maven tests during dry-run or deploy.
+
+Less common options:
+
+- `--tag TAG`: use an explicit RC tag instead of deriving `vVERSION-rcN`.
+- `--repo OWNER/REPO`: GitHub repository for `gh`; defaults to
+  `apache/paimon-mosaic`.
+- `--no-cleanup`: keep `java/src/main/resources/native` after the script exits.
+- `--skip-native-file-check`: skip native binary format checks.
+
+The last option is an escape hatch. Avoid it for normal releases.
+
+### Dry-run before publishing
+
+Always run a dry-run first with the real RC workflow artifacts:
+
+```bash
+./tools/deploy_java_staging.sh \
+  --release-version 0.3.0 \
+  --rc 1 \
+  --run-id 12345678901 \
+  --dry-run
+```
+
+Dry-run mode validates the GitHub Actions run id, downloads the native
+libraries, and runs:
+
+```bash
+mvn clean verify -Prelease -Dgpg.skip=true -DskipTests
+```
+
+It does not sign and does not deploy to Nexus. It verifies:
+
+- `java/pom.xml` version matches `--release-version`;
+- current checkout matches the RC tag, such as `v0.3.0-rc1`;
+- Java package inputs have no local changes;
+- the GitHub Actions run is a successful tag-push `Release` workflow run and its
+  commit matches the RC tag;
+- all four native libraries are present;
+- native library file formats match their target platforms;
+- the Java jar, sources jar, and javadoc jar are produced;
+- the Java jar contains all four native library entries.
+
+### Deploy to Nexus staging
+
+After the dry-run succeeds, run the same command without `--dry-run`:
+
+```bash
+./tools/deploy_java_staging.sh \
+  --release-version 0.3.0 \
+  --rc 1 \
+  --run-id 12345678901
+```
+
+The script repeats the local preflight before creating any remote staging
+artifacts:
+
+```bash
+mvn clean verify -Prelease -Dgpg.skip=true -DskipTests
+```
+
+After that passes, it runs the local Nexus staging deploy:
+
+```bash
+mvn deploy -Prelease -DskipTests \
+  -DstagingDescription="Apache Paimon Mosaic, version 0.3.0, release candidate 1"
+```
+
+The Maven output contains the Nexus staging repository id, for example:
+
+```text
+orgapachepaimon-XXXX
+```
+
+Use that id in the release vote email.

--- a/tools/README.md
+++ b/tools/README.md
@@ -22,6 +22,7 @@ runs Maven locally.
 ### Required local setup
 
 - `gh` GitHub CLI, authenticated with access to `apache/paimon-mosaic`;
+- Bash 3.2 or newer;
 - JDK and Maven;
 - local GPG setup for the release signing key;
 - Maven credentials for server id `apache.releases.https`.
@@ -88,8 +89,8 @@ The run id is:
 ```
 
 Do not use the job id, artifact id, PR number, or commit SHA. The script checks
-that this run completed successfully and that the run's commit matches the RC tag
-checked out locally.
+that this run completed successfully and that both the run's tag ref and commit
+match the RC tag checked out locally.
 
 ### Parameters
 
@@ -112,7 +113,8 @@ Common options:
 
 Less common options:
 
-- `--tag TAG`: use an explicit RC tag instead of deriving `vVERSION-rcN`.
+- `--tag TAG`: explicitly provide the RC tag. When used, it must exactly equal
+  `vVERSION-rcN` derived from `--release-version` and `--rc`.
 - `--repo OWNER/REPO`: GitHub repository for `gh`; defaults to
   `apache/paimon-mosaic`.
 - `--no-cleanup`: keep `java/src/main/resources/native` after the script exits.
@@ -136,16 +138,19 @@ Dry-run mode validates the GitHub Actions run id, downloads the native
 libraries, and runs:
 
 ```bash
-mvn clean verify -Prelease -Dgpg.skip=true -DskipTests
+mvn clean verify -Prelease -Dgpg.skip=true -DskipTests \
+  -DstagingValidationScript=/absolute/path/to/validate_java_staging_artifacts.sh
 ```
 
 It does not sign and does not deploy to Nexus. It verifies:
 
 - `java/pom.xml` version matches `--release-version`;
 - current checkout matches the RC tag, such as `v0.3.0-rc1`;
-- Java package inputs have no local changes;
+- Java package and release-tool inputs have no tracked, untracked, or ignored
+  local files, except for the managed native resource directory and Maven's
+  `target` directory;
 - the GitHub Actions run is a successful tag-push `Release` workflow run and its
-  commit matches the RC tag;
+  tag ref and commit both match the RC tag;
 - all four native libraries are present;
 - native library file formats match their target platforms;
 - the Java jar, sources jar, and javadoc jar are produced;
@@ -162,19 +167,18 @@ After the dry-run succeeds, run the same command without `--dry-run`:
   --run-id 12345678901
 ```
 
-The script repeats the local preflight before creating any remote staging
-artifacts:
+The real deployment uses one Maven lifecycle:
 
 ```bash
-mvn clean verify -Prelease -Dgpg.skip=true -DskipTests
+mvn clean deploy -Prelease -DskipTests \
+  -DstagingDescription="Apache Paimon Mosaic, version 0.3.0, release candidate 1" \
+  -DstagingValidationScript=/absolute/path/to/validate_java_staging_artifacts.sh
 ```
 
-After that passes, it runs the local Nexus staging deploy:
-
-```bash
-mvn deploy -Prelease -DskipTests \
-  -DstagingDescription="Apache Paimon Mosaic, version 0.3.0, release candidate 1"
-```
+The validation script is bound to Maven's `verify` phase. It checks the main,
+sources, and javadoc JARs and all four native entries before that same lifecycle
+continues to `install` and `deploy`; Maven does not perform a second build between
+preflight validation and the Nexus upload.
 
 The Maven output contains the Nexus staging repository id, for example:
 

--- a/tools/deploy_java_staging.sh
+++ b/tools/deploy_java_staging.sh
@@ -54,7 +54,7 @@ Required:
   --run-id RUN_ID            GitHub Actions run id containing native-* artifacts.
 
 Options:
-  --tag TAG                  RC tag. Defaults to vVERSION-rcN.
+  --tag TAG                  RC tag. Must equal vVERSION-rcN; defaults to it.
   --repo REPO                GitHub repository. Defaults to apache/paimon-mosaic.
   --dry-run                  Build and verify release artifacts locally only.
                              Does not sign or deploy to Nexus.
@@ -88,8 +88,8 @@ EOF
 require_option_value() {
   local option=$1
   local value=${2-}
-  if [[ $# -lt 2 || -z "$value" ]]; then
-    echo "$option requires a value" >&2
+  if [[ $# -lt 2 || -z "$value" || "$value" == -* ]]; then
+    echo "$option requires a value that is not another option" >&2
     usage >&2
     exit 1
   fi
@@ -173,31 +173,46 @@ require_value() {
 REPO=${REPO:-apache/paimon-mosaic}
 
 require_value "--release-version" "$RELEASE_VERSION"
+require_value "--rc" "$RC_NUMBER"
+require_value "--run-id" "$RUN_ID"
 
+if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "--release-version must use X.Y.Z numeric form: $RELEASE_VERSION" >&2
+  exit 1
+fi
+
+if [[ ! "$RC_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--rc must be a positive integer: $RC_NUMBER" >&2
+  exit 1
+fi
+
+if [[ ! "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--run-id must be a positive integer: $RUN_ID" >&2
+  exit 1
+fi
+
+EXPECTED_TAG="v${RELEASE_VERSION}-rc${RC_NUMBER}"
 if [[ -z "$TAG" ]]; then
-  require_value "--rc" "$RC_NUMBER"
-  TAG="v${RELEASE_VERSION}-rc${RC_NUMBER}"
+  TAG=$EXPECTED_TAG
+elif [[ "$TAG" != "$EXPECTED_TAG" ]]; then
+  echo "--tag must match --release-version and --rc." >&2
+  echo "tag:      $TAG" >&2
+  echo "expected: $EXPECTED_TAG" >&2
+  exit 1
 fi
 
 if [[ -z "$STAGING_DESCRIPTION" ]]; then
-  if [[ -n "$RC_NUMBER" ]]; then
-    STAGING_DESCRIPTION="Apache Paimon Mosaic, version ${RELEASE_VERSION}, release candidate ${RC_NUMBER}"
-  else
-    STAGING_DESCRIPTION="Apache Paimon Mosaic, version ${RELEASE_VERSION}, release candidate ${TAG#*-rc}"
-  fi
-fi
-
-if [[ -z "$RUN_ID" ]]; then
-  echo "--run-id is required" >&2
-  usage >&2
-  exit 1
+  STAGING_DESCRIPTION="Apache Paimon Mosaic, version ${RELEASE_VERSION}, release candidate ${RC_NUMBER}"
 fi
 
 NATIVE_DIR="$SCRIPT_DIR/release/java-native-${TAG}"
 
-if [[ -n "$MAVEN_SETTINGS" && ! -f "$MAVEN_SETTINGS" ]]; then
-  echo "--maven-settings does not exist: $MAVEN_SETTINGS" >&2
-  exit 1
+if [[ -n "$MAVEN_SETTINGS" ]]; then
+  if [[ ! -f "$MAVEN_SETTINGS" ]]; then
+    echo "--maven-settings does not exist: $MAVEN_SETTINGS" >&2
+    exit 1
+  fi
+  MAVEN_SETTINGS=$(cd "$(dirname "$MAVEN_SETTINGS")" && pwd)/$(basename "$MAVEN_SETTINGS")
 fi
 
 POM_VERSION=$(
@@ -225,20 +240,41 @@ else
 fi
 
 check_java_package_inputs_clean() {
-  local paths=(java DEPENDENCIES.rust.tsv)
+  local paths=(
+    java
+    DEPENDENCIES.rust.tsv
+    tools/deploy_java_staging.sh
+    tools/validate_java_staging_artifacts.sh
+  )
+  local ignored
   local untracked
 
   if ! git -C "$REPO_DIR" diff --quiet -- "${paths[@]}" ||
      ! git -C "$REPO_DIR" diff --cached --quiet -- "${paths[@]}"; then
-    echo "Java package inputs have local changes. Commit or revert them before publishing." >&2
+    echo "Java package or release tool inputs have local changes." >&2
+    echo "Commit or revert them before publishing." >&2
     git -C "$REPO_DIR" status --short -- "${paths[@]}" >&2
     exit 1
   fi
 
   untracked=$(git -C "$REPO_DIR" ls-files --others --exclude-standard -- "${paths[@]}")
   if [[ -n "$untracked" ]]; then
-    echo "Java package inputs contain untracked files. Remove or commit them before publishing." >&2
+    echo "Java package or release tool inputs contain untracked files." >&2
+    echo "Remove or commit them before publishing." >&2
     printf '%s\n' "$untracked" >&2
+    exit 1
+  fi
+
+  ignored=$(
+    git -C "$REPO_DIR" ls-files --others --ignored --exclude-standard -- "${paths[@]}" |
+      sed \
+        -e '\#^java/target/#d' \
+        -e '\#^java/src/main/resources/native/#d'
+  )
+  if [[ -n "$ignored" ]]; then
+    echo "Java package inputs contain ignored files that could enter release artifacts." >&2
+    echo "Remove these files before publishing:" >&2
+    printf '%s\n' "$ignored" >&2
     exit 1
   fi
 }
@@ -247,7 +283,12 @@ check_java_package_inputs_clean
 
 validate_github_run() {
   local run_output
-  local run_info
+  local run_status
+  local run_conclusion
+  local run_head_sha
+  local run_head_branch
+  local run_workflow_name
+  local run_event
   if ! run_output=$(
     gh run view "$RUN_ID" \
       --repo "$REPO" \
@@ -257,14 +298,12 @@ validate_github_run() {
     echo "Failed to read GitHub Actions run: $RUN_ID" >&2
     exit 1
   fi
-  mapfile -t run_info <<<"$run_output"
-
-  local run_status=${run_info[0]:-}
-  local run_conclusion=${run_info[1]:-}
-  local run_head_sha=${run_info[2]:-}
-  local run_head_branch=${run_info[3]:-}
-  local run_workflow_name=${run_info[4]:-}
-  local run_event=${run_info[5]:-}
+  run_status=$(printf '%s\n' "$run_output" | sed -n '1p')
+  run_conclusion=$(printf '%s\n' "$run_output" | sed -n '2p')
+  run_head_sha=$(printf '%s\n' "$run_output" | sed -n '3p')
+  run_head_branch=$(printf '%s\n' "$run_output" | sed -n '4p')
+  run_workflow_name=$(printf '%s\n' "$run_output" | sed -n '5p')
+  run_event=$(printf '%s\n' "$run_output" | sed -n '6p')
 
   if [[ "$run_status" != "completed" || "$run_conclusion" != "success" ]]; then
     echo "GitHub Actions run $RUN_ID is not a successful completed run." >&2
@@ -279,6 +318,11 @@ validate_github_run() {
 
   if [[ "$run_event" != "push" ]]; then
     echo "GitHub Actions run $RUN_ID was triggered by '$run_event', expected a tag push." >&2
+    exit 1
+  fi
+
+  if [[ "$run_head_branch" != "$TAG" ]]; then
+    echo "GitHub Actions run $RUN_ID is for '$run_head_branch', expected '$TAG'." >&2
     exit 1
   fi
 
@@ -482,69 +526,46 @@ if [[ -n "$MAVEN_SETTINGS" ]]; then
   MVN_BASE_CMD+=("-s" "$MAVEN_SETTINGS")
 fi
 
-VERIFY_CMD=("${MVN_BASE_CMD[@]}" clean verify -Prelease -Dgpg.skip=true)
-if [[ "$SKIP_TESTS" == "true" ]]; then
-  VERIFY_CMD+=(-DskipTests)
+ARTIFACT_VALIDATOR="$SCRIPT_DIR/validate_java_staging_artifacts.sh"
+if [[ ! -x "$ARTIFACT_VALIDATOR" ]]; then
+  echo "Java staging artifact validator is not executable: $ARTIFACT_VALIDATOR" >&2
+  exit 1
 fi
 
-validate_maven_artifacts() {
-  local jar_file="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}.jar"
-  local sources_jar="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}-sources.jar"
-  local javadoc_jar="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}-javadoc.jar"
-  local artifact
-  local native_entry
-
-  for artifact in "$jar_file" "$sources_jar" "$javadoc_jar"; do
-    if [[ ! -f "$artifact" ]]; then
-      echo "Expected Maven artifact is missing: $artifact" >&2
-      exit 1
-    fi
-  done
-
-  for native_entry in \
-    native/linux/x86_64/libpaimon_mosaic_jni.so \
-    native/linux/aarch64/libpaimon_mosaic_jni.so \
-    native/macos/aarch64/libpaimon_mosaic_jni.dylib \
-    native/windows/x86_64/paimon_mosaic_jni.dll
-  do
-    if ! jar tf "$jar_file" | grep -qx "$native_entry"; then
-      echo "Packaged jar is missing native entry: $native_entry" >&2
-      exit 1
-    fi
-  done
-}
+VALIDATION_PROPERTY="-DstagingValidationScript=$ARTIFACT_VALIDATOR"
 
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "Dry-running Java staging build. No artifacts will be deployed to Nexus."
+  MAVEN_CMD=("${MVN_BASE_CMD[@]}" clean verify -Prelease -Dgpg.skip=true "$VALIDATION_PROPERTY")
 else
-  echo "Running Java staging preflight before deploying to Apache Nexus."
+  echo "Running one validated Maven lifecycle before deploying to Apache Nexus."
   echo "Staging description: $STAGING_DESCRIPTION"
+  MAVEN_CMD=(
+    "${MVN_BASE_CMD[@]}" clean deploy -Prelease
+    "-DstagingDescription=$STAGING_DESCRIPTION"
+    "$VALIDATION_PROPERTY"
+  )
 fi
+
+if [[ "$SKIP_TESTS" == "true" ]]; then
+  MAVEN_CMD+=(-DskipTests)
+fi
+
+# Recheck immediately before Maven. The managed native directory and Maven's
+# target directory are the only ignored paths allowed under Java package inputs.
+check_java_package_inputs_clean
 
 (
   cd "$REPO_DIR/java"
-  "${VERIFY_CMD[@]}"
+  "${MAVEN_CMD[@]}"
 )
 
-validate_maven_artifacts
+"$ARTIFACT_VALIDATOR" "$REPO_DIR/java/target" "$RELEASE_VERSION"
 
 echo ""
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "Java staging dry run finished successfully."
 else
-  DEPLOY_CMD=("${MVN_BASE_CMD[@]}" deploy -Prelease "-DstagingDescription=$STAGING_DESCRIPTION")
-  if [[ "$SKIP_TESTS" == "true" ]]; then
-    DEPLOY_CMD+=(-DskipTests)
-  fi
-
-  echo "Preflight passed. Deploying Java artifacts to Apache Nexus staging."
-  (
-    cd "$REPO_DIR/java"
-    "${DEPLOY_CMD[@]}"
-  )
-  validate_maven_artifacts
-
-  echo ""
   echo "Java staging deploy finished."
   echo "Check the Maven output for the orgapachepaimon-XXXX staging repository id."
 fi

--- a/tools/deploy_java_staging.sh
+++ b/tools/deploy_java_staging.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MVN=${MVN:-mvn}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+
+RELEASE_VERSION=
+RC_NUMBER=
+TAG=
+NATIVE_DIR=
+RUN_ID=
+DRY_RUN=false
+SKIP_TESTS=true
+CLEANUP_NATIVE_RESOURCES=true
+MAVEN_SETTINGS=
+STAGING_DESCRIPTION=
+CHECK_NATIVE_FILES=true
+
+usage() {
+  cat <<'EOF'
+Usage:
+  deploy_java_staging.sh --release-version VERSION --rc N --run-id RUN_ID [options]
+
+Deploy Apache Paimon Mosaic Java RC artifacts to Apache Nexus staging from a
+committer/RM machine. Pass the GitHub Actions run id that built the RC native
+libraries; the script verifies the run, downloads the native artifacts, and then
+runs the local Maven deploy.
+
+Required:
+  --release-version VERSION  Release version in java/pom.xml, for example 0.3.0.
+  --rc N                     RC number, for example 1 for v0.3.0-rc1.
+  --run-id RUN_ID            GitHub Actions run id containing native-* artifacts.
+
+Options:
+  --tag TAG                  RC tag. Defaults to vVERSION-rcN.
+  --repo REPO                GitHub repository. Defaults to apache/paimon-mosaic.
+  --dry-run                  Build and verify release artifacts locally only.
+                             Does not sign or deploy to Nexus.
+  --maven-settings FILE      Maven settings.xml containing apache.releases.https.
+  --staging-description TXT  Nexus staging description.
+  --no-skip-tests            Run Maven tests.
+  --no-cleanup               Keep java/src/main/resources/native after exit.
+  --skip-native-file-check   Do not check native binary file formats.
+  -h, --help                 Show this help.
+
+Validate with the real RC artifacts before publishing:
+  ./tools/deploy_java_staging.sh --release-version 0.3.0 --rc 1 \
+    --run-id 12345678901 --dry-run
+
+Publish staging after the dry run succeeds:
+  ./tools/deploy_java_staging.sh --release-version 0.3.0 --rc 1 \
+    --run-id 12345678901
+
+Maven/GPG requirements:
+  Real deploy uses the committer's local GPG setup and Maven credentials for
+  server id apache.releases.https. Configure ~/.m2/settings.xml, pass
+  --maven-settings FILE, or set NEXUS_STAGE_DEPLOYER_USER and
+  NEXUS_STAGE_DEPLOYER_PW for a temporary settings.xml.
+
+gh CLI requirement:
+  --run-id uses the GitHub CLI to check the workflow run and fetch native
+  artifacts. Run `gh auth login` first.
+EOF
+}
+
+require_option_value() {
+  local option=$1
+  local value=${2-}
+  if [[ $# -lt 2 || -z "$value" ]]; then
+    echo "$option requires a value" >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release-version)
+      require_option_value "$@"
+      RELEASE_VERSION=$2
+      shift 2
+      ;;
+    --rc)
+      require_option_value "$@"
+      RC_NUMBER=$2
+      shift 2
+      ;;
+    --tag)
+      require_option_value "$@"
+      TAG=$2
+      shift 2
+      ;;
+    --run-id)
+      require_option_value "$@"
+      RUN_ID=$2
+      shift 2
+      ;;
+    --repo)
+      require_option_value "$@"
+      REPO=$2
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --maven-settings)
+      require_option_value "$@"
+      MAVEN_SETTINGS=$2
+      shift 2
+      ;;
+    --staging-description)
+      require_option_value "$@"
+      STAGING_DESCRIPTION=$2
+      shift 2
+      ;;
+    --no-skip-tests)
+      SKIP_TESTS=false
+      shift
+      ;;
+    --no-cleanup)
+      CLEANUP_NATIVE_RESOURCES=false
+      shift
+      ;;
+    --skip-native-file-check)
+      CHECK_NATIVE_FILES=false
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_value() {
+  local name=$1
+  local value=$2
+  if [[ -z "$value" ]]; then
+    echo "$name is required" >&2
+    usage >&2
+    exit 1
+  fi
+}
+
+REPO=${REPO:-apache/paimon-mosaic}
+
+require_value "--release-version" "$RELEASE_VERSION"
+
+if [[ -z "$TAG" ]]; then
+  require_value "--rc" "$RC_NUMBER"
+  TAG="v${RELEASE_VERSION}-rc${RC_NUMBER}"
+fi
+
+if [[ -z "$STAGING_DESCRIPTION" ]]; then
+  if [[ -n "$RC_NUMBER" ]]; then
+    STAGING_DESCRIPTION="Apache Paimon Mosaic, version ${RELEASE_VERSION}, release candidate ${RC_NUMBER}"
+  else
+    STAGING_DESCRIPTION="Apache Paimon Mosaic, version ${RELEASE_VERSION}, release candidate ${TAG#*-rc}"
+  fi
+fi
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "--run-id is required" >&2
+  usage >&2
+  exit 1
+fi
+
+NATIVE_DIR="$SCRIPT_DIR/release/java-native-${TAG}"
+
+if [[ -n "$MAVEN_SETTINGS" && ! -f "$MAVEN_SETTINGS" ]]; then
+  echo "--maven-settings does not exist: $MAVEN_SETTINGS" >&2
+  exit 1
+fi
+
+POM_VERSION=$(
+  sed -n 's#.*<version>\([^<]*\)</version>.*#\1#p' "$REPO_DIR/java/pom.xml" |
+    sed -n '2p'
+)
+if [[ "$POM_VERSION" != "$RELEASE_VERSION" ]]; then
+  echo "java/pom.xml version is $POM_VERSION, expected $RELEASE_VERSION" >&2
+  echo "Check out the RC tag after bumping versions, then run this script again." >&2
+  exit 1
+fi
+
+if ! git -C "$REPO_DIR" rev-parse -q --verify "$TAG^{commit}" >/dev/null; then
+  echo "Tag $TAG does not exist locally." >&2
+  echo "Run: git fetch --tags && git checkout $TAG" >&2
+  exit 1
+else
+  TAG_COMMIT=$(git -C "$REPO_DIR" rev-parse "$TAG^{commit}")
+  HEAD_COMMIT=$(git -C "$REPO_DIR" rev-parse HEAD)
+  if [[ "$TAG_COMMIT" != "$HEAD_COMMIT" ]]; then
+    echo "Current HEAD is not $TAG." >&2
+    echo "Run: git checkout $TAG" >&2
+    exit 1
+  fi
+fi
+
+check_java_package_inputs_clean() {
+  local paths=(java DEPENDENCIES.rust.tsv)
+  local untracked
+
+  if ! git -C "$REPO_DIR" diff --quiet -- "${paths[@]}" ||
+     ! git -C "$REPO_DIR" diff --cached --quiet -- "${paths[@]}"; then
+    echo "Java package inputs have local changes. Commit or revert them before publishing." >&2
+    git -C "$REPO_DIR" status --short -- "${paths[@]}" >&2
+    exit 1
+  fi
+
+  untracked=$(git -C "$REPO_DIR" ls-files --others --exclude-standard -- "${paths[@]}")
+  if [[ -n "$untracked" ]]; then
+    echo "Java package inputs contain untracked files. Remove or commit them before publishing." >&2
+    printf '%s\n' "$untracked" >&2
+    exit 1
+  fi
+}
+
+check_java_package_inputs_clean
+
+validate_github_run() {
+  local run_output
+  local run_info
+  if ! run_output=$(
+    gh run view "$RUN_ID" \
+      --repo "$REPO" \
+      --json status,conclusion,headSha,headBranch,workflowName,event \
+      --template '{{printf "%s\n%s\n%s\n%s\n%s\n%s\n" .status .conclusion .headSha (or .headBranch "") (or .workflowName "") (or .event "")}}'
+  ); then
+    echo "Failed to read GitHub Actions run: $RUN_ID" >&2
+    exit 1
+  fi
+  mapfile -t run_info <<<"$run_output"
+
+  local run_status=${run_info[0]:-}
+  local run_conclusion=${run_info[1]:-}
+  local run_head_sha=${run_info[2]:-}
+  local run_head_branch=${run_info[3]:-}
+  local run_workflow_name=${run_info[4]:-}
+  local run_event=${run_info[5]:-}
+
+  if [[ "$run_status" != "completed" || "$run_conclusion" != "success" ]]; then
+    echo "GitHub Actions run $RUN_ID is not a successful completed run." >&2
+    echo "status=$run_status conclusion=$run_conclusion" >&2
+    exit 1
+  fi
+
+  if [[ "$run_workflow_name" != "Release" ]]; then
+    echo "GitHub Actions run $RUN_ID is from workflow '$run_workflow_name', expected 'Release'." >&2
+    exit 1
+  fi
+
+  if [[ "$run_event" != "push" ]]; then
+    echo "GitHub Actions run $RUN_ID was triggered by '$run_event', expected a tag push." >&2
+    exit 1
+  fi
+
+  if [[ "$run_head_sha" != "$TAG_COMMIT" ]]; then
+    echo "GitHub Actions run $RUN_ID does not match $TAG." >&2
+    echo "run headSha: $run_head_sha" >&2
+    echo "tag commit:  $TAG_COMMIT" >&2
+    exit 1
+  fi
+
+  echo "Using GitHub Actions run $RUN_ID for native artifacts:"
+  echo "  workflow: ${run_workflow_name:-unknown}"
+  echo "  event:    ${run_event:-unknown}"
+  echo "  ref:      ${run_head_branch:-unknown}"
+  echo "  headSha:  ${run_head_sha:-unknown}"
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required when --run-id is used" >&2
+  exit 1
+fi
+
+validate_github_run
+
+rm -rf "$NATIVE_DIR"
+mkdir -p "$NATIVE_DIR"
+for artifact in \
+  native-linux-x86_64 \
+  native-linux-aarch64 \
+  native-macos-aarch64 \
+  native-windows-x86_64
+do
+  gh run download "$RUN_ID" \
+    --repo "$REPO" \
+    --name "$artifact" \
+    --dir "$NATIVE_DIR/$artifact"
+done
+
+if [[ ! -d "$NATIVE_DIR" ]]; then
+  echo "Native artifact download directory does not exist: $NATIVE_DIR" >&2
+  exit 1
+fi
+
+find_native() {
+  local artifact_layout=$1
+  local resource_layout=$2
+  local resource_without_native=${resource_layout#native/}
+
+  for candidate in \
+    "$NATIVE_DIR/$artifact_layout" \
+    "$NATIVE_DIR/$resource_layout" \
+    "$NATIVE_DIR/$resource_without_native"
+  do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "Missing native artifact. Tried:" >&2
+  echo "  $NATIVE_DIR/$artifact_layout" >&2
+  echo "  $NATIVE_DIR/$resource_layout" >&2
+  echo "  $NATIVE_DIR/$resource_without_native" >&2
+  exit 1
+}
+
+validate_native_file() {
+  local source_file=$1
+  local label=$2
+
+  if [[ "$CHECK_NATIVE_FILES" != "true" ]]; then
+    return
+  fi
+
+  if ! command -v file >/dev/null 2>&1; then
+    echo "WARNING: 'file' command not found; skipping native file format checks." >&2
+    return
+  fi
+
+  local info
+  info=$(file "$source_file")
+  case "$label" in
+    linux-x86_64)
+      if ! grep -Eq 'ELF 64-bit.*(x86-64|x86_64)' <<<"$info"; then
+        echo "Unexpected linux x86_64 native file: $info" >&2
+        exit 1
+      fi
+      ;;
+    linux-aarch64)
+      if ! grep -Eq 'ELF 64-bit.*(ARM aarch64|AArch64|aarch64|ARM64)' <<<"$info"; then
+        echo "Unexpected linux aarch64 native file: $info" >&2
+        exit 1
+      fi
+      ;;
+    macos-aarch64)
+      if ! grep -Eq 'Mach-O 64-bit.*(arm64|aarch64)' <<<"$info"; then
+        echo "Unexpected macOS aarch64 native file: $info" >&2
+        exit 1
+      fi
+      ;;
+    windows-x86_64)
+      if ! grep -Eq 'PE32\+.*(x86-64|x86_64)' <<<"$info"; then
+        echo "Unexpected windows x86_64 native file: $info" >&2
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Unknown native file label: $label" >&2
+      exit 1
+      ;;
+  esac
+}
+
+copy_native() {
+  local source_file=$1
+  local target_rel=$2
+  local label=$3
+  local target_file="$REPO_DIR/java/src/main/resources/$target_rel"
+
+  validate_native_file "$source_file" "$label"
+  mkdir -p "$(dirname "$target_file")"
+  cp "$source_file" "$target_file"
+}
+
+cleanup_native_resources() {
+  if [[ "$CLEANUP_NATIVE_RESOURCES" == "true" ]]; then
+    rm -rf "$REPO_DIR/java/src/main/resources/native"
+  fi
+}
+
+TEMP_SETTINGS=
+cleanup_temp_settings() {
+  if [[ -n "$TEMP_SETTINGS" ]]; then
+    rm -f "$TEMP_SETTINGS"
+  fi
+}
+
+xml_escape() {
+  printf '%s' "$1" |
+    sed \
+      -e 's/&/\&amp;/g' \
+      -e 's/</\&lt;/g' \
+      -e 's/>/\&gt;/g'
+}
+
+cleanup_all() {
+  cleanup_native_resources
+  cleanup_temp_settings
+}
+trap cleanup_all EXIT
+
+rm -rf "$REPO_DIR/java/src/main/resources/native"
+
+copy_native \
+  "$(find_native native-linux-x86_64/libpaimon_mosaic_jni.so native/linux/x86_64/libpaimon_mosaic_jni.so)" \
+  native/linux/x86_64/libpaimon_mosaic_jni.so \
+  linux-x86_64
+copy_native \
+  "$(find_native native-linux-aarch64/libpaimon_mosaic_jni.so native/linux/aarch64/libpaimon_mosaic_jni.so)" \
+  native/linux/aarch64/libpaimon_mosaic_jni.so \
+  linux-aarch64
+copy_native \
+  "$(find_native native-macos-aarch64/libpaimon_mosaic_jni.dylib native/macos/aarch64/libpaimon_mosaic_jni.dylib)" \
+  native/macos/aarch64/libpaimon_mosaic_jni.dylib \
+  macos-aarch64
+copy_native \
+  "$(find_native native-windows-x86_64/paimon_mosaic_jni.dll native/windows/x86_64/paimon_mosaic_jni.dll)" \
+  native/windows/x86_64/paimon_mosaic_jni.dll \
+  windows-x86_64
+
+echo "Native libraries staged for Java package:"
+find "$REPO_DIR/java/src/main/resources/native" -type f | sort
+
+if [[ "$DRY_RUN" != "true" &&
+      -z "$MAVEN_SETTINGS" &&
+      ( -n "${NEXUS_STAGE_DEPLOYER_USER:-}" || -n "${NEXUS_STAGE_DEPLOYER_PW:-}" ) ]]; then
+  if [[ -z "${NEXUS_STAGE_DEPLOYER_USER:-}" || -z "${NEXUS_STAGE_DEPLOYER_PW:-}" ]]; then
+    echo "Both NEXUS_STAGE_DEPLOYER_USER and NEXUS_STAGE_DEPLOYER_PW are required" >&2
+    exit 1
+  fi
+
+  TEMP_SETTINGS=$(mktemp)
+  NEXUS_STAGE_DEPLOYER_USER_XML=$(xml_escape "$NEXUS_STAGE_DEPLOYER_USER")
+  NEXUS_STAGE_DEPLOYER_PW_XML=$(xml_escape "$NEXUS_STAGE_DEPLOYER_PW")
+  cat > "$TEMP_SETTINGS" <<EOF
+<settings>
+  <servers>
+    <server>
+      <id>apache.releases.https</id>
+      <username>${NEXUS_STAGE_DEPLOYER_USER_XML}</username>
+      <password>${NEXUS_STAGE_DEPLOYER_PW_XML}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+  MAVEN_SETTINGS="$TEMP_SETTINGS"
+fi
+
+MVN_BASE_CMD=("$MVN")
+if [[ -n "$MAVEN_SETTINGS" ]]; then
+  MVN_BASE_CMD+=("-s" "$MAVEN_SETTINGS")
+fi
+
+VERIFY_CMD=("${MVN_BASE_CMD[@]}" clean verify -Prelease -Dgpg.skip=true)
+if [[ "$SKIP_TESTS" == "true" ]]; then
+  VERIFY_CMD+=(-DskipTests)
+fi
+
+validate_maven_artifacts() {
+  local jar_file="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}.jar"
+  local sources_jar="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}-sources.jar"
+  local javadoc_jar="$REPO_DIR/java/target/mosaic-${RELEASE_VERSION}-javadoc.jar"
+  local artifact
+  local native_entry
+
+  for artifact in "$jar_file" "$sources_jar" "$javadoc_jar"; do
+    if [[ ! -f "$artifact" ]]; then
+      echo "Expected Maven artifact is missing: $artifact" >&2
+      exit 1
+    fi
+  done
+
+  for native_entry in \
+    native/linux/x86_64/libpaimon_mosaic_jni.so \
+    native/linux/aarch64/libpaimon_mosaic_jni.so \
+    native/macos/aarch64/libpaimon_mosaic_jni.dylib \
+    native/windows/x86_64/paimon_mosaic_jni.dll
+  do
+    if ! jar tf "$jar_file" | grep -qx "$native_entry"; then
+      echo "Packaged jar is missing native entry: $native_entry" >&2
+      exit 1
+    fi
+  done
+}
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry-running Java staging build. No artifacts will be deployed to Nexus."
+else
+  echo "Running Java staging preflight before deploying to Apache Nexus."
+  echo "Staging description: $STAGING_DESCRIPTION"
+fi
+
+(
+  cd "$REPO_DIR/java"
+  "${VERIFY_CMD[@]}"
+)
+
+validate_maven_artifacts
+
+echo ""
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Java staging dry run finished successfully."
+else
+  DEPLOY_CMD=("${MVN_BASE_CMD[@]}" deploy -Prelease "-DstagingDescription=$STAGING_DESCRIPTION")
+  if [[ "$SKIP_TESTS" == "true" ]]; then
+    DEPLOY_CMD+=(-DskipTests)
+  fi
+
+  echo "Preflight passed. Deploying Java artifacts to Apache Nexus staging."
+  (
+    cd "$REPO_DIR/java"
+    "${DEPLOY_CMD[@]}"
+  )
+  validate_maven_artifacts
+
+  echo ""
+  echo "Java staging deploy finished."
+  echo "Check the Maven output for the orgapachepaimon-XXXX staging repository id."
+fi

--- a/tools/tests/deploy_java_staging_test.sh
+++ b/tools/tests/deploy_java_staging_test.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TEST_SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+TOOLS_DIR=$(cd "$TEST_SCRIPT_DIR/.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/paimon-mosaic-staging-test.XXXXXX")
+TEST_COUNT=0
+
+cleanup() {
+  case "$TEST_ROOT" in
+    "${TMPDIR:-/tmp}"/paimon-mosaic-staging-test.*)
+      rm -rf -- "$TEST_ROOT"
+      ;;
+    *)
+      echo "Refusing to remove unexpected test path: $TEST_ROOT" >&2
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file=$1
+  local pattern=$2
+  if ! grep -Fq -- "$pattern" "$file"; then
+    echo "Expected '$pattern' in $file" >&2
+    sed -n '1,160p' "$file" >&2
+    fail "missing expected output"
+  fi
+}
+
+assert_not_contains() {
+  local file=$1
+  local pattern=$2
+  if [[ -f "$file" ]] && grep -Fq -- "$pattern" "$file"; then
+    echo "Did not expect '$pattern' in $file" >&2
+    sed -n '1,160p' "$file" >&2
+    fail "unexpected output"
+  fi
+}
+
+assert_maven_not_invoked() {
+  local fixture=$1
+  if [[ -s "$fixture/maven.log" ]]; then
+    sed -n '1,160p' "$fixture/maven.log" >&2
+    fail "Maven must not be invoked"
+  fi
+}
+
+new_fixture() {
+  FIXTURE_DIR=$(mktemp -d "$TEST_ROOT/fixture.XXXXXX")
+  export FIXTURE_DIR
+
+  mkdir -p \
+    "$FIXTURE_DIR/fake-bin" \
+    "$FIXTURE_DIR/java/src/main/resources" \
+    "$FIXTURE_DIR/tools"
+
+  cp "$TOOLS_DIR/deploy_java_staging.sh" "$FIXTURE_DIR/tools/"
+  cp "$TOOLS_DIR/validate_java_staging_artifacts.sh" "$FIXTURE_DIR/tools/"
+  chmod +x \
+    "$FIXTURE_DIR/tools/deploy_java_staging.sh" \
+    "$FIXTURE_DIR/tools/validate_java_staging_artifacts.sh"
+
+  cat > "$FIXTURE_DIR/java/pom.xml" <<'EOF'
+<project>
+  <parent><version>23</version></parent>
+  <version>0.3.0</version>
+</project>
+EOF
+
+  cat > "$FIXTURE_DIR/.gitignore" <<'EOF'
+java/target/
+java/src/main/resources/native/
+*.class
+EOF
+
+  cat > "$FIXTURE_DIR/fake-bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "$1 $2" == "run view" ]]; then
+  printf 'completed\nsuccess\n%s\n%s\nRelease\npush\n' \
+    "$(git rev-parse HEAD)" "${FAKE_RUN_REF:-v0.3.0-rc1}"
+  exit 0
+fi
+
+if [[ "$1 $2" == "run download" ]]; then
+  artifact=
+  destination=
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --name) artifact=$2; shift 2 ;;
+      --dir) destination=$2; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  mkdir -p "$destination"
+  case "$artifact" in
+    native-linux-x86_64|native-linux-aarch64) file=libpaimon_mosaic_jni.so ;;
+    native-macos-aarch64) file=libpaimon_mosaic_jni.dylib ;;
+    native-windows-x86_64) file=paimon_mosaic_jni.dll ;;
+    *) exit 2 ;;
+  esac
+  : > "$destination/$file"
+  exit 0
+fi
+
+exit 2
+EOF
+
+  cat > "$FIXTURE_DIR/fake-bin/mvn" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+printf '%s\n' "$*" >> "$FAKE_MVN_LOG"
+validation_script=
+for argument in "$@"; do
+  case "$argument" in
+    -DstagingValidationScript=*) validation_script=${argument#*=} ;;
+  esac
+done
+
+mkdir -p target
+: > target/mosaic-0.3.0.jar
+: > target/mosaic-0.3.0-sources.jar
+: > target/mosaic-0.3.0-javadoc.jar
+
+if [[ -z "$validation_script" ]]; then
+  echo "Missing stagingValidationScript Maven property" >&2
+  exit 2
+fi
+"$validation_script" "$PWD/target" 0.3.0
+EOF
+
+  cat > "$FIXTURE_DIR/fake-bin/jar" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+
+if [[ "${1-}" != "tf" ]]; then
+  exit 2
+fi
+cat <<'ENTRIES'
+native/linux/x86_64/libpaimon_mosaic_jni.so
+native/linux/aarch64/libpaimon_mosaic_jni.so
+native/macos/aarch64/libpaimon_mosaic_jni.dylib
+native/windows/x86_64/paimon_mosaic_jni.dll
+ENTRIES
+EOF
+
+  chmod +x "$FIXTURE_DIR/fake-bin/gh" "$FIXTURE_DIR/fake-bin/mvn" "$FIXTURE_DIR/fake-bin/jar"
+  : > "$FIXTURE_DIR/DEPENDENCIES.rust.tsv"
+
+  git -C "$FIXTURE_DIR" init -q
+  git -C "$FIXTURE_DIR" config user.name "Release Script Test"
+  git -C "$FIXTURE_DIR" config user.email "release-script-test@example.invalid"
+  git -C "$FIXTURE_DIR" add .
+  git -C "$FIXTURE_DIR" commit -q -m fixture
+  git -C "$FIXTURE_DIR" tag v0.3.0-rc1
+}
+
+run_script() {
+  local run_ref=${FAKE_RUN_REF:-v0.3.0-rc1}
+  (
+    cd "$FIXTURE_DIR"
+    PATH="$FIXTURE_DIR/fake-bin:$(dirname "$BASH"):$PATH" \
+      MVN="$FIXTURE_DIR/fake-bin/mvn" \
+      FAKE_MVN_LOG="$FIXTURE_DIR/maven.log" \
+      FAKE_RUN_REF="$run_ref" \
+      "$BASH" ./tools/deploy_java_staging.sh \
+        --release-version 0.3.0 \
+        --rc 1 \
+        --run-id 42 \
+        --skip-native-file-check \
+        "$@"
+  )
+}
+
+test_missing_option_value_never_deploys() {
+  new_fixture
+  if run_script --staging-description --dry-run > "$FIXTURE_DIR/output.log" 2>&1; then
+    fail "missing staging description value was accepted"
+  fi
+  assert_contains "$FIXTURE_DIR/output.log" "requires a value that is not another option"
+  assert_maven_not_invoked "$FIXTURE_DIR"
+}
+
+test_ignored_package_input_is_rejected() {
+  new_fixture
+  printf 'unexpected bytecode\n' > "$FIXTURE_DIR/java/src/main/resources/Unexpected.class"
+  if run_script --dry-run > "$FIXTURE_DIR/output.log" 2>&1; then
+    fail "ignored Java package input was accepted"
+  fi
+  assert_contains "$FIXTURE_DIR/output.log" "java/src/main/resources/Unexpected.class"
+  assert_maven_not_invoked "$FIXTURE_DIR"
+}
+
+test_workflow_run_must_match_tag() {
+  new_fixture
+  if FAKE_RUN_REF=v0.3.0-rc2 run_script --dry-run > "$FIXTURE_DIR/output.log" 2>&1; then
+    fail "workflow run from another tag was accepted"
+  fi
+  assert_contains "$FIXTURE_DIR/output.log" "expected 'v0.3.0-rc1'"
+  assert_maven_not_invoked "$FIXTURE_DIR"
+}
+
+test_rc_and_tag_must_match() {
+  new_fixture
+  if run_script --rc 2 --tag v0.3.0-rc1 --dry-run > "$FIXTURE_DIR/output.log" 2>&1; then
+    fail "mismatched RC number and tag were accepted"
+  fi
+  assert_contains "$FIXTURE_DIR/output.log" "expected: v0.3.0-rc2"
+  assert_maven_not_invoked "$FIXTURE_DIR"
+}
+
+test_relative_maven_settings_becomes_absolute() {
+  new_fixture
+  printf '<settings/>\n' > "$FIXTURE_DIR/deploysettings.xml"
+  run_script --maven-settings deploysettings.xml --dry-run > "$FIXTURE_DIR/output.log" 2>&1
+  assert_contains "$FIXTURE_DIR/maven.log" "-s $FIXTURE_DIR/deploysettings.xml"
+}
+
+test_dry_run_never_invokes_deploy() {
+  new_fixture
+  run_script --dry-run > "$FIXTURE_DIR/output.log" 2>&1
+  assert_contains "$FIXTURE_DIR/maven.log" "clean verify"
+  assert_not_contains "$FIXTURE_DIR/maven.log" " deploy"
+  if [[ $(wc -l < "$FIXTURE_DIR/maven.log") -ne 1 ]]; then
+    fail "dry-run should invoke Maven exactly once"
+  fi
+}
+
+test_real_deploy_uses_one_validated_lifecycle() {
+  new_fixture
+  run_script > "$FIXTURE_DIR/output.log" 2>&1
+  assert_contains "$FIXTURE_DIR/maven.log" "clean deploy"
+  assert_contains "$FIXTURE_DIR/maven.log" "-DstagingValidationScript="
+  if [[ $(wc -l < "$FIXTURE_DIR/maven.log") -ne 1 ]]; then
+    fail "real deploy should invoke Maven exactly once"
+  fi
+}
+
+run_test() {
+  local name=$1
+  "$name"
+  TEST_COUNT=$((TEST_COUNT + 1))
+  echo "PASS: $name"
+}
+
+run_test test_missing_option_value_never_deploys
+run_test test_ignored_package_input_is_rejected
+run_test test_workflow_run_must_match_tag
+run_test test_rc_and_tag_must_match
+run_test test_relative_maven_settings_becomes_absolute
+run_test test_dry_run_never_invokes_deploy
+run_test test_real_deploy_uses_one_validated_lifecycle
+
+echo "All $TEST_COUNT deploy_java_staging tests passed with Bash $BASH_VERSION."

--- a/tools/validate_java_staging_artifacts.sh
+++ b/tools/validate_java_staging_artifacts.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: validate_java_staging_artifacts.sh TARGET_DIR VERSION" >&2
+  exit 1
+fi
+
+TARGET_DIR=$1
+VERSION=$2
+JAR_FILE="$TARGET_DIR/mosaic-${VERSION}.jar"
+SOURCES_JAR="$TARGET_DIR/mosaic-${VERSION}-sources.jar"
+JAVADOC_JAR="$TARGET_DIR/mosaic-${VERSION}-javadoc.jar"
+JAR_ENTRIES=
+
+cleanup() {
+  if [[ -n "$JAR_ENTRIES" ]]; then
+    rm -f -- "$JAR_ENTRIES"
+  fi
+}
+trap cleanup EXIT
+
+if ! command -v jar >/dev/null 2>&1; then
+  echo "jar command is required to validate Java staging artifacts" >&2
+  exit 1
+fi
+
+for artifact in "$JAR_FILE" "$SOURCES_JAR" "$JAVADOC_JAR"; do
+  if [[ ! -f "$artifact" ]]; then
+    echo "Expected Maven artifact is missing: $artifact" >&2
+    exit 1
+  fi
+done
+
+JAR_ENTRIES=$(mktemp "${TMPDIR:-/tmp}/paimon-mosaic-jar-entries.XXXXXX")
+jar tf "$JAR_FILE" > "$JAR_ENTRIES"
+
+for native_entry in \
+  native/linux/x86_64/libpaimon_mosaic_jni.so \
+  native/linux/aarch64/libpaimon_mosaic_jni.so \
+  native/macos/aarch64/libpaimon_mosaic_jni.dylib \
+  native/windows/x86_64/paimon_mosaic_jni.dll
+do
+  if ! grep -Fxq -- "$native_entry" "$JAR_ENTRIES"; then
+    echo "Packaged jar is missing native entry: $native_entry" >&2
+    exit 1
+  fi
+done
+
+echo "Validated Java staging artifacts."


### PR DESCRIPTION
## Purpose

Move Java RC signing and Nexus staging deployment from GitHub Actions to the Release Manager's machine, while binding the local deployment to the exact RC tag and successful Release workflow run.

## Changes

- Keep Java signing keys and Nexus credentials out of GitHub Actions; CI packages and uploads the Java/native artifacts for local staging.
- Harden argument parsing so a missing option value cannot consume `--dry-run` and trigger a real deployment.
- Require the release version, RC number, tag, workflow ref, workflow commit, and local checkout to match exactly.
- Reject tracked, untracked, and ignored Java package inputs that could enter release JARs; normalize relative Maven settings paths.
- Support macOS Bash 3.2 and run the regression suite on both Ubuntu and macOS.
- Validate the exact main, sources, javadoc, and native-containing JARs during the same `mvn clean deploy` lifecycle that uploads them.
- Update the official release guide for the local Java staging procedure.
- Fix the current Rust Clippy `byte_char_slices` failure so the PR can become green.

## Tests

- `bash tools/tests/deploy_java_staging_test.sh` (7 safety regressions)
- The same suite with GNU Bash 3.2
- `mvn clean verify -Prelease -Dgpg.skip=true -DskipTests -DstagingValidationScript=...` on JDK 8
- `cargo +1.97.1 fmt --all -- --check`
- `cargo +1.97.1 clippy --all-targets --workspace -- -D warnings`
- Parsed all workflow YAML and the release HTML
- `git diff --check`
