### PR TITLE
[core] Fix Clippy byte char slice warning

### DIFF
--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub const MAGIC: [u8; 4] = [b'M', b'O', b'S', b'A'];
+pub const MAGIC: [u8; 4] = *b"MOSA";
 pub const VERSION: u8 = 1;
 pub const FOOTER_SIZE: usize = 32;
 


### PR DESCRIPTION
## Purpose

The CI [check job](https://github.com/apache/paimon-mosaic/actions/runs/31116608863/job/92905601392) fails under Rust 1.97 because Clippy's `byte_char_slices` lint rejects the explicit byte character array used for the Mosaic magic bytes when warnings are denied.

Use byte string syntax to satisfy Clippy while preserving the exact magic value and file format.

## Changes

- Replace the explicit byte character array for `MAGIC` with `*b"MOSA"`.
- Keep the public constant type, byte value, and on-disk format unchanged.

## Tests

- `cargo fmt --all -- --check` passed.
- `cargo clippy --all-targets --workspace -- -D warnings` passed.
- `cargo test --workspace -- --skip test_read_java_written_file --skip test_read_python_written_file` passed: 379 tests passed, 0 failed.
- `git diff --check` passed.
