### PR TITLE
release: enforce signed-source preflight at publish boundaries

### DIFF
--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -30,7 +30,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   build-native:
+    needs: [release-preflight]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -120,9 +124,13 @@ jobs:
           path: target/${{ matrix.target }}/release/${{ matrix.lib_name }}
 
   deploy-staging:
-    if: github.repository == 'apache/paimon-mosaic' && startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc')
+    if: >-
+      github.event_name != 'workflow_dispatch' &&
+      github.repository == 'apache/paimon-mosaic' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      contains(github.ref_name, '-rc')
     runs-on: ubuntu-latest
-    needs: [build-native]
+    needs: [release-preflight, build-native]
     steps:
       - uses: actions/checkout@v6
 
@@ -170,7 +178,7 @@ jobs:
       - name: Deploy to Apache Nexus staging
         working-directory: java
         run: |
-          REF="${{ github.ref_name }}"
+          REF="${TAG_NAME}"
           VERSION="${REF#v}"
           if [[ "$VERSION" == *-rc* ]]; then
             DESC="Apache Paimon Mosaic, version ${VERSION%-rc*}, release candidate ${VERSION#*-rc}"
@@ -182,6 +190,7 @@ jobs:
             -DskipTests \
             -DstagingDescription="$DESC"
         env:
+          TAG_NAME: ${{ github.ref_name }}
           MAVEN_USERNAME: ${{ secrets.NEXUS_STAGE_DEPLOYER_USER }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_STAGE_DEPLOYER_PW }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release Preflight
+
+# The orchestrator calls this once for fail-fast fan-out, and each credentialed
+# leaf calls it again so an alternate caller cannot bypass release validation.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  release-preflight:
+    name: Validate release tag, versions, and source archive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Import release verification keys
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          keys_file="${RUNNER_TEMP}/KEYS"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --output "${keys_file}" \
+            https://downloads.apache.org/paimon/KEYS
+          gpg --batch --import "${keys_file}"
+
+      - name: Verify tag and component versions
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: python3 tools/verify_release_versions.py "${TAG_NAME}" --verify-signature
+
+      - name: Verify source archive
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          release_version="${GITHUB_REF_NAME#v}"
+          release_version="${release_version%-rc*}"
+          archive="${RUNNER_TEMP}/apache-paimon-mosaic-${release_version}-src.tgz"
+          prefix="paimon-mosaic-${release_version}/"
+          commit="$(git rev-parse --verify 'HEAD^{commit}')"
+          python3 tools/verify_source_archive.py create \
+            --repository "${GITHUB_WORKSPACE}" \
+            --commit "${commit}" \
+            --prefix "${prefix}" \
+            --output "${archive}"
+          python3 tools/verify_source_archive.py verify \
+            --repository "${GITHUB_WORKSPACE}" \
+            --commit "${commit}" \
+            --prefix "${prefix}" \
+            --archive "${archive}"

--- a/.github/workflows/release-python-publish.yml
+++ b/.github/workflows/release-python-publish.yml
@@ -32,9 +32,13 @@ permissions:
   contents: read
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
     name: Publish to PyPI
     if: github.repository == 'apache/paimon-mosaic' && startsWith(github.ref, 'refs/tags/')
+    needs: [release-preflight]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v5
@@ -72,7 +76,9 @@ jobs:
           done
 
       - name: Publish to TestPyPI
-        if: contains(github.ref_name, '-rc')
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          contains(github.ref_name, '-rc')
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
@@ -81,7 +87,9 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
       - name: Publish to PyPI
-        if: ${{ !contains(github.ref_name, '-') }}
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          !contains(github.ref_name, '-')
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           skip-existing: true

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -33,7 +33,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-preflight:
+    uses: ./.github/workflows/release-preflight.yml
+
   publish:
+    needs: [release-preflight]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -49,7 +53,11 @@ jobs:
         run: cargo publish -p paimon-mosaic-core --dry-run
 
       - name: Publish paimon-mosaic-core to crates.io
-        if: github.repository == 'apache/paimon-mosaic' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          github.repository == 'apache/paimon-mosaic' &&
+          startsWith(github.ref, 'refs/tags/') &&
+          !contains(github.ref_name, '-')
         run: cargo publish -p paimon-mosaic-core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-vote-gate.yml
+++ b/.github/workflows/release-vote-gate.yml
@@ -1,0 +1,119 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release Vote Gate
+
+on:
+  pull_request:
+    branches: [main, "release-*"]
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/**"
+      - "docs/creating-a-release.html"
+      - "tools/create_source_release.sh"
+      - "tools/update_branch_version.sh"
+      - "tools/verify_release_versions.py"
+      - "tools/verify_source_archive.py"
+      - "tools/tests/test_create_source_release.py"
+      - "tools/tests/test_release_vote_workflow.py"
+      - "tools/tests/test_update_branch_version.py"
+      - "tools/tests/test_verify_release_versions.py"
+      - "tools/tests/test_verify_source_archive.py"
+  push:
+    branches: [main, "release-*"]
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/**"
+      - "docs/creating-a-release.html"
+      - "tools/create_source_release.sh"
+      - "tools/update_branch_version.sh"
+      - "tools/verify_release_versions.py"
+      - "tools/verify_source_archive.py"
+      - "tools/tests/test_create_source_release.py"
+      - "tools/tests/test_release_vote_workflow.py"
+      - "tools/tests/test_update_branch_version.py"
+      - "tools/tests/test_verify_release_versions.py"
+      - "tools/tests/test_verify_source_archive.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-vote-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python -m pip install pytest PyYAML
+
+      - name: Run release vote tests
+        run: |
+          python -m pytest -q \
+            tools/tests/test_create_source_release.py \
+            tools/tests/test_release_vote_workflow.py \
+            tools/tests/test_update_branch_version.py \
+            tools/tests/test_verify_release_versions.py \
+            tools/tests/test_verify_source_archive.py
+
+      - name: Verify current source tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_dir="$(mktemp -d "${RUNNER_TEMP}/source-tree.XXXXXX")"
+          archive="${output_dir}/source.tgz"
+          commit="$(git rev-parse --verify 'HEAD^{commit}')"
+          prefix="paimon-mosaic-source-tree/"
+          python3 tools/verify_source_archive.py create \
+            --repository "${GITHUB_WORKSPACE}" \
+            --commit "${commit}" \
+            --prefix "${prefix}" \
+            --output "${archive}"
+          python3 tools/verify_source_archive.py verify \
+            --repository "${GITHUB_WORKSPACE}" \
+            --commit "${commit}" \
+            --prefix "${prefix}" \
+            --archive "${archive}"
+
+      - name: Run static checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m compileall -q \
+            tools/verify_release_versions.py \
+            tools/verify_source_archive.py \
+            tools/tests/test_create_source_release.py \
+            tools/tests/test_release_vote_workflow.py \
+            tools/tests/test_update_branch_version.py \
+            tools/tests/test_verify_release_versions.py \
+            tools/tests/test_verify_source_archive.py
+          bash -n tools/create_source_release.sh
+          bash -n tools/update_branch_version.sh
+          if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+            comparison_ref="origin/${GITHUB_BASE_REF}"
+          else
+            comparison_ref="HEAD^"
+          fi
+          git diff --check "$(git merge-base HEAD "${comparison_ref}")" HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,25 @@ permissions:
   contents: read
 
 jobs:
+  release-preflight:
+    name: Validate release tag, versions, and source archive
+    uses: ./.github/workflows/release-preflight.yml
+
   rust:
     name: Rust release
+    needs: [release-preflight]
     uses: ./.github/workflows/release-rust.yml
     secrets: inherit
 
   java:
     name: Java release
+    needs: [release-preflight]
     uses: ./.github/workflows/release-java.yml
     secrets: inherit
 
   python-wheels:
     name: Python wheels
+    needs: [release-preflight]
     uses: ./.github/workflows/release-python.yml
     secrets: inherit
 

--- a/docs/creating-a-release.html
+++ b/docs/creating-a-release.html
@@ -196,7 +196,7 @@ cd tools
 OLD_VERSION=${RELEASE_VERSION} NEW_VERSION=${NEXT_VERSION}-SNAPSHOT ./update_branch_version.sh
 cd ..
 git push origin main</code></pre>
-            <p>The script updates version strings in all <code>pom.xml</code> (matching both <code>${OLD_VERSION}</code> and <code>${OLD_VERSION}-SNAPSHOT</code>), <code>Cargo.toml</code> (excluding <code>target/</code>), and <code>python/pyproject.toml</code> files, then creates a commit.</p>
+            <p>The script updates version strings in all <code>pom.xml</code> (matching both <code>${OLD_VERSION}</code> and <code>${OLD_VERSION}-SNAPSHOT</code>), Cargo package versions, Cargo path dependency constraints and Cargo.lock, and <code>python/pyproject.toml</code>, validates the locked Cargo workspace metadata, then creates a commit.</p>
 
             <!-- ============================================================ -->
             <h2 id="build-a-release-candidate">Build a Release Candidate</h2>
@@ -217,6 +217,7 @@ git tag -v ${RC_TAG}
 git push origin ${RELEASE_BRANCH}
 git push origin ${RC_TAG}</code></pre>
             <p>After pushing, verify in <a href="https://github.com/apache/paimon-mosaic/actions">GitHub Actions</a> that the <code>Release</code> workflow succeeds:</p>
+            <p>The release preflight validates the signed tag and component versions, then creates and verifies a temporary source archive before any language release job starts.</p>
             <ul>
                 <li><strong>Rust release</strong> &mdash; dry-run check (does not publish for RC tags)</li>
                 <li><strong>Java release</strong> &mdash; builds native JNI libraries for 4 platforms, deploys JAR to Apache Nexus staging</li>
@@ -229,7 +230,7 @@ git push origin ${RC_TAG}</code></pre>
             <p>Create source release artifacts from the same commit as the RC tag:</p>
 <pre><code>git checkout ${RC_TAG}
 cd tools
-RELEASE_VERSION=${RELEASE_VERSION} ./create_source_release.sh</code></pre>
+RELEASE_VERSION=${RELEASE_VERSION} RC_TAG=${RC_TAG} ./create_source_release.sh</code></pre>
             <p>This creates the following under <code>tools/release/</code>:</p>
             <ul>
                 <li><code>apache-paimon-mosaic-${RELEASE_VERSION}-src.tgz</code> &mdash; source archive</li>
@@ -298,6 +299,10 @@ Release Manager</code></pre>
             <p>If the vote reveals issues:</p>
             <ol>
                 <li>Fix them on the release branch via normal PRs.</li>
+                <li>Preserve the previous RC's local source artifacts outside the checkout so the next build does not overwrite them:
+<pre><code># From the paimon-mosaic checkout
+mv tools/release "../paimon-mosaic-${RC_TAG}-artifacts"</code></pre>
+                </li>
                 <li>Remove the old RC from dist dev (optional):
 <pre><code>cd paimon-dist-dev
 svn remove paimon-mosaic-${RELEASE_VERSION}-rc${RC_NUM}

--- a/tools/create_source_release.sh
+++ b/tools/create_source_release.sh
@@ -22,69 +22,193 @@
 #   apache-paimon-mosaic-{version}-src.tgz.asc
 #   apache-paimon-mosaic-{version}-src.tgz.sha512
 #
-# Usage: cd tools && RELEASE_VERSION=0.1.0 ./create_source_release.sh
-
-##
-## Variables with defaults (if not overwritten by environment)
-##
-MVN=${MVN:-mvn}
+# Usage:
+#   cd tools
+#   RELEASE_VERSION=0.3.0 RC_TAG=v0.3.0-rc1 ./create_source_release.sh
 
 # fail immediately
 set -o errexit
 set -o nounset
 set -o pipefail
-# print command before executing
-set -o xtrace
 
-CURR_DIR=`pwd`
-if [[ `basename $CURR_DIR` != "tools" ]] ; then
+# Do not let inherited Git variables redirect checks or replace signature
+# verification.
+unset \
+  GIT_ALTERNATE_OBJECT_DIRECTORIES \
+  GIT_COMMON_DIR \
+  GIT_CONFIG_COUNT \
+  GIT_CONFIG_GLOBAL \
+  GIT_CONFIG_PARAMETERS \
+  GIT_CONFIG_SYSTEM \
+  GIT_DIR \
+  GIT_INDEX_FILE \
+  GIT_NAMESPACE \
+  GIT_OBJECT_DIRECTORY \
+  GIT_WORK_TREE
+export GIT_ATTR_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_NO_REPLACE_OBJECTS=1
+
+CURR_DIR=$(pwd -P)
+if [[ $(basename "${CURR_DIR}") != "tools" ]] ; then
   echo "You have to call the script from the tools/ dir"
   exit 1
 fi
 
-if [ "$(uname)" == "Darwin" ]; then
-    SHASUM="shasum -a 512"
-else
-    SHASUM="sha512sum"
+RELEASE_VERSION=${RELEASE_VERSION:-}
+RC_TAG=${RC_TAG:-}
+if [[ -z "${RELEASE_VERSION}" ]]; then
+  echo "RELEASE_VERSION is unset" >&2
+  exit 1
+fi
+if [[ -z "${RC_TAG}" ]]; then
+  echo "RC_TAG is unset" >&2
+  exit 1
+fi
+if [[ ! "${RC_TAG}" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-rc[0-9]+$ ]]; then
+  echo "RC_TAG must have the form vX.Y.Z-rcN: ${RC_TAG}" >&2
+  exit 1
+fi
+if [[ "${BASH_REMATCH[1]}" != "${RELEASE_VERSION}" ]]; then
+  echo \
+    "RC_TAG ${RC_TAG} does not match RELEASE_VERSION ${RELEASE_VERSION}" \
+    >&2
+  exit 1
 fi
 
-###########################
-
-RELEASE_VERSION=${RELEASE_VERSION}
-
-if [ -z "${RELEASE_VERSION}" ]; then
-	echo "RELEASE_VERSION is unset"
-	exit 1
-fi
-
-rm -rf release
-mkdir release
 cd ..
+REPOSITORY=$(pwd -P)
 
-echo "Creating source package"
+if [[ -n $(git status --porcelain --untracked-files=all) ]]; then
+  echo "The source release must be created from a clean Git worktree" >&2
+  git status --short >&2
+  exit 1
+fi
+
+HEAD_COMMIT=$(git rev-parse --verify 'HEAD^{commit}')
+TAG_OBJECT_ID=$(git rev-parse --verify "${RC_TAG}^{tag}")
+TAG_OBJECT=$(git cat-file tag "${TAG_OBJECT_ID}")
+TAG_OBJECT_NAMES=$(
+  awk '
+    BEGIN { separator = "" }
+    /^$/ { exit }
+    /^tag / {
+      printf "%s%s", separator, substr($0, 5)
+      separator = ", "
+    }
+    END {
+      if (separator == "") {
+        printf "<missing>"
+      }
+    }
+  ' <<< "${TAG_OBJECT}"
+)
+if [[ "${TAG_OBJECT_NAMES}" != "${RC_TAG}" ]]; then
+  echo \
+    "signed tag object names ${TAG_OBJECT_NAMES}, not ${RC_TAG}" \
+    >&2
+  exit 1
+fi
+TAG_COMMIT=$(git rev-parse --verify "${TAG_OBJECT_ID}^{commit}")
+if [[ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+  echo \
+    "RC_TAG ${RC_TAG} does not resolve to current HEAD ${HEAD_COMMIT}" \
+    >&2
+  exit 1
+fi
+if ! grep -q '^-----BEGIN PGP SIGNATURE-----$' <<< "${TAG_OBJECT}" ||
+  ! git -c gpg.program=gpg verify-tag "${TAG_OBJECT_ID}"
+then
+  echo \
+    "RC_TAG ${RC_TAG} is not a locally verifiable GPG-signed tag" \
+    >&2
+  exit 1
+fi
 
 ARCHIVE="apache-paimon-mosaic-${RELEASE_VERSION}-src.tgz"
-# Archive from Git objects so filesystem metadata such as macOS xattrs is not included.
-git archive --format=tar --prefix="paimon-mosaic-${RELEASE_VERSION}/" 'HEAD^{tree}' . \
-  ':(exclude).gitignore' ':(exclude).gitattributes' \
-  ':(exclude).asf.yaml' ':(exclude).github' \
-  ':(exclude)deploysettings.xml' ':(exclude)target' \
-  ':(exclude).idea' ':(exclude)*.iml' ':(exclude).DS_Store' \
-  | gzip -n > "tools/release/${ARCHIVE}"
+SIGNATURE="${ARCHIVE}.asc"
+CHECKSUM="${ARCHIVE}.sha512"
+ARCHIVE_ROOT="paimon-mosaic-${RELEASE_VERSION}"
+RELEASE_DIR="${CURR_DIR}/release"
 
-cd tools/release
+if [[ -e "${RELEASE_DIR}" || -L "${RELEASE_DIR}" ]]; then
+  echo "Release output already exists and will not be overwritten: ${RELEASE_DIR}" >&2
+  exit 1
+fi
 
-gpg --armor --detach-sig "${ARCHIVE}"
-$SHASUM "${ARCHIVE}" > "${ARCHIVE}.sha512"
+STAGING_DIR=$(mktemp -d "${CURR_DIR}/.source-release.XXXXXX")
+ARTIFACT_DIR="${STAGING_DIR}/release"
+mkdir "${ARTIFACT_DIR}"
+cleanup() {
+  status=$?
+  rm -rf "${STAGING_DIR}"
+  exit "${status}"
+}
+trap cleanup EXIT
 
-echo "Verifying GPG signature"
-gpg --verify "${ARCHIVE}.asc" "${ARCHIVE}"
+echo "Creating source package from signed tag ${RC_TAG}"
+python3 tools/verify_source_archive.py create \
+  --repository "${REPOSITORY}" \
+  --commit "${TAG_COMMIT}" \
+  --prefix "${ARCHIVE_ROOT}/" \
+  --output "${ARTIFACT_DIR}/${ARCHIVE}"
 
-echo "Verifying tarball integrity"
-tar tzf "${ARCHIVE}" > /dev/null
+mkdir "${STAGING_DIR}/extracted"
+tar xzf "${ARTIFACT_DIR}/${ARCHIVE}" -C "${STAGING_DIR}/extracted"
+# Bash 3.2 does not reliably propagate errexit through subshells, so preserve
+# the explicit status checks in both verification blocks.
+if (
+  cd "${STAGING_DIR}/extracted/${ARCHIVE_ROOT}" &&
+    python3 tools/verify_release_versions.py "${RC_TAG}"
+); then
+  :
+else
+  status=$?
+  exit "${status}"
+fi
+
+gpg \
+  --armor \
+  --detach-sign \
+  --output "${ARTIFACT_DIR}/${SIGNATURE}" \
+  "${ARTIFACT_DIR}/${ARCHIVE}"
+
+if (
+  cd "${ARTIFACT_DIR}" &&
+  if [[ $(uname) == "Darwin" ]]; then
+    shasum -a 512 "${ARCHIVE}" > "${CHECKSUM}" &&
+    shasum -a 512 -c "${CHECKSUM}"
+  else
+    sha512sum "${ARCHIVE}" > "${CHECKSUM}" &&
+    sha512sum -c "${CHECKSUM}"
+  fi &&
+    gpg --verify "${SIGNATURE}" "${ARCHIVE}"
+); then
+  :
+else
+  status=$?
+  exit "${status}"
+fi
+
+python3 tools/verify_source_archive.py verify \
+  --repository "${REPOSITORY}" \
+  --commit "${TAG_COMMIT}" \
+  --prefix "${ARCHIVE_ROOT}/" \
+  --archive "${ARTIFACT_DIR}/${ARCHIVE}"
+
+# The staging and release directories share a filesystem, so this publishes
+# the fully verified artifact set with one atomic directory rename.
+python3 -c \
+  'import os, sys; os.rename(sys.argv[1], sys.argv[2])' \
+  "${ARTIFACT_DIR}" \
+  "${RELEASE_DIR}"
+
+trap - EXIT
+rm -rf "${STAGING_DIR}"
 
 echo ""
 echo "Source release created successfully. Artifacts in tools/release/:"
-ls -la ${CURR_DIR}/release/apache-paimon-mosaic-*
+ls -la "${RELEASE_DIR}"/apache-paimon-mosaic-*
 echo ""
 echo "Next: upload contents to SVN (see docs/creating-a-release.html)."

--- a/tools/tests/test_create_source_release.py
+++ b/tools/tests/test_create_source_release.py
@@ -1,0 +1,688 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCE_SCRIPT = ROOT / "tools/create_source_release.sh"
+SOURCE_VERIFIER = ROOT / "tools/verify_source_archive.py"
+VERSION_VERIFIER = ROOT / "tools/verify_release_versions.py"
+VERSION = "0.3.0"
+RC_TAG = f"v{VERSION}-rc1"
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture(scope="session")
+def signing_home(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, str]:
+    if shutil.which("gpg") is None:
+        pytest.skip("gpg is required for source release tests")
+    home = tmp_path_factory.mktemp("gnupg")
+    home.chmod(0o700)
+    env = os.environ.copy()
+    env["GNUPGHOME"] = str(home)
+    run(
+        [
+            "gpg",
+            "--batch",
+            "--passphrase",
+            "",
+            "--quick-gen-key",
+            "Release Test <release-test@example.invalid>",
+            "rsa1024",
+            "sign",
+            "0",
+        ],
+        cwd=home,
+        env=env,
+    )
+    listing = run(
+        ["gpg", "--batch", "--with-colons", "--list-secret-keys"],
+        cwd=home,
+        env=env,
+    ).stdout.decode()
+    fingerprint = next(
+        line.split(":")[9]
+        for line in listing.splitlines()
+        if line.startswith("fpr:")
+    )
+    return home, fingerprint
+
+
+def initialize_release_repo(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+    *,
+    python_version: str = VERSION,
+    source_script: str | None = None,
+) -> tuple[Path, dict[str, str], str]:
+    repo = tmp_path / "repo"
+    tools = repo / "tools"
+    tools.mkdir(parents=True)
+    shutil.copy2(SOURCE_SCRIPT, tools / SOURCE_SCRIPT.name)
+    if source_script is not None:
+        write(tools / SOURCE_SCRIPT.name, source_script)
+    shutil.copy2(SOURCE_VERIFIER, tools / SOURCE_VERIFIER.name)
+    shutil.copy2(VERSION_VERIFIER, tools / VERSION_VERIFIER.name)
+
+    write(
+        repo / "Cargo.toml",
+        '[workspace]\nmembers = ["core"]\nresolver = "2"\n',
+    )
+    write(
+        repo / "core/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-core"\nversion = "{VERSION}"\n',
+    )
+    write(
+        repo / "Cargo.lock",
+        "version = 4\n\n"
+        "[[package]]\n"
+        'name = "paimon-mosaic-core"\n'
+        f'version = "{VERSION}"\n',
+    )
+    write(
+        repo / "java/pom.xml",
+        '<?xml version="1.0"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        "  <modelVersion>4.0.0</modelVersion>\n"
+        "  <groupId>org.apache.paimon</groupId>\n"
+        "  <artifactId>mosaic</artifactId>\n"
+        f"  <version>{VERSION}</version>\n"
+        "</project>\n",
+    )
+    write(
+        repo / "python/pyproject.toml",
+        '[project]\nname = "paimon-mosaic"\n'
+        f'version = "{python_version}"\n',
+    )
+    write(repo / "README.md", "source release fixture\n")
+    write(repo / ".gitignore", "tools/release/\ntools/.source-release.*\n")
+
+    run(["git", "init", "-q"], cwd=repo)
+    run(["git", "config", "user.name", "Release Test"], cwd=repo)
+    run(
+        ["git", "config", "user.email", "release-test@example.invalid"],
+        cwd=repo,
+    )
+    home, fingerprint = signing_home
+    run(["git", "config", "user.signingkey", fingerprint], cwd=repo)
+    run(["git", "add", "."], cwd=repo)
+    run(["git", "commit", "-q", "-m", "release fixture"], cwd=repo)
+    commit = run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.decode().strip()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GNUPGHOME": str(home),
+            "RELEASE_VERSION": VERSION,
+            "RC_TAG": RC_TAG,
+        }
+    )
+    run(
+        [
+            "git",
+            "tag",
+            "-s",
+            "-u",
+            fingerprint,
+            "-m",
+            f"Release candidate {RC_TAG}",
+            RC_TAG,
+        ],
+        cwd=repo,
+        env=env,
+    )
+    return repo, env, commit
+
+
+def run_script(
+    repo: Path,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["bash", SOURCE_SCRIPT.name],
+        cwd=repo / "tools",
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def output(result: subprocess.CompletedProcess[bytes]) -> str:
+    return (result.stdout + result.stderr).decode("utf-8", errors="replace")
+
+
+def artifact_paths(repo: Path) -> tuple[Path, Path, Path]:
+    archive = (
+        repo
+        / "tools/release"
+        / f"apache-paimon-mosaic-{VERSION}-src.tgz"
+    )
+    return archive, Path(f"{archive}.asc"), Path(f"{archive}.sha512")
+
+
+def test_creates_verified_artifacts_from_signed_head_tag(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, git_commit = initialize_release_repo(tmp_path, signing_home)
+
+    result = run_script(repo, env)
+
+    assert result.returncode == 0, output(result)
+    archive, signature, checksum = artifact_paths(repo)
+    assert archive.is_file()
+    assert signature.is_file()
+    assert checksum.is_file()
+    assert hashlib.sha512(archive.read_bytes()).hexdigest() in checksum.read_text(
+        encoding="utf-8"
+    )
+    run(["gpg", "--verify", str(signature), str(archive)], cwd=repo, env=env)
+    run(
+        [
+            sys.executable,
+            str(SOURCE_VERIFIER),
+            "verify",
+            "--repository",
+            str(repo),
+            "--commit",
+            git_commit,
+            "--prefix",
+            f"paimon-mosaic-{VERSION}/",
+            "--archive",
+            str(archive),
+        ],
+        cwd=repo,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize("missing", ("RELEASE_VERSION", "RC_TAG"))
+def test_requires_release_version_and_rc_tag(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+    missing: str,
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    env.pop(missing)
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert f"{missing} is unset" in output(result)
+
+
+def test_rejects_rc_tag_that_does_not_point_to_head(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    write(repo / "README.md", "new head\n")
+    run(["git", "add", "README.md"], cwd=repo)
+    run(["git", "commit", "-q", "-m", "move head"], cwd=repo)
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "does not resolve to current HEAD" in output(result)
+
+
+def test_rejects_dirty_worktree(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    write(repo / "README.md", "dirty\n")
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "clean Git worktree" in output(result)
+
+
+def test_rejects_dirty_intended_worktree_with_foreign_git_environment(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(
+        tmp_path / "intended",
+        signing_home,
+    )
+    foreign_repo, _, _ = initialize_release_repo(
+        tmp_path / "foreign",
+        signing_home,
+    )
+    write(repo / "README.md", "dirty intended worktree\n")
+    env.update(
+        {
+            "GIT_DIR": str(foreign_repo / ".git"),
+            "GIT_WORK_TREE": str(foreign_repo),
+        }
+    )
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "clean Git worktree" in output(result)
+
+
+def test_existing_artifact_is_not_overwritten(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    archive, signature, checksum = artifact_paths(repo)
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"existing artifact")
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "already exists" in output(result)
+    assert archive.read_bytes() == b"existing artifact"
+    assert not signature.exists()
+    assert not checksum.exists()
+
+
+def test_release_version_must_match_rc_tag(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    env["RELEASE_VERSION"] = "9.9.9"
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "does not match RELEASE_VERSION" in output(result)
+
+
+def test_signed_tag_with_cross_component_version_mismatch_is_rejected(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    write(
+        repo / "python/pyproject.toml",
+        '[project]\nname = "paimon-mosaic"\nversion = "0.3.1"\n',
+    )
+    run(["git", "add", "python/pyproject.toml"], cwd=repo)
+    run(["git", "commit", "-q", "-m", "mismatched Python version"], cwd=repo)
+
+    env["RC_TAG"] = f"v{VERSION}-rc2"
+    _, fingerprint = signing_home
+    run(
+        [
+            "git",
+            "tag",
+            "-s",
+            "-u",
+            fingerprint,
+            "-m",
+            f"Release candidate {env['RC_TAG']}",
+            env["RC_TAG"],
+        ],
+        cwd=repo,
+        env=env,
+    )
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "python/pyproject.toml" in output(result)
+    assert "expected '0.3.0'" in output(result)
+    assert not (repo / "tools/release").exists()
+
+
+def test_unsigned_tag_with_pgp_armor_text_is_rejected(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    env["RC_TAG"] = f"v{VERSION}-rc2"
+    run(
+        [
+            "git",
+            "tag",
+            "-a",
+            "-m",
+            "unsigned release candidate\n\n"
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "not a signature\n"
+            "-----END PGP SIGNATURE-----",
+            env["RC_TAG"],
+        ],
+        cwd=repo,
+    )
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "not a locally verifiable GPG-signed tag" in output(result)
+
+
+@pytest.mark.parametrize("injection", ("count", "parameters", "local"))
+def test_injected_gpg_program_cannot_approve_forged_tag(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+    injection: str,
+) -> None:
+    repo, env, commit = initialize_release_repo(tmp_path, signing_home)
+    forged_tag_object = subprocess.run(
+        ["git", "hash-object", "-t", "tag", "-w", "--stdin"],
+        cwd=repo,
+        check=True,
+        input=(
+            f"object {commit}\n"
+            "type commit\n"
+            f"tag {RC_TAG}\n"
+            "tagger Release Test <release-test@example.invalid> 0 +0000\n\n"
+            "forged release tag\n\n"
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "invalid\n"
+            "-----END PGP SIGNATURE-----\n"
+        ).encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.decode().strip()
+    run(
+        ["git", "update-ref", f"refs/tags/{RC_TAG}", forged_tag_object],
+        cwd=repo,
+    )
+    fake_gpg = tmp_path / "fake-gpg"
+    write(
+        fake_gpg,
+        "#!/bin/sh\n"
+        "printf '%s\\n' \\\n"
+        "  '[GNUPG:] NEWSIG' \\\n"
+        "  '[GNUPG:] GOODSIG DEADBEEF Release Test' \\\n"
+        "  '[GNUPG:] VALIDSIG 0123456789ABCDEF0123456789ABCDEF01234567 "
+        "2026-08-28 0 4 0 1 10 00 "
+        "0123456789ABCDEF0123456789ABCDEF01234567'\n"
+        "exit 0\n",
+    )
+    fake_gpg.chmod(0o755)
+    if injection == "count":
+        env.update(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "gpg.program",
+                "GIT_CONFIG_VALUE_0": str(fake_gpg),
+            }
+        )
+    elif injection == "parameters":
+        env["GIT_CONFIG_PARAMETERS"] = (
+            f"'gpg.program'='{fake_gpg}'"
+        )
+    else:
+        run(
+            ["git", "config", "gpg.program", str(fake_gpg)],
+            cwd=repo,
+        )
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "not a locally verifiable GPG-signed tag" in output(result)
+    assert not (repo / "tools/release").exists()
+
+
+def test_rejects_alias_for_different_signed_tag_name(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, _ = initialize_release_repo(tmp_path, signing_home)
+    tag_object = run(
+        ["git", "rev-parse", f"{RC_TAG}^{{tag}}"],
+        cwd=repo,
+    ).stdout.decode().strip()
+    alias = f"v{VERSION}-rc2"
+    run(
+        ["git", "update-ref", f"refs/tags/{alias}", tag_object],
+        cwd=repo,
+    )
+    env["RC_TAG"] = alias
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert f"signed tag object names {RC_TAG}, not {alias}" in output(result)
+
+
+def test_verifies_the_frozen_tag_object(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, commit = initialize_release_repo(tmp_path, signing_home)
+    signed_tag_object = run(
+        ["git", "rev-parse", f"{RC_TAG}^{{tag}}"],
+        cwd=repo,
+    ).stdout.decode().strip()
+    forged_tag_object = subprocess.run(
+        ["git", "hash-object", "-t", "tag", "-w", "--stdin"],
+        cwd=repo,
+        check=True,
+        input=(
+            f"object {commit}\n"
+            "type commit\n"
+            f"tag {RC_TAG}\n"
+            "tagger Release Test <release-test@example.invalid> 0 +0000\n\n"
+            "forged release tag\n\n"
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "invalid\n"
+            "-----END PGP SIGNATURE-----\n"
+        ).encode(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).stdout.decode().strip()
+    run(
+        ["git", "update-ref", f"refs/tags/{RC_TAG}", forged_tag_object],
+        cwd=repo,
+    )
+
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "git"
+    write(
+        wrapper,
+        "#!/bin/sh\n"
+        'for argument in "$@"; do\n'
+        '  if [ "$argument" = "verify-tag" ] && [ ! -e "$MOVE_MARKER" ]; then\n'
+        '    : > "$MOVE_MARKER"\n'
+        '    "$REAL_GIT" -C "$RELEASE_REPO" update-ref '
+        '"refs/tags/$RC_TAG" "$SIGNED_TAG_OBJECT"\n'
+        "    break\n"
+        "  fi\n"
+        "done\n"
+        'exec "$REAL_GIT" "$@"\n',
+    )
+    wrapper.chmod(0o755)
+    move_marker = tmp_path / "tag-moved-before-verification"
+    env.update(
+        {
+            "MOVE_MARKER": str(move_marker),
+            "PATH": f"{wrapper_dir}{os.pathsep}{env['PATH']}",
+            "REAL_GIT": shutil.which("git") or "git",
+            "RELEASE_REPO": str(repo),
+            "SIGNED_TAG_OBJECT": signed_tag_object,
+        }
+    )
+
+    result = run_script(repo, env)
+
+    assert move_marker.is_file()
+    assert result.returncode != 0
+    assert "not a locally verifiable GPG-signed tag" in output(result)
+    assert not (repo / "tools/release").exists()
+
+
+def test_tag_ref_move_after_verification_does_not_change_archive(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    repo, env, signed_commit = initialize_release_repo(tmp_path, signing_home)
+    write(repo / "README.md", "alternate commit\n")
+    run(["git", "add", "README.md"], cwd=repo)
+    run(["git", "commit", "-q", "-m", "alternate commit"], cwd=repo)
+    alternate_commit = run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+    ).stdout.decode().strip()
+    run(["git", "reset", "--hard", signed_commit], cwd=repo)
+
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "python3"
+    write(
+        wrapper,
+        "#!/bin/sh\n"
+        'if [ "$1" = "tools/verify_source_archive.py" ] &&\n'
+        '  [ "$2" = "create" ] && [ ! -e "$MOVE_MARKER" ]; then\n'
+        '  : > "$MOVE_MARKER"\n'
+        '  git -C "$RELEASE_REPO" update-ref "refs/tags/$RC_TAG" '
+        '"$ALTERNATE_COMMIT"\n'
+        "fi\n"
+        'exec "$REAL_PYTHON" "$@"\n',
+    )
+    wrapper.chmod(0o755)
+    move_marker = tmp_path / "tag-moved"
+    env.update(
+        {
+            "ALTERNATE_COMMIT": alternate_commit,
+            "MOVE_MARKER": str(move_marker),
+            "PATH": f"{wrapper_dir}{os.pathsep}{env['PATH']}",
+            "REAL_PYTHON": sys.executable,
+            "RELEASE_REPO": str(repo),
+        }
+    )
+
+    result = run_script(repo, env)
+
+    assert result.returncode == 0, output(result)
+    assert move_marker.is_file()
+    archive, _, _ = artifact_paths(repo)
+    with tarfile.open(archive, "r:gz") as source:
+        assert source.pax_headers["comment"] == signed_commit
+        readme = source.extractfile(f"paimon-mosaic-{VERSION}/README.md")
+        assert readme is not None
+        assert readme.read() == b"source release fixture\n"
+
+
+@pytest.mark.parametrize(
+    ("platform", "checksum_command"),
+    (("Linux", "sha512sum"), ("Darwin", "shasum")),
+)
+def test_checksum_failure_is_not_swallowed_without_errexit(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+    platform: str,
+    checksum_command: str,
+) -> None:
+    production_script = SOURCE_SCRIPT.read_text(encoding="utf-8")
+    assert "set -o errexit\n" in production_script
+    source_script = production_script.replace(
+        "set -o errexit\n",
+        "",
+        1,
+    )
+    repo, env, _ = initialize_release_repo(
+        tmp_path,
+        signing_home,
+        source_script=source_script,
+    )
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    checksum_marker = tmp_path / "checksum-failed"
+    wrapper = wrapper_dir / checksum_command
+    write(
+        wrapper,
+        "#!/bin/sh\n"
+        'if [ ! -e "$CHECKSUM_MARKER" ]; then\n'
+        '  : > "$CHECKSUM_MARKER"\n'
+        "  exit 42\n"
+        "fi\n"
+        "exit 0\n",
+    )
+    wrapper.chmod(0o755)
+    uname = wrapper_dir / "uname"
+    write(uname, '#!/bin/sh\nprintf "%s\\n" "$TEST_UNAME"\n')
+    uname.chmod(0o755)
+    env["PATH"] = f"{wrapper_dir}{os.pathsep}{env['PATH']}"
+    env["CHECKSUM_MARKER"] = str(checksum_marker)
+    env["TEST_UNAME"] = platform
+
+    result = run_script(repo, env)
+
+    assert checksum_marker.is_file()
+    assert result.returncode != 0
+    assert not (repo / "tools/release").exists()
+
+
+def test_version_failure_is_not_swallowed_without_errexit(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    production_script = SOURCE_SCRIPT.read_text(encoding="utf-8")
+    assert "set -o errexit\n" in production_script
+    source_script = production_script.replace(
+        "set -o errexit\n",
+        "",
+        1,
+    )
+    repo, env, _ = initialize_release_repo(
+        tmp_path,
+        signing_home,
+        python_version="0.3.1",
+        source_script=source_script,
+    )
+
+    result = run_script(repo, env)
+
+    assert result.returncode != 0
+    assert "python/pyproject.toml" in output(result)
+    assert not (repo / "tools/release").exists()

--- a/tools/tests/test_release_vote_workflow.py
+++ b/tools/tests/test_release_vote_workflow.py
@@ -1,0 +1,749 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github/workflows/release.yml"
+RELEASE_PREFLIGHT_WORKFLOW = ROOT / ".github/workflows/release-preflight.yml"
+GATE_WORKFLOW = ROOT / ".github/workflows/release-vote-gate.yml"
+RUST_RELEASE_WORKFLOW = ROOT / ".github/workflows/release-rust.yml"
+JAVA_RELEASE_WORKFLOW = ROOT / ".github/workflows/release-java.yml"
+PYTHON_PUBLISH_WORKFLOW = ROOT / ".github/workflows/release-python-publish.yml"
+RELEASE_DOCUMENTATION = ROOT / "docs/creating-a-release.html"
+CREDENTIALED_RELEASE_WORKFLOWS = (
+    (RUST_RELEASE_WORKFLOW, "publish"),
+    (JAVA_RELEASE_WORKFLOW, "deploy-staging"),
+    (PYTHON_PUBLISH_WORKFLOW, "publish"),
+)
+TAG_CONDITION = "startsWith(github.ref, 'refs/tags/')"
+RUST_PUBLISH_CONDITION = (
+    "github.event_name != 'workflow_dispatch' && "
+    "github.repository == 'apache/paimon-mosaic' && "
+    "startsWith(github.ref, 'refs/tags/') && "
+    "!contains(github.ref_name, '-')"
+)
+JAVA_DEPLOY_CONDITION = (
+    "github.event_name != 'workflow_dispatch' && "
+    "github.repository == 'apache/paimon-mosaic' && "
+    "startsWith(github.ref, 'refs/tags/') && "
+    "contains(github.ref_name, '-rc')"
+)
+PYTHON_TEST_PUBLISH_CONDITION = (
+    "github.event_name != 'workflow_dispatch' && "
+    "contains(github.ref_name, '-rc')"
+)
+PYTHON_PUBLISH_CONDITION = (
+    "github.event_name != 'workflow_dispatch' && "
+    "!contains(github.ref_name, '-')"
+)
+REQUIRED_GATE_PATHS = {
+    ".gitattributes",
+    ".github/workflows/**",
+    "docs/creating-a-release.html",
+    "tools/create_source_release.sh",
+    "tools/update_branch_version.sh",
+    "tools/verify_release_versions.py",
+    "tools/verify_source_archive.py",
+    "tools/tests/test_create_source_release.py",
+    "tools/tests/test_release_vote_workflow.py",
+    "tools/tests/test_update_branch_version.py",
+    "tools/tests/test_verify_release_versions.py",
+    "tools/tests/test_verify_source_archive.py",
+}
+RELEASE_WORKFLOW_BY_JOB = {
+    "rust": "./.github/workflows/release-rust.yml",
+    "java": "./.github/workflows/release-java.yml",
+    "python-wheels": "./.github/workflows/release-python.yml",
+    "python-publish": "./.github/workflows/release-python-publish.yml",
+}
+IMPORT_VERIFICATION_KEYS_COMMAND = """set -euo pipefail
+keys_file="${RUNNER_TEMP}/KEYS"
+curl --fail --location --proto '=https' --tlsv1.2 \\
+  --output "${keys_file}" \\
+  https://downloads.apache.org/paimon/KEYS
+gpg --batch --import "${keys_file}"
+"""
+VERIFY_RELEASE_COMMAND = (
+    'python3 tools/verify_release_versions.py "${TAG_NAME}" '
+    "--verify-signature"
+)
+VERIFY_SOURCE_ARCHIVE_COMMAND = """set -euo pipefail
+release_version="${GITHUB_REF_NAME#v}"
+release_version="${release_version%-rc*}"
+archive="${RUNNER_TEMP}/apache-paimon-mosaic-${release_version}-src.tgz"
+prefix="paimon-mosaic-${release_version}/"
+commit="$(git rev-parse --verify 'HEAD^{commit}')"
+python3 tools/verify_source_archive.py create \\
+  --repository "${GITHUB_WORKSPACE}" \\
+  --commit "${commit}" \\
+  --prefix "${prefix}" \\
+  --output "${archive}"
+python3 tools/verify_source_archive.py verify \\
+  --repository "${GITHUB_WORKSPACE}" \\
+  --commit "${commit}" \\
+  --prefix "${prefix}" \\
+  --archive "${archive}"
+"""
+GATE_TEST_COMMAND = """python -m pytest -q \\
+  tools/tests/test_create_source_release.py \\
+  tools/tests/test_release_vote_workflow.py \\
+  tools/tests/test_update_branch_version.py \\
+  tools/tests/test_verify_release_versions.py \\
+  tools/tests/test_verify_source_archive.py
+"""
+GATE_SOURCE_TREE_COMMAND = """set -euo pipefail
+output_dir="$(mktemp -d "${RUNNER_TEMP}/source-tree.XXXXXX")"
+archive="${output_dir}/source.tgz"
+commit="$(git rev-parse --verify 'HEAD^{commit}')"
+prefix="paimon-mosaic-source-tree/"
+python3 tools/verify_source_archive.py create \\
+  --repository "${GITHUB_WORKSPACE}" \\
+  --commit "${commit}" \\
+  --prefix "${prefix}" \\
+  --output "${archive}"
+python3 tools/verify_source_archive.py verify \\
+  --repository "${GITHUB_WORKSPACE}" \\
+  --commit "${commit}" \\
+  --prefix "${prefix}" \\
+  --archive "${archive}"
+"""
+GATE_STATIC_COMMAND = """set -euo pipefail
+python -m compileall -q \\
+  tools/verify_release_versions.py \\
+  tools/verify_source_archive.py \\
+  tools/tests/test_create_source_release.py \\
+  tools/tests/test_release_vote_workflow.py \\
+  tools/tests/test_update_branch_version.py \\
+  tools/tests/test_verify_release_versions.py \\
+  tools/tests/test_verify_source_archive.py
+bash -n tools/create_source_release.sh
+bash -n tools/update_branch_version.sh
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  comparison_ref="origin/${GITHUB_BASE_REF}"
+else
+  comparison_ref="HEAD^"
+fi
+git diff --check "$(git merge-base HEAD "${comparison_ref}")" HEAD
+"""
+
+
+def load_workflow(path: Path) -> dict:
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def needs(job: dict) -> set[str]:
+    value = job.get("needs", [])
+    return {value} if isinstance(value, str) else set(value)
+
+
+def release_version_step(workflow: dict) -> dict:
+    steps = workflow["jobs"]["release-preflight"]["steps"]
+    version_steps = [
+        step
+        for step in steps
+        if "verify_release_versions.py" in step.get("run", "")
+    ]
+    assert len(version_steps) == 1
+    return version_steps[0]
+
+
+def named_step(workflow: dict, name: str) -> dict:
+    steps = workflow["jobs"]["release-preflight"]["steps"]
+    matches = [step for step in steps if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def gate_step(workflow: dict, name: str) -> dict:
+    steps = workflow["jobs"]["release-vote-gate"]["steps"]
+    matches = [step for step in steps if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def assert_gate_contract(workflow: dict) -> None:
+    triggers = workflow["on"]
+    assert "workflow_dispatch" in triggers
+    assert set(triggers["pull_request"]["branches"]) == {"main", "release-*"}
+    assert set(triggers["push"]["branches"]) == {"main", "release-*"}
+    for event in ("pull_request", "push"):
+        assert REQUIRED_GATE_PATHS <= set(triggers[event]["paths"])
+
+    job = workflow["jobs"]["release-vote-gate"]
+    assert "if" not in job
+    assert "continue-on-error" not in job
+
+    install_step = gate_step(workflow, "Install test dependencies")
+    test_step = gate_step(workflow, "Run release vote tests")
+    source_tree_step = gate_step(workflow, "Verify current source tree")
+    static_step = gate_step(workflow, "Run static checks")
+    for step in (install_step, test_step, source_tree_step, static_step):
+        assert "if" not in step
+        assert "continue-on-error" not in step
+
+    assert install_step["run"] == "python -m pip install pytest PyYAML"
+    assert test_step["run"] == GATE_TEST_COMMAND
+    assert source_tree_step["shell"] == "bash"
+    assert source_tree_step["run"] == GATE_SOURCE_TREE_COMMAND
+    assert static_step["shell"] == "bash"
+    assert static_step["run"] == GATE_STATIC_COMMAND
+
+
+def assert_release_contract(workflow: dict) -> None:
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+
+    jobs = workflow["jobs"]
+    preflight = jobs["release-preflight"]
+    assert preflight["uses"] == "./.github/workflows/release-preflight.yml"
+    assert "runs-on" not in preflight
+    assert "continue-on-error" not in preflight
+
+    for job_name in ("rust", "java", "python-wheels", "python-publish"):
+        assert jobs[job_name].get("secrets") == "inherit"
+
+    for job_name in ("rust", "java", "python-wheels"):
+        release_job = jobs[job_name]
+        assert "release-preflight" in needs(release_job)
+        assert "if" not in release_job
+        assert "continue-on-error" not in release_job
+
+    publish_job = jobs["python-publish"]
+    assert needs(publish_job) == {"rust", "java", "python-wheels"}
+    assert publish_job["if"] == TAG_CONDITION
+    assert "continue-on-error" not in publish_job
+
+    for job_name, reusable_workflow in RELEASE_WORKFLOW_BY_JOB.items():
+        assert jobs[job_name]["uses"] == reusable_workflow
+
+    source = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert "always()" not in source
+
+
+def assert_release_preflight_contract(workflow: dict) -> None:
+    assert "workflow_call" in workflow["on"]
+    assert workflow["permissions"]["contents"] == "read"
+
+    preflight = workflow["jobs"]["release-preflight"]
+    assert "runs-on" in preflight
+    assert "uses" not in preflight
+    assert "continue-on-error" not in preflight
+    assert "continue-on-error" not in release_version_step(workflow)
+
+    checkout = next(
+        step
+        for step in preflight["steps"]
+        if step.get("uses") == "actions/checkout@v6"
+    )
+    checkout_options = checkout.get("with", {})
+    assert checkout_options.get("fetch-depth") == "0"
+    assert "ref" not in checkout_options
+
+    import_step = named_step(workflow, "Import release verification keys")
+    assert import_step["if"] == TAG_CONDITION
+    assert "env" not in import_step
+    assert "continue-on-error" not in import_step
+    assert import_step["run"] == IMPORT_VERIFICATION_KEYS_COMMAND
+
+    version_step = release_version_step(workflow)
+    assert version_step["if"] == TAG_CONDITION
+    assert version_step["env"] == {
+        "TAG_NAME": "${{ github.ref_name }}",
+    }
+    assert version_step["run"] == VERIFY_RELEASE_COMMAND
+
+    source_step = named_step(workflow, "Verify source archive")
+    assert source_step["if"] == TAG_CONDITION
+    assert "continue-on-error" not in source_step
+    assert source_step["run"] == VERIFY_SOURCE_ARCHIVE_COMMAND
+
+
+def assert_leaf_release_contract(
+    workflow: dict,
+    required_job: str,
+) -> None:
+    assert "workflow_call" in workflow["on"]
+    assert workflow["jobs"]["release-preflight"]["uses"] == (
+        "./.github/workflows/release-preflight.yml"
+    )
+    for job_name, job in workflow["jobs"].items():
+        if job_name != "release-preflight":
+            assert "release-preflight" in needs(job)
+    assert required_job in workflow["jobs"]
+
+
+def test_release_has_signed_exact_tag_preflight() -> None:
+    release = load_workflow(RELEASE_WORKFLOW)
+    preflight = load_workflow(RELEASE_PREFLIGHT_WORKFLOW)
+    assert_release_contract(release)
+    assert_release_preflight_contract(preflight)
+
+    triggers = release["on"]
+    assert "workflow_dispatch" in triggers
+    version_step = release_version_step(preflight)
+    assert version_step["if"] == TAG_CONDITION
+    assert "github.ref_name" in version_step["env"]["TAG_NAME"]
+    assert "github.ref_name" not in version_step["run"]
+
+
+def test_release_preflight_is_reusable_and_called_by_orchestrator() -> None:
+    preflight = load_workflow(RELEASE_PREFLIGHT_WORKFLOW)
+    release = load_workflow(RELEASE_WORKFLOW)
+
+    assert "workflow_call" in preflight["on"]
+    assert release["jobs"]["release-preflight"]["uses"] == (
+        "./.github/workflows/release-preflight.yml"
+    )
+
+
+def test_release_preflight_does_not_use_private_key_secret() -> None:
+    assert "GPG_SECRET_KEY" not in RELEASE_PREFLIGHT_WORKFLOW.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_release_tag_context_is_not_interpolated_into_shell() -> None:
+    workflow = load_workflow(RELEASE_PREFLIGHT_WORKFLOW)
+    version_step = release_version_step(workflow)
+
+    assert version_step["env"] == {
+        "TAG_NAME": "${{ github.ref_name }}",
+    }
+    assert version_step["run"] == VERIFY_RELEASE_COMMAND
+    assert "${{ github.ref_name }}" not in version_step["run"]
+
+
+def test_manual_rust_dispatch_cannot_publish() -> None:
+    workflow = load_workflow(RUST_RELEASE_WORKFLOW)
+    publish_steps = [
+        step
+        for step in workflow["jobs"]["publish"]["steps"]
+        if step.get("name") == "Publish paimon-mosaic-core to crates.io"
+    ]
+
+    assert len(publish_steps) == 1
+    assert publish_steps[0]["if"] == RUST_PUBLISH_CONDITION
+
+
+def test_manual_java_dispatch_cannot_deploy_staging() -> None:
+    workflow = load_workflow(JAVA_RELEASE_WORKFLOW)
+    deploy_job = workflow["jobs"]["deploy-staging"]
+
+    assert deploy_job["if"] == JAVA_DEPLOY_CONDITION
+
+
+def test_manual_release_dispatch_cannot_publish_python() -> None:
+    workflow = load_workflow(PYTHON_PUBLISH_WORKFLOW)
+    steps = workflow["jobs"]["publish"]["steps"]
+    test_publish = [
+        step for step in steps if step.get("name") == "Publish to TestPyPI"
+    ]
+    final_publish = [
+        step for step in steps if step.get("name") == "Publish to PyPI"
+    ]
+
+    assert len(test_publish) == 1
+    assert len(final_publish) == 1
+    assert test_publish[0]["if"] == PYTHON_TEST_PUBLISH_CONDITION
+    assert final_publish[0]["if"] == PYTHON_PUBLISH_CONDITION
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "credentialed_job"),
+    CREDENTIALED_RELEASE_WORKFLOWS,
+)
+def test_credentialed_release_jobs_require_reusable_preflight(
+    workflow_path: Path,
+    credentialed_job: str,
+) -> None:
+    workflow = load_workflow(workflow_path)
+
+    assert_leaf_release_contract(workflow, credentialed_job)
+
+
+def test_java_release_tag_context_is_not_interpolated_into_shell() -> None:
+    workflow = load_workflow(JAVA_RELEASE_WORKFLOW)
+    deploy_steps = [
+        step
+        for step in workflow["jobs"]["deploy-staging"]["steps"]
+        if step.get("name") == "Deploy to Apache Nexus staging"
+    ]
+
+    assert len(deploy_steps) == 1
+    deploy_step = deploy_steps[0]
+    assert deploy_step["env"]["TAG_NAME"] == "${{ github.ref_name }}"
+    assert 'REF="${TAG_NAME}"' in deploy_step["run"]
+    assert "${{ github.ref_name }}" not in deploy_step["run"]
+
+
+@pytest.mark.parametrize("job_name", ("rust", "java", "python-wheels"))
+def test_contract_rejects_deleted_preflight_need(job_name: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+    workflow["jobs"][job_name].pop("needs")
+
+    with pytest.raises(AssertionError):
+        assert_release_contract(workflow)
+
+
+@pytest.mark.parametrize("condition", ("${{ failure() }}", "${{ !cancelled() }}"))
+def test_contract_rejects_release_job_status_override(condition: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+    workflow["jobs"]["rust"]["if"] = condition
+
+    with pytest.raises(AssertionError):
+        assert_release_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("status-override", "missing-dependency", "continue-on-error"),
+)
+def test_contract_rejects_python_publish_bypass(mutation: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+    publish_job = workflow["jobs"]["python-publish"]
+    if mutation == "status-override":
+        publish_job["if"] = "${{ failure() }}"
+    elif mutation == "missing-dependency":
+        publish_job["needs"] = ["rust"]
+    elif mutation == "continue-on-error":
+        publish_job["continue-on-error"] = "true"
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_release_contract(workflow)
+
+
+@pytest.mark.parametrize("job_name", RELEASE_WORKFLOW_BY_JOB)
+def test_contract_rejects_wrong_reusable_workflow(job_name: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+    workflow["jobs"][job_name]["uses"] = "./.github/workflows/wrong.yml"
+
+    with pytest.raises(AssertionError):
+        assert_release_contract(workflow)
+
+
+@pytest.mark.parametrize("job_name", RELEASE_WORKFLOW_BY_JOB)
+def test_contract_rejects_missing_secret_inheritance(job_name: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+    workflow["jobs"][job_name].pop("secrets")
+
+    with pytest.raises(AssertionError):
+        assert_release_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    ("workflow_path", "credentialed_job"),
+    CREDENTIALED_RELEASE_WORKFLOWS,
+)
+@pytest.mark.parametrize(
+    "mutation",
+    ("missing-workflow-call", "missing-dependency", "unguarded-extra-job"),
+)
+def test_credentialed_release_contract_rejects_preflight_bypass(
+    workflow_path: Path,
+    credentialed_job: str,
+    mutation: str,
+) -> None:
+    workflow = copy.deepcopy(load_workflow(workflow_path))
+    if mutation == "missing-workflow-call":
+        workflow["on"].pop("workflow_call")
+    elif mutation == "missing-dependency":
+        job = workflow["jobs"][credentialed_job]
+        job["needs"] = [
+            dependency
+            for dependency in job.get("needs", [])
+            if dependency != "release-preflight"
+        ]
+    elif mutation == "unguarded-extra-job":
+        workflow["jobs"]["alternate-publish"] = {
+            "runs-on": "ubuntu-latest",
+            "steps": [{"run": "echo publish"}],
+        }
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_leaf_release_contract(workflow, credentialed_job)
+
+
+def test_contract_rejects_masked_release_verifier_failure() -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_PREFLIGHT_WORKFLOW))
+    release_version_step(workflow)["run"] += " || true"
+
+    with pytest.raises(AssertionError):
+        assert_release_preflight_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("missing-step", "masked-command", "step-continue", "wrong-commit"),
+)
+def test_contract_rejects_source_archive_preflight_mutations(
+    mutation: str,
+) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_PREFLIGHT_WORKFLOW))
+    if mutation == "missing-step":
+        steps = workflow["jobs"]["release-preflight"]["steps"]
+        steps.remove(named_step(workflow, "Verify source archive"))
+    elif mutation == "masked-command":
+        named_step(workflow, "Verify source archive")["run"] += " || true"
+    elif mutation == "step-continue":
+        named_step(workflow, "Verify source archive")[
+            "continue-on-error"
+        ] = "true"
+    elif mutation == "wrong-commit":
+        source_step = named_step(workflow, "Verify source archive")
+        source_step["run"] = source_step["run"].replace(
+            '--commit "${commit}"',
+            "--commit HEAD^",
+        )
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_release_preflight_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    (
+        "wrong-checkout-ref",
+        "missing-signature-verification",
+        "masked-key-import",
+        "key-import-continue",
+        "private-key-secret",
+    ),
+)
+def test_contract_rejects_signed_tag_preflight_mutations(mutation: str) -> None:
+    workflow = copy.deepcopy(load_workflow(RELEASE_PREFLIGHT_WORKFLOW))
+    if mutation == "wrong-checkout-ref":
+        checkout = next(
+            step
+            for step in workflow["jobs"]["release-preflight"]["steps"]
+            if step.get("uses") == "actions/checkout@v6"
+        )
+        checkout["with"]["ref"] = "main"
+    elif mutation == "missing-signature-verification":
+        release_version_step(workflow)["run"] = (
+            'python3 tools/verify_release_versions.py "${TAG_NAME}"'
+        )
+    elif mutation == "masked-key-import":
+        named_step(workflow, "Import release verification keys")[
+            "run"
+        ] += " || true"
+    elif mutation == "key-import-continue":
+        named_step(workflow, "Import release verification keys")[
+            "continue-on-error"
+        ] = "true"
+    elif mutation == "private-key-secret":
+        import_step = named_step(workflow, "Import release verification keys")
+        import_step["env"] = {
+            "GPG_SECRET_KEY": "${{ secrets.GPG_SECRET_KEY }}"
+        }
+        import_step["run"] = (
+            "printf '%s' \"${GPG_SECRET_KEY}\" | gpg --batch --import"
+        )
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_release_preflight_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("cancel-in-progress", "preflight-continue", "version-step-continue"),
+)
+def test_contract_rejects_non_blocking_preflight_mutations(mutation: str) -> None:
+    if mutation == "cancel-in-progress":
+        workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+        workflow["concurrency"]["cancel-in-progress"] = "true"
+        contract = assert_release_contract
+    elif mutation == "preflight-continue":
+        workflow = copy.deepcopy(load_workflow(RELEASE_WORKFLOW))
+        workflow["jobs"]["release-preflight"]["continue-on-error"] = "true"
+        contract = assert_release_contract
+    elif mutation == "version-step-continue":
+        workflow = copy.deepcopy(load_workflow(RELEASE_PREFLIGHT_WORKFLOW))
+        release_version_step(workflow)["continue-on-error"] = "true"
+        contract = assert_release_preflight_contract
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        contract(workflow)
+
+
+def test_source_release_documentation_passes_rc_tag_explicitly() -> None:
+    source = RELEASE_DOCUMENTATION.read_text(encoding="utf-8")
+    invocation = (
+        "RELEASE_VERSION=${RELEASE_VERSION} "
+        "RC_TAG=${RC_TAG} ./create_source_release.sh"
+    )
+    assert invocation in source
+
+    assert "Cargo path dependency constraints and Cargo.lock" in source
+    assert (
+        "<tr><td><code>GPG_SECRET_KEY</code></td>"
+        "<td>Java artifact signing</td></tr>"
+    ) in source
+
+
+def test_release_documentation_describes_source_archive_preflight() -> None:
+    source = RELEASE_DOCUMENTATION.read_text(encoding="utf-8")
+    assert "temporary source archive" in source
+
+
+def test_release_documentation_preserves_previous_rc_output_before_retry() -> None:
+    source = RELEASE_DOCUMENTATION.read_text(encoding="utf-8")
+    retry_section = source.partition('<h2 id="fix-any-issues">')[2].partition(
+        '<h2 id="finalize-the-release">'
+    )[0]
+    preserve_command = (
+        'mv tools/release "../paimon-mosaic-${RC_TAG}-artifacts"'
+    )
+
+    assert preserve_command in retry_section
+    assert retry_section.index(preserve_command) < retry_section.index(
+        "Increment <code>RC_NUM</code>"
+    )
+
+
+def test_release_vote_gate_matches_blocking_contract() -> None:
+    workflow = load_workflow(GATE_WORKFLOW)
+    assert_gate_contract(workflow)
+
+
+@pytest.mark.parametrize("event", ("pull_request", "push"))
+def test_release_vote_gate_covers_all_workflows_and_archive_attributes(
+    event: str,
+) -> None:
+    workflow = load_workflow(GATE_WORKFLOW)
+    paths = set(workflow["on"][event]["paths"])
+
+    assert ".github/workflows/**" in paths
+    assert ".gitattributes" in paths
+
+
+def test_release_vote_gate_verifies_current_source_tree() -> None:
+    workflow = load_workflow(GATE_WORKFLOW)
+    step = gate_step(workflow, "Verify current source tree")
+
+    assert "if" not in step
+    assert "continue-on-error" not in step
+    assert step["shell"] == "bash"
+    assert step["run"] == GATE_SOURCE_TREE_COMMAND
+
+
+@pytest.mark.parametrize("event", ("pull_request", "push"))
+@pytest.mark.parametrize("required_path", (".github/workflows/**", ".gitattributes"))
+def test_gate_contract_rejects_missing_release_input_path(
+    event: str,
+    required_path: str,
+) -> None:
+    workflow = copy.deepcopy(load_workflow(GATE_WORKFLOW))
+    workflow["on"][event]["paths"].remove(required_path)
+
+    with pytest.raises(AssertionError):
+        assert_gate_contract(workflow)
+
+
+@pytest.mark.parametrize("event", ("pull_request", "push"))
+def test_gate_contract_rejects_missing_release_branch(event: str) -> None:
+    workflow = copy.deepcopy(load_workflow(GATE_WORKFLOW))
+    workflow["on"][event]["branches"].remove("release-*")
+
+    with pytest.raises(AssertionError):
+        assert_gate_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("masked-command", "step-continue", "step-condition", "job-continue"),
+)
+def test_gate_contract_rejects_non_blocking_test_mutations(mutation: str) -> None:
+    workflow = copy.deepcopy(load_workflow(GATE_WORKFLOW))
+    if mutation == "masked-command":
+        gate_step(workflow, "Run release vote tests")["run"] += " || true"
+    elif mutation == "step-continue":
+        gate_step(workflow, "Run release vote tests")[
+            "continue-on-error"
+        ] = "true"
+    elif mutation == "step-condition":
+        gate_step(workflow, "Run release vote tests")["if"] = "failure()"
+    elif mutation == "job-continue":
+        workflow["jobs"]["release-vote-gate"]["continue-on-error"] = "true"
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_gate_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("masked-command", "step-continue", "step-condition", "wrong-commit"),
+)
+def test_gate_contract_rejects_source_tree_check_mutations(
+    mutation: str,
+) -> None:
+    workflow = copy.deepcopy(load_workflow(GATE_WORKFLOW))
+    source_step = gate_step(workflow, "Verify current source tree")
+    if mutation == "masked-command":
+        source_step["run"] += " || true"
+    elif mutation == "step-continue":
+        source_step["continue-on-error"] = "true"
+    elif mutation == "step-condition":
+        source_step["if"] = "failure()"
+    elif mutation == "wrong-commit":
+        source_step["run"] = source_step["run"].replace(
+            '--commit "${commit}"',
+            "--commit HEAD^",
+        )
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_gate_contract(workflow)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("masked-command", "step-continue", "step-condition"),
+)
+def test_gate_contract_rejects_non_blocking_static_checks(mutation: str) -> None:
+    workflow = copy.deepcopy(load_workflow(GATE_WORKFLOW))
+    static_step = gate_step(workflow, "Run static checks")
+    if mutation == "masked-command":
+        static_step["run"] += " || true"
+    elif mutation == "step-continue":
+        static_step["continue-on-error"] = "true"
+    elif mutation == "step-condition":
+        static_step["if"] = "failure()"
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    with pytest.raises(AssertionError):
+        assert_gate_contract(workflow)

--- a/tools/tests/test_update_branch_version.py
+++ b/tools/tests/test_update_branch_version.py
@@ -1,0 +1,177 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[2]
+UPDATE_SCRIPT = ROOT / "tools/update_branch_version.sh"
+VERSION_VERIFIER = ROOT / "tools/verify_release_versions.py"
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def initialize_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    tools = repo / "tools"
+    tools.mkdir(parents=True)
+    shutil.copy2(UPDATE_SCRIPT, tools / UPDATE_SCRIPT.name)
+    shutil.copy2(VERSION_VERIFIER, tools / VERSION_VERIFIER.name)
+
+    write(
+        repo / "Cargo.toml",
+        '[workspace]\nmembers = ["core", "cli"]\nresolver = "2"\n',
+    )
+    write(
+        repo / "core/Cargo.toml",
+        '[package]\nname = "paimon-mosaic-core"\nversion = "0.3.0"\n',
+    )
+    write(repo / "core/src/lib.rs", "")
+    write(
+        repo / "cli/Cargo.toml",
+        '[package]\nname = "paimon-mosaic-cli"\nversion = "0.3.0"\n\n'
+        "[dependencies]\n"
+        'paimon-mosaic-core = { path = "../core", version = "0.3.0" }\n',
+    )
+    write(repo / "cli/src/main.rs", "fn main() {}\n")
+    write(
+        repo / "java/pom.xml",
+        '<?xml version="1.0"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        "  <modelVersion>4.0.0</modelVersion>\n"
+        "  <groupId>org.apache.paimon</groupId>\n"
+        "  <artifactId>mosaic</artifactId>\n"
+        "  <version>0.3.0</version>\n"
+        "</project>\n",
+    )
+    write(
+        repo / "python/pyproject.toml",
+        '[project]\nname = "paimon-mosaic"\nversion = "0.3.0"\n',
+    )
+
+    run(["cargo", "generate-lockfile", "--offline"], cwd=repo)
+    run(["git", "init", "-q"], cwd=repo)
+    run(["git", "config", "user.name", "Version Test"], cwd=repo)
+    run(
+        ["git", "config", "user.email", "version-test@example.invalid"],
+        cwd=repo,
+    )
+    run(["git", "add", "."], cwd=repo)
+    run(["git", "commit", "-q", "-m", "version fixture"], cwd=repo)
+    return repo
+
+
+def run_updater(repo: Path, old: str, new: str) -> None:
+    env = os.environ.copy()
+    env.update({"OLD_VERSION": old, "NEW_VERSION": new})
+    run(["bash", UPDATE_SCRIPT.name], cwd=repo / "tools", env=env)
+
+
+def package_versions(path: Path) -> dict[str, str]:
+    lock = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {
+        package["name"]: package["version"]
+        for package in lock["package"]
+        if package["name"].startswith("paimon-mosaic")
+    }
+
+
+def test_documented_version_transitions_refresh_cargo_constraints_and_lock(
+    tmp_path: Path,
+) -> None:
+    repo = initialize_repo(tmp_path)
+
+    run_updater(repo, "0.3.0", "0.4.0-SNAPSHOT")
+
+    assert (
+        tomllib.loads((repo / "core/Cargo.toml").read_text(encoding="utf-8"))[
+            "package"
+        ]["version"]
+        == "0.4.0"
+    )
+    cli = tomllib.loads(
+        (repo / "cli/Cargo.toml").read_text(encoding="utf-8")
+    )
+    assert cli["package"]["version"] == "0.4.0"
+    assert cli["dependencies"]["paimon-mosaic-core"]["version"] == "0.4.0"
+    assert package_versions(repo / "Cargo.lock") == {
+        "paimon-mosaic-cli": "0.4.0",
+        "paimon-mosaic-core": "0.4.0",
+    }
+    assert "<version>0.4.0-SNAPSHOT</version>" in (
+        repo / "java/pom.xml"
+    ).read_text(encoding="utf-8")
+    assert (
+        tomllib.loads(
+            (repo / "python/pyproject.toml").read_text(encoding="utf-8")
+        )["project"]["version"]
+        == "0.4.0"
+    )
+    assert run(["git", "status", "--porcelain"], cwd=repo).stdout == b""
+
+    run_updater(repo, "0.4.0-SNAPSHOT", "0.4.0")
+
+    assert package_versions(repo / "Cargo.lock") == {
+        "paimon-mosaic-cli": "0.4.0",
+        "paimon-mosaic-core": "0.4.0",
+    }
+    assert "<version>0.4.0</version>" in (
+        repo / "java/pom.xml"
+    ).read_text(encoding="utf-8")
+    assert run(["git", "status", "--porcelain"], cwd=repo).stdout == b""
+    assert (
+        run(["git", "rev-list", "--count", "HEAD"], cwd=repo)
+        .stdout.decode()
+        .strip()
+        == "3"
+    )
+    run(
+        [
+            sys.executable,
+            str(VERSION_VERIFIER),
+            "--root",
+            str(repo),
+            "v0.4.0-rc1",
+        ],
+        cwd=repo,
+    )

--- a/tools/tests/test_verify_release_versions.py
+++ b/tools/tests/test_verify_release_versions.py
@@ -1,0 +1,779 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+TOOLS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS))
+
+import verify_release_versions as verifier  # noqa: E402
+
+
+VERSION = "0.3.0"
+TAG = f"v{VERSION}-rc1"
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def initialize_versions(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    write(
+        root / "Cargo.toml",
+        '[workspace]\nmembers = ["core", "ffi", "helper"]\nresolver = "2"\n',
+    )
+    write(
+        root / "core/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-core"\nversion = "{VERSION}"\n',
+    )
+    write(
+        root / "ffi/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-ffi"\nversion = "{VERSION}"\n',
+    )
+    write(
+        root / "helper/Cargo.toml",
+        '[package]\nname = "fixture-helper"\nversion = "9.9.9"\n',
+    )
+    write(
+        root / "Cargo.lock",
+        "version = 4\n\n"
+        "[[package]]\n"
+        'name = "paimon-mosaic-core"\n'
+        f'version = "{VERSION}"\n\n'
+        "[[package]]\n"
+        'name = "paimon-mosaic-ffi"\n'
+        f'version = "{VERSION}"\n\n'
+        "[[package]]\n"
+        'name = "fixture-helper"\n'
+        'version = "9.9.9"\n',
+    )
+    write(
+        root / "java/pom.xml",
+        '<?xml version="1.0"?>\n'
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+        "  <modelVersion>4.0.0</modelVersion>\n"
+        "  <groupId>org.apache.paimon</groupId>\n"
+        "  <artifactId>mosaic</artifactId>\n"
+        f"  <version>{VERSION}</version>\n"
+        "</project>\n",
+    )
+    write(
+        root / "python/pyproject.toml",
+        '[project]\nname = "paimon-mosaic"\n'
+        f'version = "{VERSION}"\n',
+    )
+    return root
+
+
+def replace(path: Path, old: str, new: str) -> None:
+    source = path.read_text(encoding="utf-8")
+    assert old in source
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+
+def initialize_git_repository(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Release Test"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "release-test@example.invalid"],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=root, check=True)
+
+
+@pytest.fixture(scope="session")
+def signing_home(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, str]:
+    if shutil.which("gpg") is None:
+        pytest.skip("gpg is required for release tag tests")
+    home = tmp_path_factory.mktemp("release-tag-gnupg")
+    home.chmod(0o700)
+    env = os.environ.copy()
+    env["GNUPGHOME"] = str(home)
+    subprocess.run(
+        [
+            "gpg",
+            "--batch",
+            "--passphrase",
+            "",
+            "--quick-gen-key",
+            "Release Tag Test <release-tag-test@example.invalid>",
+            "rsa1024",
+            "sign",
+            "0",
+        ],
+        cwd=home,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    listing = subprocess.run(
+        ["gpg", "--batch", "--with-colons", "--list-secret-keys"],
+        cwd=home,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ).stdout
+    fingerprint = next(
+        line.split(":")[9]
+        for line in listing.splitlines()
+        if line.startswith("fpr:")
+    )
+    return home, fingerprint
+
+
+def sign_release_tag(
+    root: Path,
+    signing_home: tuple[Path, str],
+) -> dict[str, str]:
+    home, fingerprint = signing_home
+    env = os.environ.copy()
+    env["GNUPGHOME"] = str(home)
+    subprocess.run(
+        ["git", "config", "user.signingkey", fingerprint],
+        cwd=root,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "tag", "-s", "-u", fingerprint, TAG, "-m", "signed release tag"],
+        cwd=root,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return env
+
+
+def run_verifier(
+    root: Path,
+    *,
+    env: dict[str, str] | None = None,
+    tag: str = TAG,
+    verify_signature: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        str(TOOLS / "verify_release_versions.py"),
+        tag,
+        "--root",
+        str(root),
+    ]
+    if verify_signature:
+        command.append("--verify-signature")
+    return subprocess.run(
+        command,
+        cwd=root,
+        env=env,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_all_release_versions_match_tag(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+
+    assert verifier.verify_release_versions(root, TAG) == VERSION
+
+
+def test_cli_verify_signature_rejects_unsigned_tag(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    subprocess.run(
+        ["git", "tag", "-a", TAG, "-m", "unsigned release tag"],
+        cwd=root,
+        check=True,
+    )
+
+    result = run_verifier(root, verify_signature=True)
+
+    assert result.returncode == 1
+    assert "not a verifiable signed tag" in result.stderr
+
+
+def test_cli_verify_signature_accepts_signed_tag(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    env = sign_release_tag(root, signing_home)
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert result.returncode == 0, result.stderr
+    assert f"verified release tag {TAG}" in result.stdout
+
+
+@pytest.mark.parametrize("injection", ("count", "parameters", "local"))
+def test_cli_verify_signature_rejects_injected_gpg_program(
+    tmp_path: Path,
+    injection: str,
+) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    forged_tag_object = subprocess.run(
+        ["git", "hash-object", "-t", "tag", "-w", "--stdin"],
+        cwd=root,
+        check=True,
+        input=(
+            f"object {commit}\n"
+            "type commit\n"
+            f"tag {TAG}\n"
+            "tagger Release Test <release-test@example.invalid> 0 +0000\n\n"
+            "forged release tag\n\n"
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "invalid\n"
+            "-----END PGP SIGNATURE-----\n"
+        ),
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "update-ref", f"refs/tags/{TAG}", forged_tag_object],
+        cwd=root,
+        check=True,
+    )
+    fake_gpg = tmp_path / "fake-gpg"
+    write(
+        fake_gpg,
+        "#!/bin/sh\n"
+        "printf '%s\\n' \\\n"
+        "  '[GNUPG:] NEWSIG' \\\n"
+        "  '[GNUPG:] GOODSIG DEADBEEF Release Test' \\\n"
+        "  '[GNUPG:] VALIDSIG 0123456789ABCDEF0123456789ABCDEF01234567 "
+        "2026-08-28 0 4 0 1 10 00 "
+        "0123456789ABCDEF0123456789ABCDEF01234567'\n"
+        "exit 0\n",
+    )
+    fake_gpg.chmod(0o755)
+    env = os.environ.copy()
+    if injection == "count":
+        env.update(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "gpg.program",
+                "GIT_CONFIG_VALUE_0": str(fake_gpg),
+            }
+        )
+    elif injection == "parameters":
+        env["GIT_CONFIG_PARAMETERS"] = (
+            f"'gpg.program'='{fake_gpg}'"
+        )
+    else:
+        subprocess.run(
+            ["git", "config", "gpg.program", str(fake_gpg)],
+            cwd=root,
+            check=True,
+        )
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert result.returncode == 1
+    assert "not a verifiable signed tag" in result.stderr
+
+
+def test_cli_verify_signature_reads_versions_from_signed_commit(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path)
+    pom = root / "java/pom.xml"
+    replace(pom, "<version>0.3.0</version>", "<version>0.3.1</version>")
+    initialize_git_repository(root)
+    env = sign_release_tag(root, signing_home)
+    replace(pom, "<version>0.3.1</version>", "<version>0.3.0</version>")
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert result.returncode == 1
+    assert (
+        "java/pom.xml project version is '0.3.1', expected '0.3.0'"
+        in result.stderr
+    )
+
+
+def test_cli_verify_signature_ignores_inherited_git_repository_selection(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path / "intended")
+    initialize_git_repository(root)
+    sign_release_tag(root, signing_home)
+
+    foreign = initialize_versions(tmp_path / "foreign")
+    replace(
+        foreign / "java/pom.xml",
+        "<version>0.3.0</version>",
+        "<version>0.3.1</version>",
+    )
+    initialize_git_repository(foreign)
+    env = sign_release_tag(foreign, signing_home)
+    env.update(
+        {
+            "GIT_DIR": str(foreign / ".git"),
+            "GIT_WORK_TREE": str(foreign),
+        }
+    )
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert result.returncode == 0, result.stderr
+    assert f"verified release tag {TAG}" in result.stdout
+
+
+def test_materialize_release_version_files_rejects_symlink(
+    tmp_path: Path,
+) -> None:
+    root = initialize_versions(tmp_path)
+    pom = root / "java/pom.xml"
+    pom.unlink()
+    pom.symlink_to("../Cargo.toml")
+    initialize_git_repository(root)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(
+        ValueError,
+        match="release version file is not regular: java/pom.xml",
+    ):
+        verifier.materialize_release_version_files(
+            root,
+            commit,
+            tmp_path / "materialized",
+        )
+
+
+def test_materialize_release_version_files_requires_all_roots(
+    tmp_path: Path,
+) -> None:
+    root = initialize_versions(tmp_path)
+    (root / "python/pyproject.toml").unlink()
+    initialize_git_repository(root)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+    with pytest.raises(
+        ValueError,
+        match="signed commit is missing release version files.*python/pyproject.toml",
+    ):
+        verifier.materialize_release_version_files(
+            root,
+            commit,
+            tmp_path / "materialized",
+        )
+
+
+def test_cli_verify_signature_rejects_tag_not_at_head(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    env = sign_release_tag(root, signing_home)
+    write(root / "after-tag.txt", "new commit\n")
+    subprocess.run(["git", "add", "after-tag.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "after tag"], cwd=root, check=True)
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert result.returncode == 1
+    assert "not current HEAD" in result.stderr
+
+
+def test_cli_verify_signature_rejects_alias_for_different_tag_name(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    env = sign_release_tag(root, signing_home)
+    tag_object = subprocess.run(
+        ["git", "rev-parse", TAG],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    alias = f"v{VERSION}"
+    subprocess.run(
+        ["git", "update-ref", f"refs/tags/{alias}", tag_object],
+        cwd=root,
+        check=True,
+    )
+
+    result = run_verifier(
+        root,
+        env=env,
+        tag=alias,
+        verify_signature=True,
+    )
+
+    assert result.returncode == 1
+    assert f"signed tag object names {TAG}, not {alias}" in result.stderr
+
+
+def test_cli_verifies_the_frozen_tag_object(
+    tmp_path: Path,
+    signing_home: tuple[Path, str],
+) -> None:
+    root = initialize_versions(tmp_path)
+    initialize_git_repository(root)
+    env = sign_release_tag(root, signing_home)
+    signed_tag_object = subprocess.run(
+        ["git", "rev-parse", f"{TAG}^{{tag}}"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    forged_tag_object = subprocess.run(
+        ["git", "hash-object", "-t", "tag", "-w", "--stdin"],
+        cwd=root,
+        check=True,
+        input=(
+            f"object {commit}\n"
+            "type commit\n"
+            f"tag {TAG}\n"
+            "tagger Release Test <release-test@example.invalid> 0 +0000\n\n"
+            "forged release tag\n\n"
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "invalid\n"
+            "-----END PGP SIGNATURE-----\n"
+        ),
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "update-ref", f"refs/tags/{TAG}", forged_tag_object],
+        cwd=root,
+        check=True,
+    )
+
+    wrapper_dir = tmp_path / "bin"
+    wrapper_dir.mkdir()
+    wrapper = wrapper_dir / "git"
+    write(
+        wrapper,
+        "#!/bin/sh\n"
+        'for argument in "$@"; do\n'
+        '  if [ "$argument" = "verify-tag" ] && [ ! -e "$MOVE_MARKER" ]; then\n'
+        '    : > "$MOVE_MARKER"\n'
+        '    "$REAL_GIT" -C "$RELEASE_REPO" update-ref '
+        '"refs/tags/$RELEASE_TAG" "$SIGNED_TAG_OBJECT"\n'
+        "    break\n"
+        "  fi\n"
+        "done\n"
+        'exec "$REAL_GIT" "$@"\n',
+    )
+    wrapper.chmod(0o755)
+    move_marker = tmp_path / "tag-moved-before-verification"
+    env.update(
+        {
+            "MOVE_MARKER": str(move_marker),
+            "PATH": f"{wrapper_dir}{os.pathsep}{env['PATH']}",
+            "REAL_GIT": shutil.which("git") or "git",
+            "RELEASE_REPO": str(root),
+            "RELEASE_TAG": TAG,
+            "SIGNED_TAG_OBJECT": signed_tag_object,
+        }
+    )
+
+    result = run_verifier(root, env=env, verify_signature=True)
+
+    assert move_marker.is_file()
+    assert result.returncode == 1
+    assert "not a verifiable signed tag" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "old", "new", "expected"),
+    (
+        (
+            "ffi/Cargo.toml",
+            'version = "0.3.0"',
+            'version = "0.3.1"',
+            "ffi/Cargo.toml",
+        ),
+        (
+            "Cargo.lock",
+            'name = "paimon-mosaic-ffi"\nversion = "0.3.0"',
+            'name = "paimon-mosaic-ffi"\nversion = "0.3.1"',
+            "Cargo.lock",
+        ),
+        (
+            "java/pom.xml",
+            "<version>0.3.0</version>",
+            "<version>0.3.0-SNAPSHOT</version>",
+            "java/pom.xml",
+        ),
+        (
+            "python/pyproject.toml",
+            'version = "0.3.0"',
+            'version = "0.3.0rc1"',
+            "python/pyproject.toml",
+        ),
+    ),
+)
+def test_rejects_cross_language_version_mismatch(
+    tmp_path: Path,
+    relative_path: str,
+    old: str,
+    new: str,
+    expected: str,
+) -> None:
+    root = initialize_versions(tmp_path)
+    replace(root / relative_path, old, new)
+
+    with pytest.raises(ValueError, match=expected):
+        verifier.verify_release_versions(root, TAG)
+
+
+def test_rejects_missing_workspace_package_in_cargo_lock(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+    lock = root / "Cargo.lock"
+    source = lock.read_text(encoding="utf-8")
+    source = source.replace(
+        "\n[[package]]\n"
+        'name = "paimon-mosaic-ffi"\n'
+        'version = "0.3.0"\n',
+        "",
+    )
+    lock.write_text(source, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Cargo.lock.*paimon-mosaic-ffi"):
+        verifier.verify_release_versions(root, TAG)
+
+
+@pytest.mark.parametrize(
+    "dependency_table",
+    (
+        "[dependencies]",
+        "[target.'cfg(unix)'.dev-dependencies]",
+    ),
+)
+def test_rejects_mismatched_versioned_workspace_path_dependency(
+    tmp_path: Path,
+    dependency_table: str,
+) -> None:
+    root = initialize_versions(tmp_path)
+    write(
+        root / "ffi/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-ffi"\nversion = "{VERSION}"\n\n'
+        f"{dependency_table}\n"
+        'paimon-mosaic-core = { path = "../core", version = "0.2.0" }\n',
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ffi/Cargo.toml.*paimon-mosaic-core path dependency version "
+            "is '0.2.0', expected '0.3.0'"
+        ),
+    ):
+        verifier.verify_release_versions(root, TAG)
+
+
+def test_checks_path_dependencies_from_non_release_workspace_members(
+    tmp_path: Path,
+) -> None:
+    root = initialize_versions(tmp_path)
+    write(
+        root / "helper/Cargo.toml",
+        '[package]\nname = "fixture-helper"\nversion = "9.9.9"\n\n'
+        "[build-dependencies]\n"
+        'core-under-test = { package = "paimon-mosaic-core", '
+        'path = "../core", version = "0.2.0" }\n',
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "helper/Cargo.toml.*core-under-test path dependency version "
+            "is '0.2.0', expected '0.3.0'"
+        ),
+    ):
+        verifier.verify_release_versions(root, TAG)
+
+
+def test_checks_automatically_included_path_workspace_members(
+    tmp_path: Path,
+) -> None:
+    root = initialize_versions(tmp_path)
+    replace(
+        root / "Cargo.toml",
+        'members = ["core", "ffi", "helper"]',
+        'members = ["ffi", "helper"]',
+    )
+    write(
+        root / "ffi/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-ffi"\nversion = "{VERSION}"\n\n'
+        "[dependencies]\n"
+        'paimon-mosaic-core = { path = "../core", version = "0.2.0" }\n',
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ffi/Cargo.toml.*paimon-mosaic-core path dependency version "
+            "is '0.2.0', expected '0.3.0'"
+        ),
+    ):
+        verifier.verify_release_versions(root, TAG)
+
+
+def test_rejects_noncanonical_path_dependency_requirement(
+    tmp_path: Path,
+) -> None:
+    root = initialize_versions(tmp_path)
+    write(
+        root / "ffi/Cargo.toml",
+        f'[package]\nname = "paimon-mosaic-ffi"\nversion = "{VERSION}"\n\n'
+        "[dependencies]\n"
+        'paimon-mosaic-core = { path = "../core", version = "^0.3.0" }\n',
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "ffi/Cargo.toml.*paimon-mosaic-core path dependency version "
+            r"is '\^0\.3\.0', expected '0\.3\.0'"
+        ),
+    ):
+        verifier.verify_release_versions(root, TAG)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    (
+        "0.3.0",
+        "v0.3",
+        "v0.3.0-RC1",
+        "v0.3.0-rc",
+        "v0.3.0-rc1-extra",
+    ),
+)
+def test_rejects_non_release_tag(tag: str, tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+
+    with pytest.raises(ValueError, match="release tag"):
+        verifier.verify_release_versions(root, tag)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    (
+        "v01.2.3",
+        "v1.02.3",
+        "v1.2.03",
+        "v1.2.3-rc01",
+    ),
+)
+def test_rejects_noncanonical_release_tag_numbers(tag: str) -> None:
+    with pytest.raises(ValueError, match="invalid release tag"):
+        verifier.release_version(tag)
+
+
+def test_cli_is_read_only_and_reports_mismatches(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+    pom = root / "java/pom.xml"
+    replace(pom, "<version>0.3.0</version>", "<version>0.3.1</version>")
+    before = pom.read_bytes()
+
+    result = run_verifier(root)
+
+    assert result.returncode == 1
+    assert "java/pom.xml" in result.stderr
+    assert pom.read_bytes() == before
+
+
+def test_workspace_package_can_inherit_workspace_version(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+    replace(
+        root / "Cargo.toml",
+        '[workspace]\nmembers = ["core", "ffi", "helper"]\n',
+        '[workspace]\nmembers = ["core", "ffi", "helper"]\n'
+        f'[workspace.package]\nversion = "{VERSION}"\n',
+    )
+    replace(
+        root / "core/Cargo.toml",
+        f'version = "{VERSION}"',
+        "version.workspace = true",
+    )
+
+    assert verifier.verify_release_versions(root, TAG) == VERSION
+
+
+def test_workspace_exclude_is_not_a_workspace_package(tmp_path: Path) -> None:
+    root = initialize_versions(tmp_path)
+    replace(
+        root / "Cargo.toml",
+        'members = ["core", "ffi", "helper"]',
+        'members = ["core", "ffi", "helper", "excluded"]\n'
+        'exclude = ["excluded"]',
+    )
+    write(
+        root / "excluded/Cargo.toml",
+        '[package]\nname = "paimon-mosaic-excluded"\nversion = "9.9.9"\n',
+    )
+
+    assert verifier.verify_release_versions(root, TAG) == VERSION

--- a/tools/tests/test_verify_source_archive.py
+++ b/tools/tests/test_verify_source_archive.py
@@ -1,0 +1,404 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import copy
+import gzip
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+
+TOOLS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS))
+
+import verify_source_archive as verifier  # noqa: E402
+
+
+PREFIX = "paimon-mosaic-0.3.0/"
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def commit(repo: Path, message: str) -> str:
+    run(["git", "add", "."], cwd=repo)
+    run(["git", "commit", "-q", "-m", message], cwd=repo)
+    return run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.decode().strip()
+
+
+def initialize_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    write(repo / "README.md", "source contents\n")
+    write(repo / "bin/tool.sh", "#!/usr/bin/env bash\n")
+    (repo / "bin/tool.sh").chmod(0o755)
+    write(repo / ".gitignore", "ignored\n")
+    write(repo / ".github/workflows/ci.yml", "name: ignored\n")
+    write(repo / ".idea/workspace.xml", "ignored\n")
+    write(repo / "target/generated.txt", "ignored\n")
+    write(repo / "nested/project.iml", "ignored\n")
+    write(repo / "nested/.DS_Store", "ignored\n")
+    write(repo / "deploysettings.xml", "ignored\n")
+    os.symlink("../README.md", repo / "bin/README-link")
+
+    run(["git", "init", "-q"], cwd=repo)
+    run(["git", "config", "user.name", "Archive Test"], cwd=repo)
+    run(
+        ["git", "config", "user.email", "archive-test@example.invalid"],
+        cwd=repo,
+    )
+    return repo, commit(repo, "fixture")
+
+
+def read_members(path: Path) -> list[tuple[tarfile.TarInfo, bytes | None]]:
+    members = []
+    with tarfile.open(path, mode="r:gz") as archive:
+        for member in archive:
+            content = archive.extractfile(member).read() if member.isfile() else None
+            members.append((copy.copy(member), content))
+    return members
+
+
+def write_tgz(
+    path: Path,
+    members: list[tuple[tarfile.TarInfo, bytes | None]],
+    *,
+    pax_headers: dict[str, str] | None = None,
+) -> None:
+    raw = io.BytesIO()
+    with tarfile.open(
+        fileobj=raw,
+        mode="w",
+        format=tarfile.PAX_FORMAT,
+        pax_headers=pax_headers,
+    ) as archive:
+        for member, content in members:
+            archive.addfile(
+                member,
+                io.BytesIO(content) if content is not None else None,
+            )
+    with path.open("wb") as output:
+        with gzip.GzipFile(
+            filename="",
+            mode="wb",
+            fileobj=output,
+            mtime=0,
+        ) as compressed:
+            compressed.write(raw.getvalue())
+
+
+def archive_pax_headers(path: Path) -> dict[str, str]:
+    with tarfile.open(path, mode="r:gz") as archive:
+        return dict(archive.pax_headers)
+
+
+def test_create_and_verify_uses_one_git_archive_and_raw_git_objects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, git_commit = initialize_repo(tmp_path)
+    archive = tmp_path / "source.tgz"
+    git_archive_calls = 0
+    real_run = verifier.subprocess.run
+
+    def recording_run(command, *args, **kwargs):
+        nonlocal git_archive_calls
+        if "archive" in command:
+            git_archive_calls += 1
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(verifier.subprocess, "run", recording_run)
+
+    assert (
+        verifier.create_archive(archive, repo, git_commit, PREFIX) == git_commit
+    )
+    assert verifier.verify_archive(archive, repo, git_commit, PREFIX) == git_commit
+    assert git_archive_calls == 1
+
+    with tarfile.open(archive, mode="r:gz") as source:
+        names = {member.name for member in source}
+        assert source.getmember(f"{PREFIX}README.md").mode == 0o664
+        assert source.getmember(f"{PREFIX}bin/tool.sh").mode == 0o775
+        assert source.getmember(f"{PREFIX}bin/README-link").linkname == "../README.md"
+    assert f"{PREFIX}README.md" in names
+    assert f"{PREFIX}.gitignore" not in names
+    assert not any(name.startswith(f"{PREFIX}.github") for name in names)
+    assert not any(name.startswith(f"{PREFIX}.idea") for name in names)
+    assert not any(name.startswith(f"{PREFIX}target") for name in names)
+    assert f"{PREFIX}nested/project.iml" not in names
+    assert f"{PREFIX}nested/.DS_Store" not in names
+    assert f"{PREFIX}deploysettings.xml" not in names
+
+
+def test_repository_argument_overrides_foreign_git_environment(
+    tmp_path: Path,
+) -> None:
+    intended_root = tmp_path / "intended"
+    intended_root.mkdir()
+    intended_repo, intended_commit = initialize_repo(intended_root)
+    foreign_root = tmp_path / "foreign"
+    foreign_root.mkdir()
+    foreign_repo, _ = initialize_repo(foreign_root)
+    write(intended_repo / "README.md", "intended repository contents\n")
+    intended_commit = commit(intended_repo, "distinguish intended repository")
+    archive = tmp_path / "source.tgz"
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_DIR": str(foreign_repo / ".git"),
+            "GIT_WORK_TREE": str(foreign_repo),
+        }
+    )
+    command = [
+        sys.executable,
+        str(TOOLS / "verify_source_archive.py"),
+        "create",
+        "--repository",
+        str(intended_repo),
+        "--commit",
+        intended_commit,
+        "--prefix",
+        PREFIX,
+        "--output",
+        str(archive),
+    ]
+
+    run(command, cwd=tmp_path, env=env)
+    command[2] = "verify"
+    command[-2:] = ["--archive", str(archive)]
+    run(command, cwd=tmp_path, env=env)
+
+
+def test_committed_export_ignore_is_reported_as_missing(tmp_path: Path) -> None:
+    repo, _ = initialize_repo(tmp_path)
+    write(repo / "protected.txt", "must be present\n")
+    write(repo / ".gitattributes", "protected.txt export-ignore\n")
+    git_commit = commit(repo, "export-ignore")
+
+    with pytest.raises(ValueError, match="missing entries.*protected.txt"):
+        verifier.create_archive(
+            tmp_path / "source.tgz",
+            repo,
+            git_commit,
+            PREFIX,
+        )
+
+
+def test_committed_export_subst_is_reported_as_byte_mismatch(tmp_path: Path) -> None:
+    repo, _ = initialize_repo(tmp_path)
+    write(repo / "revision.txt", "$Format:%H$\n")
+    write(repo / ".gitattributes", "revision.txt export-subst\n")
+    git_commit = commit(repo, "export-subst")
+
+    with pytest.raises(ValueError, match="content differs.*revision.txt"):
+        verifier.create_archive(
+            tmp_path / "source.tgz",
+            repo,
+            git_commit,
+            PREFIX,
+        )
+
+
+def test_same_tree_from_wrong_commit_is_rejected(tmp_path: Path) -> None:
+    repo, first_commit = initialize_repo(tmp_path)
+    archive = tmp_path / "source.tgz"
+    verifier.create_archive(archive, repo, first_commit, PREFIX)
+    run(["git", "commit", "-q", "--allow-empty", "-m", "second"], cwd=repo)
+    second_commit = run(["git", "rev-parse", "HEAD"], cwd=repo).stdout.decode().strip()
+
+    with pytest.raises(ValueError, match="embedded Git commit"):
+        verifier.verify_archive(archive, repo, second_commit, PREFIX)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected"),
+    (
+        ("missing", "missing entries"),
+        ("unexpected", "unexpected entries"),
+        ("mode", "mode differs"),
+        ("content", "content differs"),
+        ("symlink", "symbolic-link target differs"),
+    ),
+)
+def test_tree_identity_mutations_are_rejected(
+    tmp_path: Path,
+    mutation: str,
+    expected: str,
+) -> None:
+    repo, git_commit = initialize_repo(tmp_path)
+    archive = tmp_path / "source.tgz"
+    verifier.create_archive(archive, repo, git_commit, PREFIX)
+    headers = archive_pax_headers(archive)
+    members = read_members(archive)
+
+    if mutation == "missing":
+        members = [item for item in members if item[0].name != f"{PREFIX}README.md"]
+    elif mutation == "unexpected":
+        info = tarfile.TarInfo(f"{PREFIX}UNEXPECTED")
+        info.mode = 0o664
+        info.size = 1
+        members.append((info, b"x"))
+    elif mutation == "mode":
+        for info, _ in members:
+            if info.name == f"{PREFIX}README.md":
+                info.mode = 0o777
+    elif mutation == "content":
+        members = [
+            (info, b"different\n" if info.name == f"{PREFIX}README.md" else content)
+            for info, content in members
+        ]
+        for info, content in members:
+            if info.name == f"{PREFIX}README.md":
+                assert content is not None
+                info.size = len(content)
+    elif mutation == "symlink":
+        for info, _ in members:
+            if info.name == f"{PREFIX}bin/README-link":
+                info.linkname = "tool.sh"
+    else:
+        raise AssertionError(f"unknown mutation: {mutation}")
+
+    write_tgz(archive, members, pax_headers=headers)
+
+    with pytest.raises(ValueError, match=expected):
+        verifier.verify_archive(archive, repo, git_commit, PREFIX)
+
+
+def test_rejects_unsafe_and_duplicate_paths(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.tgz"
+    first = tarfile.TarInfo("../escape")
+    first.mode = 0o664
+    first.size = 1
+    write_tgz(archive, [(first, b"x")])
+    with pytest.raises(ValueError, match="unsafe archive entry path"):
+        verifier.read_source_archive(archive, PREFIX)
+
+    duplicate = tarfile.TarInfo(f"{PREFIX}README.md")
+    duplicate.mode = 0o664
+    duplicate.size = 1
+    write_tgz(archive, [(copy.copy(duplicate), b"x"), (duplicate, b"y")])
+    with pytest.raises(ValueError, match="duplicate archive entry"):
+        verifier.read_source_archive(archive, PREFIX)
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    (
+        ("../outside", "escapes the archive root"),
+        ("C:../outside", "unsafe symbolic-link target"),
+        ("..\\outside", "unsafe symbolic-link target"),
+    ),
+)
+def test_rejects_unsafe_symlink_targets(
+    tmp_path: Path,
+    target: str,
+    expected: str,
+) -> None:
+    archive = tmp_path / "symlink.tgz"
+    root = tarfile.TarInfo(PREFIX.rstrip("/"))
+    root.type = tarfile.DIRTYPE
+    root.mode = 0o775
+    link = tarfile.TarInfo(f"{PREFIX}link")
+    link.type = tarfile.SYMTYPE
+    link.mode = 0o777
+    link.linkname = target
+    write_tgz(archive, [(root, None), (link, None)])
+
+    with pytest.raises(ValueError, match=expected):
+        verifier.read_source_archive(archive, PREFIX)
+
+
+def test_rejects_trailing_gzip_and_tar_data(tmp_path: Path) -> None:
+    repo, git_commit = initialize_repo(tmp_path)
+    archive = tmp_path / "source.tgz"
+    verifier.create_archive(archive, repo, git_commit, PREFIX)
+
+    archive.write_bytes(archive.read_bytes() + b"trailing")
+    with pytest.raises(ValueError, match="trailing gzip data"):
+        verifier.read_source_archive(archive, PREFIX)
+
+    archive.unlink()
+    verifier.create_archive(archive, repo, git_commit, PREFIX)
+    raw = gzip.decompress(archive.read_bytes())
+    extra = io.BytesIO()
+    with tarfile.open(fileobj=extra, mode="w") as trailing:
+        info = tarfile.TarInfo(f"{PREFIX}UNVERIFIED")
+        info.size = 1
+        trailing.addfile(info, io.BytesIO(b"x"))
+    archive.write_bytes(gzip.compress(raw + extra.getvalue(), mtime=0))
+    with pytest.raises(ValueError, match="trailing tar data"):
+        verifier.read_source_archive(archive, PREFIX)
+
+
+def test_rejects_gzip_stream_with_truncated_final_trailer(tmp_path: Path) -> None:
+    repo, git_commit = initialize_repo(tmp_path)
+    archive = tmp_path / "source.tgz"
+    verifier.create_archive(archive, repo, git_commit, PREFIX)
+    complete = archive.read_bytes()
+    assert len(complete) > 8
+    archive.write_bytes(complete[:-8])
+
+    with pytest.raises(ValueError, match="ended before its trailer"):
+        verifier.read_source_archive(archive, PREFIX)
+
+
+def test_rejects_unreasonably_large_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = tmp_path / "large.tgz"
+    archive.write_bytes(gzip.compress(b"x" * 2048, mtime=0))
+    monkeypatch.setattr(verifier, "MAX_ARCHIVE_BYTES", 1024)
+
+    with pytest.raises(ValueError, match="size limit"):
+        verifier.read_source_archive(archive, PREFIX)
+
+
+def test_rejects_unreasonably_large_git_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo, git_commit = initialize_repo(tmp_path)
+    monkeypatch.setattr(verifier, "MAX_ARCHIVE_BYTES", 8)
+
+    with pytest.raises(ValueError, match="Git source tree exceeds the size limit"):
+        verifier.expected_entries(repo, git_commit, PREFIX)

--- a/tools/update_branch_version.sh
+++ b/tools/update_branch_version.sh
@@ -60,11 +60,23 @@ NEW_VERSION_CLEAN=$(echo "$NEW_VERSION" | sed 's/-SNAPSHOT//')
 #change version in all pom files (match both exact and -SNAPSHOT suffix)
 find . -name 'pom.xml' -type f -exec perl -pi -e 's#<version>'$OLD_VERSION'(-SNAPSHOT)?</version>#<version>'$NEW_VERSION'</version>#' {} \;
 
-#change version in Cargo.toml files
-find . -name 'Cargo.toml' -not -path '*/target/*' -type f -exec perl -pi -e 's#^version = "'$OLD_VERSION_CLEAN'"#version = "'$NEW_VERSION_CLEAN'"#' {} \;
+#change package versions and versioned path dependencies in Cargo.toml files
+OLD_VERSION_CLEAN="${OLD_VERSION_CLEAN}" \
+NEW_VERSION_CLEAN="${NEW_VERSION_CLEAN}" \
+find . -name 'Cargo.toml' -not -path '*/target/*' -type f \
+  -exec perl -pi -e '
+    s/^version = "\Q$ENV{OLD_VERSION_CLEAN}\E"/version = "$ENV{NEW_VERSION_CLEAN}"/;
+    if (/path\s*=/) {
+      s/(\bversion\s*=\s*")\Q$ENV{OLD_VERSION_CLEAN}\E(")/$1$ENV{NEW_VERSION_CLEAN}$2/g;
+    }
+  ' {} \;
 
 #change version in pyproject.toml
 perl -pi -e 's#^version = "'$OLD_VERSION_CLEAN'"#version = "'$NEW_VERSION_CLEAN'"#' python/pyproject.toml
+
+#refresh and validate workspace package versions in Cargo.lock
+cargo update --workspace
+cargo metadata --locked --format-version 1 --no-deps >/dev/null
 
 git commit -am "Update version to $NEW_VERSION"
 

--- a/tools/verify_release_versions.py
+++ b/tools/verify_release_versions.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Verify that every published component matches a release tag."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import tomllib
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CANONICAL_NUMBER = r"(?:0|[1-9][0-9]*)"
+RELEASE_TAG = re.compile(
+    rf"^v(?P<version>{CANONICAL_NUMBER}\.{CANONICAL_NUMBER}\."
+    rf"{CANONICAL_NUMBER})(?:-rc{CANONICAL_NUMBER})?$"
+)
+REQUIRED_RELEASE_VERSION_FILES = {
+    "Cargo.toml",
+    "Cargo.lock",
+    "java/pom.xml",
+    "python/pyproject.toml",
+}
+GIT_ENVIRONMENT = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_WORK_TREE",
+)
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as source:
+        return tomllib.load(source)
+
+
+def release_version(tag: str) -> str:
+    match = RELEASE_TAG.fullmatch(tag)
+    if match is None:
+        raise ValueError(
+            f"invalid release tag {tag!r}; expected vX.Y.Z or vX.Y.Z-rcN"
+        )
+    return match.group("version")
+
+
+def git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in list(environment):
+        if (
+            variable in GIT_ENVIRONMENT
+            or variable.startswith("GIT_CONFIG_KEY_")
+            or variable.startswith("GIT_CONFIG_VALUE_")
+        ):
+            environment.pop(variable)
+    environment["GIT_ATTR_NOSYSTEM"] = "1"
+    environment["GIT_CONFIG_GLOBAL"] = os.devnull
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return environment
+
+
+def run_git(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        check=False,
+        env=git_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ValueError(detail or f"git {' '.join(arguments)} failed")
+    return result.stdout.strip()
+
+
+def run_git_bytes(root: Path, *arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        check=False,
+        env=git_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        if not detail:
+            detail = result.stdout.decode(errors="replace").strip()
+        raise ValueError(detail or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def verify_release_tag(root: Path, tag: str) -> str:
+    root = root.resolve()
+    release_version(tag)
+    if run_git(root, "cat-file", "-t", tag) != "tag":
+        raise ValueError(f"{tag} is not an annotated release tag")
+
+    tag_object = run_git(root, "rev-parse", "--verify", f"{tag}^{{tag}}")
+    tag_headers = run_git(root, "cat-file", "tag", tag_object).partition("\n\n")[0]
+    embedded_names = [
+        line.removeprefix("tag ")
+        for line in tag_headers.splitlines()
+        if line.startswith("tag ")
+    ]
+    if embedded_names != [tag]:
+        found = ", ".join(embedded_names) if embedded_names else "<missing>"
+        raise ValueError(f"signed tag object names {found}, not {tag}")
+
+    head_commit = run_git(root, "rev-parse", "--verify", "HEAD^{commit}")
+    tag_commit = run_git(
+        root,
+        "rev-parse",
+        "--verify",
+        f"{tag_object}^{{commit}}",
+    )
+    if tag_commit != head_commit:
+        raise ValueError(
+            f"{tag} resolves to {tag_commit}, not current HEAD {head_commit}"
+        )
+
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "-c",
+            "gpg.program=gpg",
+            "verify-tag",
+            tag_object,
+        ],
+        check=False,
+        env=git_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        suffix = f": {detail}" if detail else ""
+        raise ValueError(f"{tag} is not a verifiable signed tag{suffix}")
+    return tag_commit
+
+
+def is_release_version_file(path: str) -> bool:
+    return path in REQUIRED_RELEASE_VERSION_FILES or path.endswith("/Cargo.toml")
+
+
+def materialize_release_version_files(
+    repository: Path,
+    commit: str,
+    destination: Path,
+) -> None:
+    records = run_git_bytes(
+        repository,
+        "ls-tree",
+        "-r",
+        "-z",
+        "--full-tree",
+        commit,
+    )
+    materialized = set()
+    for raw_record in records.split(b"\0"):
+        if not raw_record:
+            continue
+        metadata, raw_path = raw_record.split(b"\t", 1)
+        path = os.fsdecode(raw_path)
+        if not is_release_version_file(path):
+            continue
+        parts = path.split("/")
+        if (
+            path.startswith("/")
+            or "\\" in path
+            or "" in parts
+            or "." in parts
+            or ".." in parts
+        ):
+            raise ValueError(f"unsafe release version file path: {path!r}")
+        mode, object_type, object_id = metadata.decode("ascii").split()
+        if object_type != "blob" or mode not in {"100644", "100755"}:
+            raise ValueError(f"release version file is not regular: {path}")
+        target = destination.joinpath(*parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(run_git_bytes(repository, "cat-file", "blob", object_id))
+        materialized.add(path)
+
+    missing = sorted(REQUIRED_RELEASE_VERSION_FILES - materialized)
+    if missing:
+        raise ValueError(f"signed commit is missing release version files: {missing}")
+
+
+def verify_signed_release_versions(root: Path, tag: str) -> str:
+    root = root.resolve()
+    commit = verify_release_tag(root, tag)
+    with tempfile.TemporaryDirectory(prefix="release-version-") as directory:
+        signed_root = Path(directory)
+        materialize_release_version_files(root, commit, signed_root)
+        return verify_release_versions(signed_root, tag)
+
+
+def excluded_workspace_manifests(root: Path, workspace: dict) -> set[Path]:
+    excluded = set()
+    for pattern in workspace.get("exclude", []):
+        if not isinstance(pattern, str):
+            continue
+        for match in glob.glob(str(root / pattern)):
+            path = Path(match)
+            manifest = path if path.name == "Cargo.toml" else path / "Cargo.toml"
+            excluded.add(manifest.resolve())
+    return excluded
+
+
+def workspace_manifests(root: Path, workspace: dict) -> list[Path]:
+    members = workspace.get("members")
+    if not isinstance(members, list) or not all(
+        isinstance(member, str) for member in members
+    ):
+        raise ValueError("Cargo.toml [workspace].members must be a string list")
+
+    excluded = excluded_workspace_manifests(root, workspace)
+    manifests = []
+    for pattern in members:
+        matches = [Path(path) for path in glob.glob(str(root / pattern))]
+        if not matches:
+            raise ValueError(f"Cargo workspace member does not exist: {pattern}")
+        for match in matches:
+            manifest = match if match.name == "Cargo.toml" else match / "Cargo.toml"
+            if manifest.resolve() in excluded:
+                continue
+            if not manifest.is_file():
+                raise ValueError(
+                    f"Cargo workspace member has no Cargo.toml: "
+                    f"{manifest.relative_to(root)}"
+                )
+            manifests.append(manifest)
+    return sorted(set(manifests))
+
+
+def package_version(package: dict, workspace_version: object) -> str:
+    version = package.get("version")
+    if isinstance(version, str):
+        return version
+    if (
+        isinstance(version, dict)
+        and version.get("workspace") is True
+        and isinstance(workspace_version, str)
+    ):
+        return workspace_version
+    raise ValueError("Cargo package has no explicit or inherited string version")
+
+
+def rust_workspace_packages(root: Path) -> dict[str, tuple[str, Path]]:
+    root_manifest = load_toml(root / "Cargo.toml")
+    workspace = root_manifest.get("workspace")
+    if not isinstance(workspace, dict):
+        raise ValueError("Cargo.toml has no [workspace] table")
+    workspace_package = workspace.get("package", {})
+    workspace_version = (
+        workspace_package.get("version")
+        if isinstance(workspace_package, dict)
+        else None
+    )
+
+    manifests = discovered_workspace_manifests(root, workspace)
+    if isinstance(root_manifest.get("package"), dict):
+        manifests.append(root / "Cargo.toml")
+
+    packages = {}
+    for manifest in sorted(set(manifests)):
+        package = load_toml(manifest).get("package")
+        if not isinstance(package, dict):
+            raise ValueError(
+                f"{manifest.relative_to(root)} has no [package] table"
+            )
+        name = package.get("name")
+        if not isinstance(name, str):
+            raise ValueError(
+                f"{manifest.relative_to(root)} has no package name"
+            )
+        if not name.startswith("paimon-mosaic"):
+            continue
+        if name in packages:
+            raise ValueError(f"duplicate Cargo workspace package name: {name}")
+        packages[name] = (
+            package_version(package, workspace_version),
+            manifest.relative_to(root),
+        )
+
+    if not packages:
+        raise ValueError("Cargo workspace has no paimon-mosaic packages")
+    return packages
+
+
+def dependency_tables(manifest: dict) -> list[dict]:
+    tables = []
+    for name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        table = manifest.get(name)
+        if isinstance(table, dict):
+            tables.append(table)
+
+    targets = manifest.get("target")
+    if isinstance(targets, dict):
+        for target in targets.values():
+            if not isinstance(target, dict):
+                continue
+            for name in ("dependencies", "dev-dependencies", "build-dependencies"):
+                table = target.get(name)
+                if isinstance(table, dict):
+                    tables.append(table)
+
+    workspace = manifest.get("workspace")
+    if isinstance(workspace, dict):
+        table = workspace.get("dependencies")
+        if isinstance(table, dict):
+            tables.append(table)
+    return tables
+
+
+def discovered_workspace_manifests(root: Path, workspace: dict) -> list[Path]:
+    root = root.resolve()
+    excluded = excluded_workspace_manifests(root, workspace)
+    manifests = {manifest.resolve() for manifest in workspace_manifests(root, workspace)}
+    pending = [root / "Cargo.toml", *sorted(manifests)]
+    scanned = set()
+    while pending:
+        manifest = pending.pop()
+        if manifest in scanned:
+            continue
+        scanned.add(manifest)
+        for table in dependency_tables(load_toml(manifest)):
+            for dependency in table.values():
+                if not isinstance(dependency, dict):
+                    continue
+                path = dependency.get("path")
+                if not isinstance(path, str):
+                    continue
+                dependency_manifest = (manifest.parent / path).resolve()
+                if dependency_manifest.name != "Cargo.toml":
+                    dependency_manifest /= "Cargo.toml"
+                try:
+                    dependency_manifest.relative_to(root)
+                except ValueError:
+                    continue
+                if (
+                    dependency_manifest in excluded
+                    or not dependency_manifest.is_file()
+                    or dependency_manifest in manifests
+                ):
+                    continue
+                manifests.add(dependency_manifest)
+                pending.append(dependency_manifest)
+    return sorted(manifests)
+
+
+def workspace_path_dependency_failures(
+    root: Path,
+    packages: dict[str, tuple[str, Path]],
+) -> list[str]:
+    packages_by_manifest = {
+        (root / manifest).resolve(): (name, version)
+        for name, (version, manifest) in packages.items()
+    }
+    root_manifest = load_toml(root / "Cargo.toml")
+    workspace = root_manifest.get("workspace")
+    if not isinstance(workspace, dict):
+        raise ValueError("Cargo.toml has no [workspace] table")
+    manifests = {root / "Cargo.toml"}
+    manifests.update(discovered_workspace_manifests(root, workspace))
+
+    failures = []
+    for manifest in sorted(manifests):
+        source = load_toml(manifest)
+        for table in dependency_tables(source):
+            for dependency_name, dependency in table.items():
+                if not isinstance(dependency, dict):
+                    continue
+                path = dependency.get("path")
+                declared_version = dependency.get("version")
+                if not isinstance(path, str) or not isinstance(
+                    declared_version, str
+                ):
+                    continue
+                dependency_manifest = (manifest.parent / path).resolve()
+                if dependency_manifest.name != "Cargo.toml":
+                    dependency_manifest /= "Cargo.toml"
+                target = packages_by_manifest.get(dependency_manifest)
+                if target is None:
+                    continue
+                target_name, target_version = target
+                # The release updater rewrites only the canonical plain
+                # version form, not alternative semver requirement syntax.
+                if declared_version != target_version:
+                    failures.append(
+                        f"{manifest.relative_to(root)}: {dependency_name} "
+                        f"path dependency version is {declared_version!r}, "
+                        f"expected {target_version!r} for {target_name}"
+                    )
+    return failures
+
+
+def direct_java_version(root: Path) -> str:
+    project = ET.parse(root / "java/pom.xml").getroot()
+    namespace = ""
+    if project.tag.startswith("{"):
+        namespace = project.tag.partition("}")[0] + "}"
+    version = project.find(f"{namespace}version")
+    if version is None or not version.text:
+        raise ValueError("java/pom.xml has no direct project version")
+    return version.text.strip()
+
+
+def verify_release_versions(root: Path, tag: str) -> str:
+    root = root.resolve()
+    expected = release_version(tag)
+    failures = []
+
+    rust_packages = rust_workspace_packages(root)
+    for name, (version, manifest) in sorted(rust_packages.items()):
+        if version != expected:
+            failures.append(
+                f"{manifest}: {name} version is {version!r}, expected {expected!r}"
+            )
+    failures.extend(workspace_path_dependency_failures(root, rust_packages))
+
+    lock = load_toml(root / "Cargo.lock")
+    locked_packages = lock.get("package")
+    if not isinstance(locked_packages, list):
+        raise ValueError("Cargo.lock has no [[package]] entries")
+    for name in sorted(rust_packages):
+        versions = {
+            package.get("version")
+            for package in locked_packages
+            if isinstance(package, dict) and package.get("name") == name
+        }
+        if not versions:
+            failures.append(f"Cargo.lock has no package entry for {name}")
+        elif versions != {expected}:
+            failures.append(
+                f"Cargo.lock versions for {name} are "
+                f"{sorted(str(version) for version in versions)!r}, "
+                f"expected only {expected!r}"
+            )
+
+    java = direct_java_version(root)
+    if java != expected:
+        failures.append(
+            f"java/pom.xml project version is {java!r}, expected {expected!r}"
+        )
+
+    python = load_toml(root / "python/pyproject.toml").get("project", {}).get(
+        "version"
+    )
+    if python != expected:
+        failures.append(
+            f"python/pyproject.toml project version is {python!r}, "
+            f"expected {expected!r}"
+        )
+
+    if failures:
+        raise ValueError("release version verification failed:\n- " + "\n- ".join(failures))
+    return expected
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="release tag: vX.Y.Z or vX.Y.Z-rcN")
+    parser.add_argument("--root", type=Path, default=ROOT)
+    parser.add_argument(
+        "--verify-signature",
+        action="store_true",
+        help="require an annotated signed tag bound to the current HEAD",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.verify_signature:
+            version = verify_signed_release_versions(args.root, args.tag)
+        else:
+            version = verify_release_versions(args.root, args.tag)
+    except (OSError, ET.ParseError, tomllib.TOMLDecodeError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    print(f"verified release tag {args.tag}: all component versions are {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_source_archive.py
+++ b/tools/verify_source_archive.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Create or verify an exact source archive for one Git commit."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import gzip
+import io
+import os
+from pathlib import Path
+import posixpath
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zlib
+
+
+EXCLUDED_ROOT_FILES = {
+    ".asf.yaml",
+    ".gitattributes",
+    ".gitignore",
+    "deploysettings.xml",
+}
+EXCLUDED_ROOT_DIRECTORIES = {".github", ".idea", "target"}
+EXCLUDED_BASENAMES = {".DS_Store"}
+MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 65536
+WINDOWS_DRIVE = re.compile(r"^[A-Za-z]:")
+GIT_ENVIRONMENT = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_WORK_TREE",
+)
+
+
+@dataclass(frozen=True)
+class ArchiveEntry:
+    kind: str
+    mode: int
+    content: bytes | None = None
+    link_target: str | None = None
+
+
+def git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in GIT_ENVIRONMENT:
+        environment.pop(variable, None)
+    environment["GIT_ATTR_NOSYSTEM"] = "1"
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    return environment
+
+
+def run_git(
+    repository: Path,
+    arguments: list[str],
+    **kwargs,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        env=git_environment(),
+        stderr=subprocess.PIPE,
+        **kwargs,
+    )
+
+
+def resolve_commit(repository: Path, commit: str) -> str:
+    result = run_git(
+        repository,
+        ["rev-parse", "--verify", f"{commit}^{{commit}}"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def validate_prefix(prefix: str) -> str:
+    if (
+        not prefix.endswith("/")
+        or prefix.startswith("/")
+        or "\\" in prefix
+        or "\x00" in prefix
+        or WINDOWS_DRIVE.match(prefix)
+    ):
+        raise ValueError(f"invalid archive prefix: {prefix!r}")
+    root = prefix[:-1]
+    if not root or "/" in root or root in {".", ".."}:
+        raise ValueError(f"invalid archive prefix: {prefix!r}")
+    return root
+
+
+def is_excluded(path: str) -> bool:
+    parts = path.split("/")
+    return (
+        path in EXCLUDED_ROOT_FILES
+        or parts[0] in EXCLUDED_ROOT_DIRECTORIES
+        or parts[-1] in EXCLUDED_BASENAMES
+        or parts[-1].endswith(".iml")
+    )
+
+
+def read_blobs(repository: Path, object_ids: set[str]) -> dict[str, bytes]:
+    if not object_ids:
+        return {}
+    ordered_ids = sorted(object_ids)
+    process = subprocess.Popen(
+        ["git", "-C", str(repository), "cat-file", "--batch"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=git_environment(),
+    )
+    request = b"".join(f"{object_id}\n".encode("ascii") for object_id in ordered_ids)
+    stdout, stderr = process.communicate(request)
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(
+            process.returncode,
+            process.args,
+            output=stdout,
+            stderr=stderr,
+        )
+
+    blobs = {}
+    offset = 0
+    for requested in ordered_ids:
+        line_end = stdout.find(b"\n", offset)
+        if line_end < 0:
+            raise ValueError("git cat-file returned a truncated header")
+        header = stdout[offset:line_end].decode("ascii").split()
+        if len(header) != 3 or header[0] != requested or header[1] != "blob":
+            raise ValueError(
+                f"git cat-file returned an unexpected header for {requested}: "
+                f"{' '.join(header)!r}"
+            )
+        size = int(header[2])
+        start = line_end + 1
+        end = start + size
+        if end >= len(stdout) or stdout[end : end + 1] != b"\n":
+            raise ValueError(f"git cat-file returned a truncated blob for {requested}")
+        blobs[requested] = stdout[start:end]
+        offset = end + 1
+    if offset != len(stdout):
+        raise ValueError("git cat-file returned unexpected trailing output")
+    return blobs
+
+
+def expected_entries(
+    repository: Path,
+    commit: str,
+    prefix: str,
+) -> dict[str, ArchiveEntry]:
+    root = validate_prefix(prefix)
+    result = run_git(
+        repository,
+        ["ls-tree", "-r", "-l", "-z", "--full-tree", commit],
+        stdout=subprocess.PIPE,
+    )
+    records = []
+    object_ids = set()
+    total_blob_bytes = 0
+    for raw_record in result.stdout.split(b"\0"):
+        if not raw_record:
+            continue
+        metadata, raw_path = raw_record.split(b"\t", 1)
+        mode, object_type, object_id, size_text = metadata.decode("ascii").split()
+        path = os.fsdecode(raw_path)
+        if is_excluded(path):
+            continue
+        if object_type != "blob" or mode not in {"100644", "100755", "120000"}:
+            raise ValueError(
+                f"unsupported Git tree entry {path!r}: mode={mode}, type={object_type}"
+            )
+        total_blob_bytes += int(size_text)
+        if total_blob_bytes > MAX_ARCHIVE_BYTES:
+            raise ValueError("Git source tree exceeds the size limit")
+        records.append((mode, object_id, path))
+        if len(records) > MAX_ARCHIVE_ENTRIES:
+            raise ValueError(
+                f"Git source tree exceeds the {MAX_ARCHIVE_ENTRIES} entry limit"
+            )
+        object_ids.add(object_id)
+
+    blobs = read_blobs(repository, object_ids)
+    entries = {root: ArchiveEntry("directory", 0o775)}
+    directories = set()
+    for mode, object_id, path in records:
+        parent = posixpath.dirname(path)
+        while parent:
+            directories.add(parent)
+            parent = posixpath.dirname(parent)
+        archive_path = prefix + path
+        blob = blobs[object_id]
+        if mode == "120000":
+            target = blob.decode("utf-8", errors="surrogateescape")
+            entries[archive_path] = ArchiveEntry(
+                "symlink",
+                0o777,
+                link_target=target,
+            )
+        else:
+            entries[archive_path] = ArchiveEntry(
+                "file",
+                0o775 if mode == "100755" else 0o664,
+                content=blob,
+            )
+    for directory in directories:
+        entries[prefix + directory] = ArchiveEntry("directory", 0o775)
+    return entries
+
+
+def validate_member_path(name: str, root: str, kind: str) -> str:
+    if (
+        not name
+        or name.startswith("/")
+        or "\\" in name
+        or "\x00" in name
+        or WINDOWS_DRIVE.match(name)
+    ):
+        raise ValueError(f"unsafe archive entry path: {name!r}")
+    parts = name.split("/")
+    if "" in parts or "." in parts or ".." in parts or posixpath.normpath(name) != name:
+        raise ValueError(f"unsafe archive entry path: {name!r}")
+    if name == root:
+        if kind != "directory":
+            raise ValueError("archive root must be a directory")
+    elif not name.startswith(root + "/"):
+        raise ValueError(f"archive entry is outside the single root directory: {name!r}")
+    return name
+
+
+def validate_link_target(path: str, target: str, root: str) -> str:
+    if (
+        not target
+        or target.startswith("/")
+        or "\\" in target
+        or "\x00" in target
+        or WINDOWS_DRIVE.match(target)
+    ):
+        raise ValueError(f"unsafe symbolic-link target for {path!r}: {target!r}")
+    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(path), target))
+    if resolved != root and not resolved.startswith(root + "/"):
+        raise ValueError(
+            f"symbolic link {path!r} escapes the archive root: {target!r}"
+        )
+    return target
+
+
+def archive_entries(
+    archive: tarfile.TarFile,
+    prefix: str,
+) -> dict[str, ArchiveEntry]:
+    root = validate_prefix(prefix)
+    entries = {}
+    total_file_bytes = 0
+    for count, member in enumerate(archive, 1):
+        if count > MAX_ARCHIVE_ENTRIES:
+            raise ValueError(
+                f"source archive exceeds the {MAX_ARCHIVE_ENTRIES} entry limit"
+            )
+        if member.isfile():
+            kind = "file"
+        elif member.isdir():
+            kind = "directory"
+        elif member.issym():
+            kind = "symlink"
+        else:
+            raise ValueError(
+                f"unsupported archive entry type for {member.name!r}"
+            )
+        path = validate_member_path(member.name, root, kind)
+        if path in entries:
+            raise ValueError(f"duplicate archive entry path: {path!r}")
+
+        content = None
+        target = None
+        if kind == "file":
+            if member.size < 0:
+                raise ValueError(f"negative file size for {path!r}")
+            total_file_bytes += member.size
+            if total_file_bytes > MAX_ARCHIVE_BYTES:
+                raise ValueError("source archive file contents exceed the size limit")
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                raise ValueError(f"cannot read archive file {path!r}")
+            content = extracted.read()
+            if len(content) != member.size:
+                raise ValueError(f"archive file size differs for {path!r}")
+        elif kind == "symlink":
+            target = validate_link_target(path, member.linkname, root)
+
+        entries[path] = ArchiveEntry(
+            kind=kind,
+            mode=member.mode & 0o7777,
+            content=content,
+            link_target=target,
+        )
+    if root not in entries:
+        raise ValueError(f"source archive has no root directory {root!r}")
+    return entries
+
+
+def read_source_archive(
+    path: Path,
+    prefix: str,
+) -> tuple[dict[str, ArchiveEntry], str | None]:
+    if path.stat().st_size > MAX_ARCHIVE_BYTES:
+        raise ValueError("compressed source archive exceeds the size limit")
+    compressed = path.read_bytes()
+    try:
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        raw_tar = decompressor.decompress(compressed, MAX_ARCHIVE_BYTES + 1)
+        if len(raw_tar) > MAX_ARCHIVE_BYTES or decompressor.unconsumed_tail:
+            raise ValueError("uncompressed source archive exceeds the size limit")
+        raw_tar += decompressor.flush()
+        if len(raw_tar) > MAX_ARCHIVE_BYTES:
+            raise ValueError("uncompressed source archive exceeds the size limit")
+        if not decompressor.eof:
+            raise ValueError("gzip source archive ended before its trailer")
+        if decompressor.unused_data or decompressor.unconsumed_tail:
+            raise ValueError("source archive contains trailing gzip data")
+
+        with tarfile.open(fileobj=io.BytesIO(raw_tar), mode="r:") as archive:
+            embedded_commit = archive.pax_headers.get("comment")
+            entries = archive_entries(archive, prefix)
+            trailer = raw_tar[archive.offset :]
+        if len(trailer) < 1024 or len(trailer) % 512 != 0 or any(trailer):
+            raise ValueError("source archive contains trailing tar data")
+        return entries, embedded_commit
+    except (tarfile.TarError, EOFError, zlib.error) as error:
+        raise ValueError(f"cannot read source archive {path}: {error}") from error
+
+
+def compare_entries(
+    actual: dict[str, ArchiveEntry],
+    expected: dict[str, ArchiveEntry],
+) -> None:
+    actual_paths = set(actual)
+    expected_paths = set(expected)
+    missing = sorted(expected_paths - actual_paths)
+    unexpected = sorted(actual_paths - expected_paths)
+    if missing:
+        raise ValueError(f"source archive is missing entries: {missing}")
+    if unexpected:
+        raise ValueError(f"source archive has unexpected entries: {unexpected}")
+    for path in sorted(expected_paths):
+        found = actual[path]
+        wanted = expected[path]
+        if found.kind != wanted.kind:
+            raise ValueError(f"entry type differs for {path!r}")
+        if found.mode != wanted.mode:
+            raise ValueError(f"entry mode differs for {path!r}")
+        if found.link_target != wanted.link_target:
+            raise ValueError(f"symbolic-link target differs for {path!r}")
+        if found.content != wanted.content:
+            raise ValueError(f"file content differs for {path!r}")
+
+
+def verify_archive(
+    archive: Path,
+    repository: Path,
+    commit: str,
+    prefix: str,
+) -> str:
+    repository = repository.resolve()
+    resolved = resolve_commit(repository, commit)
+    actual, embedded_commit = read_source_archive(archive, prefix)
+    if embedded_commit != resolved:
+        raise ValueError(
+            f"embedded Git commit differs: found {embedded_commit!r}, "
+            f"expected {resolved!r}"
+        )
+    compare_entries(actual, expected_entries(repository, resolved, prefix))
+    return resolved
+
+
+def reject_local_archive_attributes(repository: Path) -> None:
+    result = run_git(
+        repository,
+        ["rev-parse", "--git-path", "info/attributes"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    path = Path(result.stdout.strip())
+    if not path.is_absolute():
+        path = repository / path
+    if path.exists() and path.read_bytes().strip():
+        raise ValueError(
+            f"repository-local Git attributes can change source output: {path}"
+        )
+
+
+def create_archive(
+    output: Path,
+    repository: Path,
+    commit: str,
+    prefix: str,
+) -> str:
+    repository = repository.resolve()
+    validate_prefix(prefix)
+    resolved = resolve_commit(repository, commit)
+    reject_local_archive_attributes(repository)
+    if output.exists() or output.is_symlink():
+        raise ValueError(f"output already exists: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    temporary_output = None
+    try:
+        with tempfile.TemporaryDirectory(
+            prefix="source-archive-",
+            dir=output.parent,
+        ) as directory:
+            raw_tar = Path(directory) / "source.tar"
+            with raw_tar.open("wb") as destination:
+                run_git(
+                    repository,
+                    [
+                        "-c",
+                        "tar.umask=0002",
+                        "-c",
+                        "core.attributesFile=/dev/null",
+                        "-c",
+                        "core.autocrlf=false",
+                        "-c",
+                        "core.eol=lf",
+                        "archive",
+                        "--format=tar",
+                        f"--prefix={prefix}",
+                        resolved,
+                        "--",
+                        ".",
+                        ":(exclude).gitignore",
+                        ":(exclude).gitattributes",
+                        ":(exclude).asf.yaml",
+                        ":(exclude).github",
+                        ":(exclude)deploysettings.xml",
+                        ":(exclude)target",
+                        ":(exclude).idea",
+                        ":(exclude,glob)**/*.iml",
+                        ":(exclude,glob)**/.DS_Store",
+                    ],
+                    stdout=destination,
+                )
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                dir=output.parent,
+                prefix=output.name + ".",
+                suffix=".tmp",
+                delete=False,
+            ) as destination:
+                temporary_output = Path(destination.name)
+                with raw_tar.open("rb") as source, gzip.GzipFile(
+                    filename="",
+                    mode="wb",
+                    fileobj=destination,
+                    mtime=0,
+                ) as compressed:
+                    shutil.copyfileobj(source, compressed)
+
+        assert temporary_output is not None
+        verify_archive(temporary_output, repository, resolved, prefix)
+        os.chmod(temporary_output, 0o644)
+        os.replace(temporary_output, output)
+        temporary_output = None
+        return resolved
+    finally:
+        if temporary_output is not None:
+            temporary_output.unlink(missing_ok=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    def common(command: argparse.ArgumentParser) -> None:
+        command.add_argument("--repository", type=Path, default=Path("."))
+        command.add_argument("--commit", required=True)
+        command.add_argument("--prefix", required=True)
+
+    create = commands.add_parser("create")
+    common(create)
+    create.add_argument("--output", required=True, type=Path)
+
+    verify = commands.add_parser("verify")
+    common(verify)
+    verify.add_argument("--archive", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "create":
+            commit = create_archive(
+                args.output,
+                args.repository,
+                args.commit,
+                args.prefix,
+            )
+            print(f"created {args.output} from Git commit {commit}")
+        else:
+            commit = verify_archive(
+                args.archive,
+                args.repository,
+                args.commit,
+                args.prefix,
+            )
+            print(f"verified {args.archive} against Git commit {commit}")
+        return 0
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        detail = error.stderr if isinstance(error, subprocess.CalledProcessError) else None
+        if isinstance(detail, bytes):
+            detail = detail.decode(errors="replace")
+        print(
+            f"source archive verification failed: {detail or error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Gate release publication on a reusable signed-source preflight so release tags, component versions, and source artifacts are validated against the exact commit before credentialed publishing begins.

## Changes

- Add a reusable release preflight that, for tag runs, imports ASF `KEYS`, verifies an annotated signed tag bound to the current commit, and reads component versions from that signed Git tree.
- Create and verify deterministic source archives against raw Git blobs, with explicit size, entry, path, symlink, mode, and embedded-commit checks.
- Require the top-level release workflow and every credentialed Rust, Java, and Python publishing boundary to pass preflight; manual `workflow_dispatch` runs remain verification-only and cannot publish.
- Harden local source release creation with clean-tree and exact-tag checks, Git-environment isolation, GPG/SHA-512 verification, private staging, and no-overwrite behavior.
- Keep Rust package versions, Cargo path dependency constraints, `Cargo.lock`, Java, and Python versions aligned across documented branch transitions.
- Add the Release Vote Gate for `main` and `release-*`, plus adversarial regression tests for signature, source provenance, workflow dependencies, manual-dispatch guards, archive integrity, and version updates.
- Document RC retry behavior so prior local source artifacts are preserved before creating the next candidate.

## Validation

- [x] The branch contains exactly one commit on the current `apache/paimon-mosaic:main`.
- [x] `146 passed` across the focused release tooling test suite.
- [x] `actionlint 1.7.7` passed for all workflows.
- [x] Python compile checks, Bash syntax checks, YAML parsing, and `git diff --check` passed.
- [x] A source archive was created and independently verified against commit `01d8070aa2e5d01cc430043d8d04de837d6d5c7e`.
- [ ] Upstream GitHub Actions checks after PR creation.

## Notes

- This PR does not change the public API, runtime data format, or native read/write behavior.
- ASF vote outcome and final release authorization remain human governance steps; this PR supplies technical release gates only.
- Java JAR and Python wheel content verification remain outside this PR.
- Current review found no P0/P1 blockers. Symlinked Cargo path-dependency materialization and generic concurrent-output atomicity remain non-blocking P2 follow-ups rather than reasons to expand this release-gate PR.
