### PR TITLE
[cli] Split and harden inferred JSON and CSV conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,8 @@ version = "0.3.0"
 dependencies = [
  "arrow",
  "clap",
+ "csv",
+ "libc",
  "paimon-mosaic-core",
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -30,5 +30,7 @@ path = "src/main.rs"
 paimon-mosaic-core = { path = "../core", version = "0.3.0" }
 arrow = { version = "58", features = ["csv", "json"] }
 clap = { version = "4", features = ["derive"] }
+csv = "1.4"
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["raw_value"] }

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,7 @@ mosaic <command> <file>
 
 ## Commands
 
-All inspection and query commands accept `--json`; `convert` writes a file.
+All inspection and query commands accept `--json`; `convert` and `convert-csv` write files.
 
 | Command | Shows | Reads |
 |---------|-------|-------|
@@ -48,7 +48,8 @@ All inspection and query commands accept `--json`; `convert` writes a file.
 | `cat` | rows as a table (all rows by default; `-n` to limit) | column data |
 | `head` | first N rows (default 10) | column data |
 | `count` | total row count | footer + index |
-| `convert` | import CSV or JSON into a new file | writes file |
+| `convert` | import JSON; legacy single-file CSV calls remain compatible | writes file |
+| `convert-csv` | import CSV into a new file | writes file |
 
 ## Inspect
 
@@ -97,12 +98,46 @@ $ mosaic head data.mosaic --json
 
 ## Convert
 
-Import CSV or JSON lines into a new Mosaic file; the schema is inferred.
+Import a JSON data file (`.json`/`.ndjson`/`.jsonl`, one object per line) into
+a new Mosaic file; the schema is inferred from the complete input. A field
+with no non-null value cannot be inferred and is reported as an error.
+Inferred conversion requires a regular file because schema inference and
+conversion read the input separately; FIFOs and devices are rejected.
 An existing output is kept unless `--overwrite` is given.
-`--stats id` builds min/max for those columns, which `cat --where` then uses to
-skip row groups that cannot match.
+Existing `mosaic convert data.csv -o data.mosaic` calls remain supported with
+the default CSV dialect; use `convert-csv` for multiple inputs or CSV options.
+Use `-c`/`--column` to project top-level fields; each occurrence accepts a
+comma-separated list, and unselected fields do not participate in inference.
+`--stats id` builds min/max for those columns, which `cat --where` then uses
+to skip row groups that cannot match.
 
 ```text
-$ mosaic convert data.csv -o data.mosaic --stats id
-wrote data.mosaic (200 rows, 5 columns)
+$ mosaic convert data.json -o data.mosaic
+$ mosaic convert data.json -o data.mosaic -c id,name
+$ mosaic convert data.json -o data.mosaic --stats id
+```
+
+## Convert CSV
+
+Import one or more regular CSV files with an inferred schema. Header fields are
+matched by name across inputs; fields missing from a shard are nullable and
+written as null, and compatible integer/float and timestamp precisions are
+promoted. Lossy bare-integer-to-`Float64` promotion and explicit timezones in
+inferred local timestamps are rejected. Empty files are skipped.
+CSV cannot say what type an all-empty column is, so columns inferred as Arrow
+`Null` fall back to nullable `Utf8`. `--require col` marks an inferred field as
+not null (repeat it for multiple fields). Backslash escaping is disabled by
+default; pass `--escape` only when the CSV dialect uses it.
+`--delimiter`, `--quote`, `--no-header`, `--header`, and `--skip-lines`
+control parsing. Inferred conversion rejects FIFOs, devices, and other
+non-regular paths instead of attempting a multi-pass read. Input files must
+remain unchanged while conversion is running.
+`--stats id` builds min/max for those columns, which `cat --where` then uses
+to skip row groups that cannot match.
+
+```text
+$ mosaic convert-csv data.csv -o data.mosaic
+
+$ mosaic convert-csv data.csv -o data.mosaic --require id --require ts
+$ mosaic convert-csv data.csv -o data.mosaic --stats id
 ```

--- a/cli/src/fmt.rs
+++ b/cli/src/fmt.rs
@@ -75,6 +75,11 @@ pub fn safe(s: &str) -> String {
         .collect()
 }
 
+/// Render a path for terminal output without allowing control-sequence injection.
+pub fn safe_path(path: &std::path::Path) -> String {
+    safe(&path.to_string_lossy())
+}
+
 /// Human-readable encoding name.
 pub fn encoding_name(e: paimon_mosaic_core::reader::Encoding) -> String {
     use paimon_mosaic_core::reader::Encoding::*;
@@ -311,6 +316,12 @@ mod tests {
     fn render_value_strips_control_chars() {
         let s = render_value(&Value::String(b"\x1b[31mred".to_vec()));
         assert!(!s.contains('\x1b'), "ANSI escape must not survive: {s:?}");
+    }
+
+    #[test]
+    fn safe_path_strips_control_chars() {
+        let path = std::path::Path::new("input-\x1b]2;owned\x07.csv");
+        assert_eq!(safe_path(path), "input-\u{fffd}]2;owned\u{fffd}.csv");
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,14 +22,24 @@ mod jsonout;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use arrow::array::RecordBatch;
+use arrow::array::timezone::Tz;
+use arrow::array::types::{
+    Float64Type, TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+};
+use arrow::array::{new_null_array, ArrayRef, PrimitiveArray, RecordBatch, StringArray};
+use arrow::compute::kernels::cast_utils::{string_to_datetime, Parser as ArrowValueParser};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use clap::{Parser, Subcommand};
 use paimon_mosaic_core::reader::{MosaicReader, ReaderAccess};
+use serde::de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor};
+use serde_json::value::RawValue;
+use serde_json::Value;
 
 use crate::input::FileInput;
 
-/// Mosaic file inspector — the cat/meta/schema/pages toolkit (cf. parquet-cli).
+/// Mosaic file inspector — the cat/meta/schema/pages toolkit.
 #[derive(Parser)]
 #[command(name = "mosaic", version, about)]
 struct Cli {
@@ -123,14 +133,55 @@ enum Cmd {
         #[arg(long)]
         json: bool,
     },
-    /// Import a CSV or JSON file into a new Mosaic file (schema inferred).
+    /// Create a Mosaic file from JSON, with legacy single-file CSV compatibility.
     Convert {
-        /// Input: CSV (.csv, header row) or JSON lines (.json/.ndjson/.jsonl).
+        /// JSON data file; non-JSON paths use the legacy default CSV conversion.
         input: PathBuf,
         /// Output .mosaic path.
-        #[arg(short, long)]
+        #[arg(short = 'o', long = "output", visible_alias = "out")]
         out: PathBuf,
-        /// Columns to build min/max stats for (comma-separated).
+        /// Columns to keep; each occurrence accepts a comma-separated list.
+        #[arg(short = 'c', long = "column")]
+        columns: Vec<String>,
+        /// Columns to build min/max stats for (comma-separated); `cat --where`
+        /// uses them to skip row groups.
+        #[arg(long)]
+        stats: Option<String>,
+        /// Overwrite the output file if it already exists.
+        #[arg(long)]
+        overwrite: bool,
+    },
+    /// Create a Mosaic file from CSV data.
+    ConvertCsv {
+        /// Input CSV path(s).
+        #[arg(required = true)]
+        inputs: Vec<PathBuf>,
+        /// Output .mosaic path.
+        #[arg(short = 'o', long = "output", visible_alias = "out")]
+        out: PathBuf,
+        /// Do not allow null values for inferred fields; repeat for multiple fields.
+        #[arg(long)]
+        require: Vec<String>,
+        /// Delimiter character.
+        #[arg(long, default_value = ",")]
+        delimiter: String,
+        /// Escape character (disabled by default).
+        #[arg(long)]
+        escape: Option<String>,
+        /// Quote character.
+        #[arg(long, default_value = "\"")]
+        quote: String,
+        /// Don't use first line as CSV header.
+        #[arg(long, conflicts_with = "header")]
+        no_header: bool,
+        /// Line to use as a header. Must match the CSV settings.
+        #[arg(long, conflicts_with = "no_header")]
+        header: Option<String>,
+        /// Lines to skip before CSV start.
+        #[arg(long, default_value_t = 0)]
+        skip_lines: usize,
+        /// Columns to build min/max stats for (comma-separated); `cat --where`
+        /// uses them to skip row groups.
         #[arg(long)]
         stats: Option<String>,
         /// Overwrite the output file if it already exists.
@@ -175,9 +226,41 @@ fn main() -> ExitCode {
         Cmd::Convert {
             input,
             out,
+            columns,
             stats,
             overwrite,
-        } => convert(&input, &out, stats, overwrite),
+        } => convert(&input, &out, &columns, stats.as_deref(), overwrite),
+        Cmd::ConvertCsv {
+            inputs,
+            out,
+            require,
+            delimiter,
+            escape,
+            quote,
+            no_header,
+            header,
+            skip_lines,
+            stats,
+            overwrite,
+        } => {
+            let options = CsvConvertOptions {
+                delimiter,
+                escape,
+                quote,
+                no_header,
+                header,
+                skip_lines,
+            };
+            convert_csv(
+                &inputs,
+                &out,
+                &require,
+                options,
+                stats.as_deref(),
+                overwrite,
+                false,
+            )
+        }
     };
     match res {
         Ok(()) => ExitCode::SUCCESS,
@@ -429,51 +512,164 @@ fn count(file: &Path, json: bool) -> std::io::Result<()> {
 fn convert(
     input: &Path,
     out: &Path,
-    stats: Option<String>,
+    columns: &[String],
+    stats: Option<&str>,
     overwrite: bool,
 ) -> std::io::Result<()> {
-    if out.exists() && !overwrite {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::AlreadyExists,
-            format!("{} exists (use --overwrite to replace)", out.display()),
-        ));
-    }
     use arrow::error::ArrowError;
-    use paimon_mosaic_core::writer::{MosaicWriter, WriterOptions};
     let bad = |e: ArrowError| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string());
-    let is_json = matches!(
-        input.extension().and_then(|e| e.to_str()),
-        Some("json") | Some("ndjson") | Some("jsonl")
-    );
-    // Infer schema, then build a batch iterator — CSV (header) or JSON (one object per line).
-    type Batches = Box<dyn Iterator<Item = Result<RecordBatch, ArrowError>>>;
-    // Schema inference and the data reader each need their own pass over the
-    // file (inference consumes a reader), so open it twice via one helper.
+    if !is_json_input(input) {
+        if !columns.is_empty() {
+            return Err(invalid_schema(
+                "--column is only supported for JSON input; use convert-csv for CSV options",
+            ));
+        }
+        let inputs = [input.to_path_buf()];
+        return convert_csv(
+            &inputs,
+            out,
+            &[],
+            CsvConvertOptions {
+                delimiter: ",".to_string(),
+                escape: None,
+                quote: "\"".to_string(),
+                no_header: false,
+                header: None,
+                skip_lines: 0,
+            },
+            stats,
+            overwrite,
+            true,
+        );
+    }
+    let columns = parse_convert_columns(columns)?;
+    ensure_can_write(out, overwrite)?;
+    ensure_regular_inferred_input(input, "JSON")?;
     let open =
         || -> std::io::Result<_> { Ok(std::io::BufReader::new(std::fs::File::open(input)?)) };
-    let (schema, reader): (arrow::datatypes::Schema, Batches) = if is_json {
-        let (schema, _) =
-            arrow::json::reader::infer_json_schema(&mut open()?, None).map_err(bad)?;
-        let rd = arrow::json::ReaderBuilder::new(std::sync::Arc::new(schema.clone()))
-            .build(open()?)
-            .map_err(bad)?;
-        (schema, Box::new(rd))
-    } else {
-        let (schema, _) = arrow::csv::reader::Format::default()
-            .with_header(true)
-            .infer_schema(open()?, None)
-            .map_err(bad)?;
-        let rd = arrow::csv::ReaderBuilder::new(std::sync::Arc::new(schema.clone()))
-            .with_header(true)
-            .build(open()?)
-            .map_err(bad)?;
-        (schema, Box::new(rd))
+    let selected = (!columns.is_empty()).then_some(columns.as_slice());
+    let schema = infer_json_schema_lossless(open()?, selected).map_err(bad)?;
+    let schema = project_convert_schema(schema, &columns)?;
+    reject_null_inferred_fields(&schema)?;
+    let reader = arrow::json::ReaderBuilder::new(Arc::new(schema.clone()))
+        .build(open()?)
+        .map_err(bad)?;
+    write_mosaic(out, overwrite, &schema, stats, |writer, rows| {
+        for batch in reader {
+            let batch = batch
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            *rows += batch.num_rows();
+            writer.write_batch(&batch)?;
+        }
+        Ok(())
+    })
+}
+
+struct CsvConvertOptions {
+    delimiter: String,
+    escape: Option<String>,
+    quote: String,
+    no_header: bool,
+    header: Option<String>,
+    skip_lines: usize,
+}
+
+fn convert_csv(
+    inputs: &[PathBuf],
+    out: &Path,
+    required_fields: &[String],
+    options: CsvConvertOptions,
+    stats: Option<&str>,
+    overwrite: bool,
+    allow_empty_legacy_input: bool,
+) -> std::io::Result<()> {
+    if inputs.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "CSV path is required",
+        ));
+    }
+    ensure_can_write(out, overwrite)?;
+    for input in inputs {
+        ensure_regular_inferred_input(input, "CSV")?;
+    }
+    use arrow::error::ArrowError;
+    let bad = |e: ArrowError| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string());
+    let format = csv_format(&options)?;
+    let mut inferred: Option<Schema> = None;
+    for input in inputs {
+        let inspected = inspect_csv_input(open_csv(input)?, &options, &format)?;
+        if let Some(schema) = inspected {
+            inferred = Some(match inferred.take() {
+                Some(prev) => merge_csv_inferred_schema(prev, schema, input, !options.no_header)?,
+                None => schema,
+            });
+        }
+    }
+    let schema = match inferred {
+        Some(schema) => schema,
+        None if allow_empty_legacy_input
+            && inputs.len() == 1
+            && std::fs::metadata(&inputs[0])?.len() == 0 =>
+        {
+            Schema::empty()
+        }
+        None => return Err(invalid_schema("no CSV data to infer a schema from")),
     };
+    let schema = apply_required_fields(csv_schema_with_null_fallback(schema), required_fields)?;
+    let schema_index = csv_schema_index(&schema);
+    write_mosaic(out, overwrite, &schema, stats, |writer, rows| {
+        for input in inputs {
+            let mut reader = open_csv(input)?;
+            let layout = inspect_csv_layout(&mut reader, &options)?;
+            if !layout.has_records {
+                continue;
+            }
+            let reader_schema = csv_reader_schema(&schema, &schema_index, &layout);
+            let source_mapping = csv_output_mapping(&schema, &schema_index, &layout);
+            validate_csv_mapping(&schema, &layout, &source_mapping, input)?;
+            let (projection, mapping) = csv_projection(&source_mapping);
+            let reader = build_csv_replay_reader(
+                reader_schema,
+                format.clone(),
+                projection,
+                schema.fields().len(),
+                reader,
+            )
+            .map_err(bad)?;
+            for batch in reader {
+                let batch = batch.map_err(|e| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+                })?;
+                let batch = align_csv_batch_to_schema(batch, &schema, &mapping, input)?;
+                *rows += batch.num_rows();
+                writer.write_batch(&batch)?;
+            }
+        }
+        Ok(())
+    })
+}
+
+fn write_mosaic<F>(
+    out: &Path,
+    overwrite: bool,
+    schema: &Schema,
+    stats: Option<&str>,
+    write: F,
+) -> std::io::Result<()>
+where
+    F: FnOnce(
+        &mut paimon_mosaic_core::writer::MosaicWriter<paimon_mosaic_core::writer::FileSink>,
+        &mut usize,
+    ) -> std::io::Result<()>,
+{
+    use paimon_mosaic_core::writer::{FileSink, MosaicWriter, WriterOptions};
+    ensure_can_write(out, overwrite)?;
     let opts = WriterOptions {
-        stats_columns: stats.map(|s| parse_comma_list(&s)).unwrap_or_default(),
+        stats_columns: stats.map(parse_comma_list).unwrap_or_default(),
         ..Default::default()
     };
-    // Write to a unique sibling temp file and rename on success, so a mid-stream
+    // Write to a unique sibling temp file and install it on success, so a mid-stream
     // failure never leaves a truncated .mosaic — and a process-unique suffix
     // avoids clobbering an unrelated `out.mosaic.tmp` the user may already have.
     let uniq = std::time::SystemTime::now()
@@ -483,25 +679,29 @@ fn convert(
     let tmp = out.with_extension(format!("mosaic.{}.{uniq}.tmp", std::process::id()));
     let mut rows = 0;
     let res = (|| {
-        let sink = paimon_mosaic_core::writer::FileSink::create(&tmp)?;
-        let mut w = MosaicWriter::new(sink, &schema, opts)?;
-        for batch in reader {
-            let batch = batch
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-            rows += batch.num_rows();
-            w.write_batch(&batch)?;
-        }
+        let sink = FileSink::create(&tmp)?;
+        let mut w = MosaicWriter::new(sink, schema, opts)?;
+        write(&mut w, &mut rows)?;
         w.close()
     })();
     if let Err(e) = res {
         let _ = std::fs::remove_file(&tmp);
         return Err(e);
     }
-    #[cfg(windows)]
-    if out.exists() {
-        std::fs::remove_file(out)?;
+    match install_mosaic_output(&tmp, out, overwrite) {
+        Ok(InstallOutcome::Clean) => {}
+        Ok(InstallOutcome::CommittedWithCleanupError(error)) => {
+            eprintln!(
+                "warning: output was committed to {}, but temporary file {} could not be removed: {error}",
+                fmt::safe_path(out),
+                fmt::safe_path(&tmp)
+            );
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(error);
+        }
     }
-    std::fs::rename(&tmp, out)?;
     let plural = |n: usize, w: &str| {
         if n == 1 {
             format!("1 {w}")
@@ -511,11 +711,1673 @@ fn convert(
     };
     println!(
         "wrote {} ({}, {})",
-        out.display(),
+        fmt::safe_path(out),
         plural(rows, "row"),
         plural(schema.fields().len(), "column")
     );
     Ok(())
+}
+
+#[derive(Debug)]
+enum InstallOutcome {
+    Clean,
+    CommittedWithCleanupError(std::io::Error),
+}
+
+fn install_mosaic_output(
+    tmp: &Path,
+    out: &Path,
+    overwrite: bool,
+) -> std::io::Result<InstallOutcome> {
+    if overwrite {
+        #[cfg(windows)]
+        if std::fs::symlink_metadata(out).is_ok() {
+            std::fs::remove_file(out)?;
+        }
+        std::fs::rename(tmp, out)?;
+        return Ok(InstallOutcome::Clean);
+    }
+    install_mosaic_output_no_replace(
+        tmp,
+        out,
+        |from, to| std::fs::hard_link(from, to),
+        rename_no_replace,
+        |path| std::fs::remove_file(path),
+    )
+}
+
+fn install_mosaic_output_no_replace<H, R, C>(
+    tmp: &Path,
+    out: &Path,
+    hard_link: H,
+    rename_no_replace: R,
+    cleanup_temp: C,
+) -> std::io::Result<InstallOutcome>
+where
+    H: FnOnce(&Path, &Path) -> std::io::Result<()>,
+    R: FnOnce(&Path, &Path) -> std::io::Result<()>,
+    C: FnOnce(&Path) -> std::io::Result<()>,
+{
+    // Both paths are siblings. Prefer a hard link for a portable atomic
+    // no-replace install, but filesystems such as VFAT do not support links;
+    // use the platform's no-replace rename there.
+    match hard_link(tmp, out) {
+        Ok(()) => match cleanup_temp(tmp) {
+            Ok(()) => Ok(InstallOutcome::Clean),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(InstallOutcome::Clean),
+            Err(error) => Ok(InstallOutcome::CommittedWithCleanupError(error)),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            Err(output_exists_error(out))
+        }
+        Err(hard_link_error) => match rename_no_replace(tmp, out) {
+            Ok(()) => Ok(InstallOutcome::Clean),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                Err(output_exists_error(out))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Unsupported => Err(hard_link_error),
+            Err(error) => Err(error),
+        },
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn rename_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let from = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let to = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    // SAFETY: both CStrings are NUL-terminated and remain alive for the
+    // duration of the syscall; renameat2 does not retain their pointers.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            from.as_ptr(),
+            libc::AT_FDCWD,
+            to.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn rename_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let from = CString::new(from.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let to = CString::new(to.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    // SAFETY: both CStrings are NUL-terminated and remain alive for the
+    // duration of renamex_np, which does not retain their pointers.
+    let result = unsafe { libc::renamex_np(from.as_ptr(), to.as_ptr(), libc::RENAME_EXCL) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(windows)]
+fn rename_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    // std::fs::rename does not replace an existing destination on Windows.
+    std::fs::rename(from, to)
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple",
+    windows
+)))]
+fn rename_no_replace(_from: &Path, _to: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+fn project_convert_schema(schema: Schema, columns: &[String]) -> std::io::Result<Schema> {
+    if columns.is_empty() {
+        return Ok(schema);
+    }
+    let by_name: std::collections::HashMap<&str, usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, field)| (field.name().as_str(), index))
+        .collect();
+    let mut seen = std::collections::HashSet::new();
+    let mut fields = Vec::new();
+    for name in columns {
+        if name.is_empty() {
+            return Err(invalid_schema("--column field name cannot be empty"));
+        }
+        let index = by_name.get(name.as_str()).copied().ok_or_else(|| {
+            invalid_schema(format!(
+                "--column '{}' not found in schema",
+                fmt::safe(name)
+            ))
+        })?;
+        if seen.insert(index) {
+            fields.push(schema.fields()[index].as_ref().clone());
+        }
+    }
+    Ok(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+fn parse_convert_columns(arguments: &[String]) -> std::io::Result<Vec<String>> {
+    if arguments.is_empty() {
+        return Ok(Vec::new());
+    }
+    let columns: Vec<String> = arguments
+        .iter()
+        .flat_map(|argument| parse_comma_list(argument))
+        .collect();
+    if columns.is_empty() {
+        return Err(invalid_schema("--column field name cannot be empty"));
+    }
+    Ok(columns)
+}
+
+fn infer_json_schema_lossless<R: std::io::BufRead>(
+    mut reader: R,
+    columns: Option<&[String]>,
+) -> Result<Schema, arrow::error::ArrowError> {
+    use arrow::error::ArrowError;
+
+    let columns: Option<std::collections::HashSet<&str>> =
+        columns.map(|columns| columns.iter().map(String::as_str).collect());
+    let mut inexact_f64_integer_paths = std::collections::BTreeSet::new();
+    let mut inexact_f64_integer_path_index = JsonNumberPathTrie::default();
+    let schema = {
+        let mut line = String::new();
+        let values = std::iter::from_fn(|| loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => return None,
+                Err(error) => {
+                    return Some(Err(ArrowError::JsonError(format!(
+                        "Failed to read JSON record: {error}"
+                    ))));
+                }
+                Ok(_) if line.trim().is_empty() => continue,
+                Ok(_) => {
+                    let record = line.trim();
+                    let value = if columns.is_some() {
+                        // Projection must not materialize or numerically validate
+                        // unselected values: a caller can deliberately exclude an
+                        // otherwise unsupported number.
+                        parse_json_record_lossless(
+                            record,
+                            columns.as_ref(),
+                            &mut inexact_f64_integer_paths,
+                        )
+                        .map_err(|error| ArrowError::JsonError(format!("Not valid JSON: {error}")))
+                    } else {
+                        match serde_json::from_str::<Value>(record) {
+                            Ok(value) if !json_value_might_need_lossless_numbers(&value) => {
+                                Ok(value)
+                            }
+                            Ok(value) => {
+                                match scan_json_numbers(
+                                    record,
+                                    &mut inexact_f64_integer_paths,
+                                    &mut inexact_f64_integer_path_index,
+                                ) {
+                                    Ok(()) => Ok(value),
+                                    Err(JsonNumberScanError::Syntax) => parse_json_record_lossless(
+                                        record,
+                                        None,
+                                        &mut inexact_f64_integer_paths,
+                                    )
+                                    .map_err(|error| {
+                                        ArrowError::JsonError(format!("Not valid JSON: {error}"))
+                                    }),
+                                    Err(JsonNumberScanError::Validation(error)) => Err(
+                                        ArrowError::JsonError(format!("Not valid JSON: {error}")),
+                                    ),
+                                }
+                            }
+                            Err(error) => match parse_json_record_lossless(
+                                record,
+                                None,
+                                &mut inexact_f64_integer_paths,
+                            ) {
+                                Err(lossless_error)
+                                    if lossless_error
+                                        .to_string()
+                                        .contains("out of range for Float64") =>
+                                {
+                                    Err(ArrowError::JsonError(format!(
+                                        "Not valid JSON: {lossless_error}"
+                                    )))
+                                }
+                                Ok(_) | Err(_) => {
+                                    Err(ArrowError::JsonError(format!("Not valid JSON: {error}")))
+                                }
+                            },
+                        }
+                    };
+                    return Some(value);
+                }
+            }
+        });
+        arrow::json::reader::infer_json_schema_from_iterator(values)?
+    };
+    // Walk the inferred schema once: resolving every raw path independently is
+    // quadratic for wide objects. Sibling fields can retain independent types.
+    if let Some(path) = find_inexact_f64_path(&schema, &inexact_f64_integer_paths) {
+        return Err(ArrowError::JsonError(format!(
+            "numeric value in JSON field '{}' cannot be represented exactly as Float64",
+            fmt::safe(&format_json_number_path(path))
+        )));
+    }
+    Ok(schema)
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum JsonNumberPathSegment {
+    Field(String),
+    Element,
+}
+
+const MAX_JSON_NESTING_DEPTH: usize = 128;
+
+fn json_integer_exceeds_exact_f64_range(literal: &str) -> bool {
+    const MAX_EXACT_F64_INTEGER: &str = "9007199254740992";
+    let digits = literal
+        .strip_prefix('-')
+        .unwrap_or(literal)
+        .trim_start_matches('0');
+    digits.len() > MAX_EXACT_F64_INTEGER.len()
+        || (digits.len() == MAX_EXACT_F64_INTEGER.len() && digits > MAX_EXACT_F64_INTEGER)
+}
+
+fn json_value_might_need_lossless_numbers(value: &Value) -> bool {
+    const MAX_EXACT_F64_INTEGER: u64 = 9_007_199_254_740_992;
+    match value {
+        Value::Number(number) => match (number.as_i64(), number.as_u64()) {
+            (Some(value), _) => value.unsigned_abs() > MAX_EXACT_F64_INTEGER,
+            (_, Some(value)) => value > MAX_EXACT_F64_INTEGER,
+            (None, None) => number
+                .as_f64()
+                .is_some_and(|value| value.abs() > MAX_EXACT_F64_INTEGER as f64),
+        },
+        Value::Array(values) => values.iter().any(json_value_might_need_lossless_numbers),
+        Value::Object(record) => record.values().any(json_value_might_need_lossless_numbers),
+        Value::Null | Value::Bool(_) | Value::String(_) => false,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum JsonScanPathSegment {
+    Field { start: usize, end: usize },
+    Element,
+}
+
+#[derive(Debug)]
+enum JsonNumberScanError {
+    Syntax,
+    Validation(String),
+}
+
+impl std::fmt::Display for JsonNumberScanError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Syntax => formatter.write_str("invalid JSON syntax"),
+            Self::Validation(message) => formatter.write_str(message),
+        }
+    }
+}
+
+fn scan_json_numbers_with_prefix(
+    record: &str,
+    inexact: &mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+    inexact_index: &mut JsonNumberPathTrie,
+    path_prefix: Vec<JsonNumberPathSegment>,
+    parent_depth: usize,
+) -> Result<(), JsonNumberScanError> {
+    let mut scanner = JsonNumberScanner {
+        bytes: record.as_bytes(),
+        position: 0,
+        path: Vec::new(),
+        path_prefix,
+        inexact,
+        inexact_index,
+        depth: parent_depth,
+    };
+    scanner.scan_value()?;
+    scanner.skip_whitespace();
+    if scanner.position == scanner.bytes.len() {
+        Ok(())
+    } else {
+        Err(JsonNumberScanError::Syntax)
+    }
+}
+
+fn scan_json_numbers(
+    record: &str,
+    inexact: &mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+    inexact_index: &mut JsonNumberPathTrie,
+) -> Result<(), JsonNumberScanError> {
+    scan_json_numbers_with_prefix(record, inexact, inexact_index, Vec::new(), 0)
+}
+
+struct JsonNumberScanner<'record, 'inexact, 'index> {
+    bytes: &'record [u8],
+    position: usize,
+    path: Vec<JsonScanPathSegment>,
+    path_prefix: Vec<JsonNumberPathSegment>,
+    inexact: &'inexact mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+    inexact_index: &'index mut JsonNumberPathTrie,
+    depth: usize,
+}
+
+impl JsonNumberScanner<'_, '_, '_> {
+    fn scan_value(&mut self) -> Result<(), JsonNumberScanError> {
+        self.skip_whitespace();
+        match self.bytes.get(self.position).copied() {
+            Some(b'{') => self.scan_object(),
+            Some(b'[') => self.scan_array(),
+            Some(b'"') => self.scan_string().map(|_| ()),
+            Some(b'-' | b'0'..=b'9') => self.scan_number(),
+            Some(b't') => self.scan_keyword(b"true"),
+            Some(b'f') => self.scan_keyword(b"false"),
+            Some(b'n') => self.scan_keyword(b"null"),
+            _ => Err(JsonNumberScanError::Syntax),
+        }
+    }
+
+    fn scan_object(&mut self) -> Result<(), JsonNumberScanError> {
+        self.enter_container()?;
+        let result = self.scan_object_contents();
+        self.depth -= 1;
+        result
+    }
+
+    fn scan_object_contents(&mut self) -> Result<(), JsonNumberScanError> {
+        self.position += 1;
+        self.skip_whitespace();
+        if self.consume(b'}') {
+            return Ok(());
+        }
+        loop {
+            self.skip_whitespace();
+            let (start, end) = self.scan_string()?;
+            self.skip_whitespace();
+            if !self.consume(b':') {
+                return Err(JsonNumberScanError::Syntax);
+            }
+            self.path.push(JsonScanPathSegment::Field { start, end });
+            self.scan_value()?;
+            self.path.pop();
+            self.skip_whitespace();
+            if self.consume(b'}') {
+                return Ok(());
+            }
+            if !self.consume(b',') {
+                return Err(JsonNumberScanError::Syntax);
+            }
+        }
+    }
+
+    fn scan_array(&mut self) -> Result<(), JsonNumberScanError> {
+        self.enter_container()?;
+        let result = self.scan_array_contents();
+        self.depth -= 1;
+        result
+    }
+
+    fn scan_array_contents(&mut self) -> Result<(), JsonNumberScanError> {
+        self.position += 1;
+        self.skip_whitespace();
+        if self.consume(b']') {
+            return Ok(());
+        }
+        self.path.push(JsonScanPathSegment::Element);
+        loop {
+            self.scan_value()?;
+            self.skip_whitespace();
+            if self.consume(b']') {
+                self.path.pop();
+                return Ok(());
+            }
+            if !self.consume(b',') {
+                self.path.pop();
+                return Err(JsonNumberScanError::Syntax);
+            }
+        }
+    }
+
+    fn enter_container(&mut self) -> Result<(), JsonNumberScanError> {
+        if self.depth == MAX_JSON_NESTING_DEPTH {
+            return Err(JsonNumberScanError::Validation(
+                "recursion limit exceeded".to_string(),
+            ));
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn scan_string(&mut self) -> Result<(usize, usize), JsonNumberScanError> {
+        let start = self.position;
+        if !self.consume(b'"') {
+            return Err(JsonNumberScanError::Syntax);
+        }
+        while let Some(byte) = self.bytes.get(self.position).copied() {
+            match byte {
+                b'"' => {
+                    self.position += 1;
+                    return Ok((start, self.position));
+                }
+                b'\\' => {
+                    self.position += 1;
+                    let escaped = self
+                        .bytes
+                        .get(self.position)
+                        .copied()
+                        .ok_or(JsonNumberScanError::Syntax)?;
+                    self.position += 1;
+                    if escaped == b'u' {
+                        if self.position + 4 > self.bytes.len() {
+                            return Err(JsonNumberScanError::Syntax);
+                        }
+                        self.position += 4;
+                    }
+                }
+                0..=0x1f => return Err(JsonNumberScanError::Syntax),
+                _ => self.position += 1,
+            }
+        }
+        Err(JsonNumberScanError::Syntax)
+    }
+
+    fn scan_number(&mut self) -> Result<(), JsonNumberScanError> {
+        let start = self.position;
+        self.consume(b'-');
+        match self.bytes.get(self.position).copied() {
+            Some(b'0') => self.position += 1,
+            Some(b'1'..=b'9') => {
+                self.position += 1;
+                while matches!(self.bytes.get(self.position), Some(b'0'..=b'9')) {
+                    self.position += 1;
+                }
+            }
+            _ => return Err(JsonNumberScanError::Syntax),
+        }
+        if self.consume(b'.') {
+            let fraction_start = self.position;
+            while matches!(self.bytes.get(self.position), Some(b'0'..=b'9')) {
+                self.position += 1;
+            }
+            if self.position == fraction_start {
+                return Err(JsonNumberScanError::Syntax);
+            }
+        }
+        if matches!(self.bytes.get(self.position), Some(b'e' | b'E')) {
+            self.position += 1;
+            if matches!(self.bytes.get(self.position), Some(b'+' | b'-')) {
+                self.position += 1;
+            }
+            let exponent_start = self.position;
+            while matches!(self.bytes.get(self.position), Some(b'0'..=b'9')) {
+                self.position += 1;
+            }
+            if self.position == exponent_start {
+                return Err(JsonNumberScanError::Syntax);
+            }
+        }
+        if !self
+            .bytes
+            .get(self.position)
+            .is_none_or(|byte| matches!(*byte, b' ' | b'\t' | b'\r' | b'\n' | b',' | b']' | b'}'))
+        {
+            return Err(JsonNumberScanError::Syntax);
+        }
+        let literal = std::str::from_utf8(&self.bytes[start..self.position])
+            .map_err(|_| JsonNumberScanError::Syntax)?;
+        let promoted = match literal.parse::<f64>() {
+            Ok(promoted) => promoted,
+            Err(_) => {
+                let path = self.materialize_path()?;
+                return Err(JsonNumberScanError::Validation(format!(
+                    "invalid JSON number at '{}'",
+                    fmt::safe(&format_json_number_path(&path))
+                )));
+            }
+        };
+        if !promoted.is_finite() {
+            let path = self.materialize_path()?;
+            return Err(JsonNumberScanError::Validation(format!(
+                "numeric value in JSON field '{}' is out of range for Float64",
+                fmt::safe(&format_json_number_path(&path))
+            )));
+        }
+        let integer = !literal
+            .bytes()
+            .any(|byte| matches!(byte, b'.' | b'e' | b'E'));
+        if integer && json_integer_exceeds_exact_f64_range(literal) {
+            let known = if self.path_prefix.is_empty() {
+                self.inexact_index
+                    .contains_scan_path(self.bytes, &self.path)?
+            } else {
+                let path = self.materialize_path()?;
+                self.inexact.contains(&path)
+            };
+            if !known && is_inexact_f64_integer(literal) {
+                let path = self.materialize_path()?;
+                self.inexact_index.insert(&path);
+                self.inexact.insert(path);
+            }
+        }
+        Ok(())
+    }
+
+    fn materialize_path(&self) -> Result<Vec<JsonNumberPathSegment>, JsonNumberScanError> {
+        let mut path = self.path_prefix.clone();
+        path.extend(materialize_json_scan_path(self.bytes, &self.path)?);
+        Ok(path)
+    }
+
+    fn scan_keyword(&mut self, keyword: &[u8]) -> Result<(), JsonNumberScanError> {
+        if self.bytes.get(self.position..self.position + keyword.len()) != Some(keyword) {
+            return Err(JsonNumberScanError::Syntax);
+        }
+        self.position += keyword.len();
+        if self
+            .bytes
+            .get(self.position)
+            .is_none_or(|byte| matches!(*byte, b' ' | b'\t' | b'\r' | b'\n' | b',' | b']' | b'}'))
+        {
+            Ok(())
+        } else {
+            Err(JsonNumberScanError::Syntax)
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(
+            self.bytes.get(self.position),
+            Some(b' ' | b'\t' | b'\r' | b'\n')
+        ) {
+            self.position += 1;
+        }
+    }
+
+    fn consume(&mut self, expected: u8) -> bool {
+        if self.bytes.get(self.position) == Some(&expected) {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn materialize_json_scan_path(
+    bytes: &[u8],
+    path: &[JsonScanPathSegment],
+) -> Result<Vec<JsonNumberPathSegment>, JsonNumberScanError> {
+    path.iter()
+        .map(|segment| match segment {
+            JsonScanPathSegment::Field { start, end } => json_scan_field_name(bytes, *start, *end)
+                .map(std::borrow::Cow::into_owned)
+                .map(JsonNumberPathSegment::Field),
+            JsonScanPathSegment::Element => Ok(JsonNumberPathSegment::Element),
+        })
+        .collect()
+}
+
+fn json_scan_field_name(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+) -> Result<std::borrow::Cow<'_, str>, JsonNumberScanError> {
+    let raw = bytes.get(start..end).ok_or(JsonNumberScanError::Syntax)?;
+    let inner = raw
+        .get(1..raw.len().saturating_sub(1))
+        .ok_or(JsonNumberScanError::Syntax)?;
+    if !inner.contains(&b'\\') {
+        return std::str::from_utf8(inner)
+            .map(std::borrow::Cow::Borrowed)
+            .map_err(|_| JsonNumberScanError::Syntax);
+    }
+    serde_json::from_slice::<String>(raw)
+        .map(std::borrow::Cow::Owned)
+        .map_err(|_| JsonNumberScanError::Syntax)
+}
+
+#[derive(Default)]
+struct JsonNumberPathTrie {
+    terminal: bool,
+    fields: std::collections::HashMap<String, JsonNumberPathTrie>,
+    element: Option<Box<JsonNumberPathTrie>>,
+}
+
+impl JsonNumberPathTrie {
+    fn contains_scan_path(
+        &self,
+        bytes: &[u8],
+        path: &[JsonScanPathSegment],
+    ) -> Result<bool, JsonNumberScanError> {
+        let mut node = self;
+        for segment in path {
+            node = match segment {
+                JsonScanPathSegment::Field { start, end } => {
+                    let name = json_scan_field_name(bytes, *start, *end)?;
+                    let Some(child) = node.fields.get(name.as_ref()) else {
+                        return Ok(false);
+                    };
+                    child
+                }
+                JsonScanPathSegment::Element => {
+                    let Some(child) = node.element.as_deref() else {
+                        return Ok(false);
+                    };
+                    child
+                }
+            };
+        }
+        Ok(node.terminal)
+    }
+
+    fn insert(&mut self, path: &[JsonNumberPathSegment]) {
+        let mut node = self;
+        for segment in path {
+            node = match segment {
+                JsonNumberPathSegment::Field(name) => node.fields.entry(name.clone()).or_default(),
+                JsonNumberPathSegment::Element => node
+                    .element
+                    .get_or_insert_with(|| Box::new(JsonNumberPathTrie::default())),
+            };
+        }
+        node.terminal = true;
+    }
+}
+
+fn is_inexact_f64_integer(literal: &str) -> bool {
+    if let Ok(exact) = literal.parse::<i128>() {
+        return literal
+            .parse::<f64>()
+            .ok()
+            .and_then(exact_i128_from_f64)
+            .is_none_or(|promoted| promoted != exact);
+    }
+
+    // Fixed-point formatting recovers the exact integer represented by f64,
+    // including large powers of two, without conservatively rejecting them.
+    literal
+        .parse::<f64>()
+        .ok()
+        .filter(|promoted| promoted.is_finite())
+        .is_none_or(|promoted| format!("{promoted:.0}") != literal)
+}
+
+fn find_inexact_f64_path<'a>(
+    schema: &Schema,
+    inexact: &'a std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+) -> Option<&'a [JsonNumberPathSegment]> {
+    let mut path = Vec::new();
+    for field in schema.fields() {
+        path.push(JsonNumberPathSegment::Field(field.name().clone()));
+        let found = find_inexact_f64_path_in_type(field.data_type(), &mut path, inexact);
+        path.pop();
+        if found.is_some() {
+            return found;
+        }
+    }
+    None
+}
+
+fn find_inexact_f64_path_in_type<'a>(
+    data_type: &DataType,
+    path: &mut Vec<JsonNumberPathSegment>,
+    inexact: &'a std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+) -> Option<&'a [JsonNumberPathSegment]> {
+    match data_type {
+        DataType::Float64 => inexact.get(path.as_slice()).map(Vec::as_slice),
+        DataType::Struct(fields) => {
+            for field in fields {
+                path.push(JsonNumberPathSegment::Field(field.name().clone()));
+                let found = find_inexact_f64_path_in_type(field.data_type(), path, inexact);
+                path.pop();
+                if found.is_some() {
+                    return found;
+                }
+            }
+            None
+        }
+        DataType::List(field)
+        | DataType::ListView(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::LargeList(field)
+        | DataType::LargeListView(field) => {
+            path.push(JsonNumberPathSegment::Element);
+            let found = find_inexact_f64_path_in_type(field.data_type(), path, inexact);
+            path.pop();
+            found
+        }
+        _ => None,
+    }
+}
+
+fn format_json_number_path(path: &[JsonNumberPathSegment]) -> String {
+    let mut formatted = String::new();
+    for segment in path {
+        match segment {
+            JsonNumberPathSegment::Field(name) => {
+                if !formatted.is_empty() {
+                    formatted.push('.');
+                }
+                formatted.push_str(name);
+            }
+            JsonNumberPathSegment::Element => formatted.push_str("[]"),
+        }
+    }
+    formatted
+}
+
+fn parse_json_record_lossless<'columns>(
+    record: &str,
+    columns: Option<&'columns std::collections::HashSet<&'columns str>>,
+    inexact_f64_integer_paths: &mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+) -> serde_json::Result<Value> {
+    let mut deserializer = serde_json::Deserializer::from_str(record);
+    let value = FilteredJsonRecordSeed {
+        columns,
+        inexact_f64_integer_paths,
+    }
+    .deserialize(&mut deserializer)?;
+    deserializer.end()?;
+    Ok(value)
+}
+
+struct FilteredJsonRecordSeed<'columns, 'inexact> {
+    columns: Option<&'columns std::collections::HashSet<&'columns str>>,
+    inexact_f64_integer_paths: &'inexact mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+}
+
+impl<'de> DeserializeSeed<'de> for FilteredJsonRecordSeed<'_, '_> {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(FilteredJsonRecordVisitor {
+            columns: self.columns,
+            inexact_f64_integer_paths: self.inexact_f64_integer_paths,
+        })
+    }
+}
+
+struct FilteredJsonRecordVisitor<'columns, 'inexact> {
+    columns: Option<&'columns std::collections::HashSet<&'columns str>>,
+    inexact_f64_integer_paths: &'inexact mut std::collections::BTreeSet<Vec<JsonNumberPathSegment>>,
+}
+
+impl<'de> Visitor<'de> for FilteredJsonRecordVisitor<'_, '_> {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a JSON object")
+    }
+
+    fn visit_map<M>(self, mut map: M) -> Result<Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let mut projected = serde_json::Map::new();
+        while let Some(name) = map.next_key::<std::borrow::Cow<'de, str>>()? {
+            if self
+                .columns
+                .is_none_or(|columns| columns.contains(name.as_ref()))
+            {
+                let name = name.into_owned();
+                let raw = map.next_value::<&RawValue>()?;
+                let mut inexact_index = JsonNumberPathTrie::default();
+                scan_json_numbers_with_prefix(
+                    raw.get(),
+                    self.inexact_f64_integer_paths,
+                    &mut inexact_index,
+                    vec![JsonNumberPathSegment::Field(name.clone())],
+                    1,
+                )
+                .map_err(serde::de::Error::custom)?;
+                let value = serde_json::from_str(raw.get()).map_err(serde::de::Error::custom)?;
+                projected.insert(name, value);
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        Ok(Value::Object(projected))
+    }
+}
+
+/// Mosaic cannot store Arrow `Null` columns, and JSON inference produces
+/// `Null` for a field with no non-null value in the input — fail
+/// with the column name instead of the writer's late "unsupported DataType".
+fn reject_null_inferred_fields(schema: &Schema) -> std::io::Result<()> {
+    for field in schema.fields() {
+        if matches!(field.data_type(), DataType::Null) {
+            return Err(invalid_schema(format!(
+                "cannot infer a type for column '{}' (no non-null value in the records)",
+                fmt::safe(field.name())
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_json_input(input: &Path) -> bool {
+    input
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "json" | "ndjson" | "jsonl"
+            )
+        })
+}
+
+fn ensure_regular_inferred_input(input: &Path, format: &str) -> std::io::Result<()> {
+    let metadata = std::fs::metadata(input)?;
+    if metadata.file_type().is_file() {
+        Ok(())
+    } else {
+        Err(invalid_schema(format!(
+            "{format} schema inference requires a regular file: {}",
+            fmt::safe_path(input)
+        )))
+    }
+}
+
+fn ensure_can_write(out: &Path, overwrite: bool) -> std::io::Result<()> {
+    if overwrite {
+        return Ok(());
+    }
+    match std::fs::symlink_metadata(out) {
+        Ok(_) => Err(output_exists_error(out)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn output_exists_error(out: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::AlreadyExists,
+        format!(
+            "{} exists (use --overwrite to replace)",
+            fmt::safe_path(out)
+        ),
+    )
+}
+
+fn csv_format(options: &CsvConvertOptions) -> std::io::Result<arrow::csv::reader::Format> {
+    let delimiter = parse_csv_byte(&options.delimiter, "delimiter")?;
+    let escape = parse_optional_csv_byte(options.escape.as_deref(), "escape")?;
+    let quote = parse_csv_byte(&options.quote, "quote")?;
+    let format = arrow::csv::reader::Format::default()
+        .with_header(!options.no_header && options.header.is_none())
+        .with_delimiter(delimiter)
+        .with_quote(quote);
+    Ok(match escape {
+        Some(escape) => format.with_escape(escape),
+        None => format,
+    })
+}
+
+fn parse_csv_byte(value: &str, name: &str) -> std::io::Result<u8> {
+    let bytes = value.as_bytes();
+    if bytes.len() == 1 {
+        Ok(bytes[0])
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("--{name} must be exactly one byte"),
+        ))
+    }
+}
+
+fn parse_optional_csv_byte(value: Option<&str>, name: &str) -> std::io::Result<Option<u8>> {
+    value.map(|value| parse_csv_byte(value, name)).transpose()
+}
+
+fn open_csv(path: &Path) -> std::io::Result<std::io::BufReader<std::fs::File>> {
+    Ok(std::io::BufReader::new(std::fs::File::open(path)?))
+}
+
+fn skip_csv_lines<R: std::io::BufRead>(reader: &mut R, skip_lines: usize) -> std::io::Result<()> {
+    for _ in 0..skip_lines {
+        loop {
+            let buffer = reader.fill_buf()?;
+            if buffer.is_empty() {
+                return Ok(());
+            }
+            let newline = buffer.iter().position(|byte| *byte == b'\n');
+            let consumed = newline.map_or(buffer.len(), |index| index + 1);
+            reader.consume(consumed);
+            if newline.is_some() {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+const DEFAULT_CSV_BATCH_SIZE: usize = 1024;
+const CSV_REPLAY_CELL_BUDGET: usize = 1 << 20;
+
+fn csv_replay_batch_size(columns: usize) -> usize {
+    CSV_REPLAY_CELL_BUDGET
+        .checked_div(columns)
+        .unwrap_or(DEFAULT_CSV_BATCH_SIZE)
+        .clamp(1, DEFAULT_CSV_BATCH_SIZE)
+}
+
+fn build_csv_replay_reader<R: std::io::Read>(
+    schema: Schema,
+    format: arrow::csv::reader::Format,
+    projection: Vec<usize>,
+    output_columns: usize,
+    reader: R,
+) -> Result<arrow::csv::Reader<R>, arrow::error::ArrowError> {
+    let batch_size = csv_replay_batch_size(output_columns);
+    arrow::csv::ReaderBuilder::new(Arc::new(schema))
+        .with_format(format.with_truncated_rows(false))
+        .with_batch_size(batch_size)
+        .with_projection(projection)
+        .build(reader)
+}
+
+struct CsvInputLayout {
+    header: Option<Vec<String>>,
+    columns: usize,
+    has_records: bool,
+}
+
+fn inspect_csv_input<R: std::io::BufRead + std::io::Seek>(
+    mut reader: R,
+    options: &CsvConvertOptions,
+    format: &arrow::csv::reader::Format,
+) -> std::io::Result<Option<Schema>> {
+    let layout = inspect_csv_layout(&mut reader, options)?;
+    if !layout.has_records {
+        return Ok(None);
+    }
+
+    let (schema, rows) = format
+        .infer_schema(reader, None)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))?;
+    // A shard with no data rows has nothing to infer from; it is skipped
+    // when reading too.
+    if rows == 0 || schema.fields().is_empty() {
+        return Ok(None);
+    }
+    let schema =
+        promote_second_precision_csv_timestamps(csv_schema_with_csv_names(schema, options)?);
+    Ok(Some(schema))
+}
+
+fn inspect_csv_layout<R: std::io::BufRead + std::io::Seek>(
+    reader: &mut R,
+    options: &CsvConvertOptions,
+) -> std::io::Result<CsvInputLayout> {
+    skip_csv_lines(reader, options.skip_lines)?;
+    let layout = csv_input_layout(&mut *reader, options)?;
+    reader.seek(std::io::SeekFrom::Start(0))?;
+    skip_csv_lines(reader, options.skip_lines)?;
+    Ok(layout)
+}
+
+fn csv_input_layout<R: std::io::Read>(
+    reader: R,
+    options: &CsvConvertOptions,
+) -> std::io::Result<CsvInputLayout> {
+    let delimiter = parse_csv_byte(&options.delimiter, "delimiter")?;
+    let escape = parse_optional_csv_byte(options.escape.as_deref(), "escape")?;
+    let quote = parse_csv_byte(&options.quote, "quote")?;
+    let mut builder = csv::ReaderBuilder::new();
+    builder
+        .has_headers(false)
+        .flexible(true)
+        .delimiter(delimiter)
+        .quote(quote)
+        .escape(escape);
+    let mut reader = builder.from_reader(reader);
+    let mut records = reader.records();
+    let (header, has_records) = if let Some(header) = &options.header {
+        (
+            Some(parse_csv_header(header, options)?),
+            records
+                .next()
+                .transpose()
+                .map_err(|e| invalid_schema(format!("invalid CSV record: {e}")))?
+                .is_some(),
+        )
+    } else if options.no_header {
+        (
+            None,
+            records
+                .next()
+                .transpose()
+                .map_err(|e| invalid_schema(format!("invalid CSV record: {e}")))?
+                .is_some(),
+        )
+    } else {
+        match records.next() {
+            Some(record) => {
+                let record =
+                    record.map_err(|e| invalid_schema(format!("invalid CSV header: {e}")))?;
+                let header: Vec<String> = record.iter().map(ToString::to_string).collect();
+                let has_records = records
+                    .next()
+                    .transpose()
+                    .map_err(|e| invalid_schema(format!("invalid CSV record: {e}")))?
+                    .is_some();
+                if has_records {
+                    validate_csv_header_names(&header)?;
+                }
+                (Some(header), has_records)
+            }
+            None => (Some(Vec::new()), false),
+        }
+    };
+    let columns = header.as_ref().map_or(0, Vec::len);
+    Ok(CsvInputLayout {
+        header,
+        columns,
+        has_records,
+    })
+}
+
+fn csv_schema_index(schema: &Schema) -> std::collections::HashMap<&str, usize> {
+    schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, field)| (field.name().as_str(), index))
+        .collect()
+}
+
+fn csv_reader_schema(
+    output_schema: &Schema,
+    schema_index: &std::collections::HashMap<&str, usize>,
+    layout: &CsvInputLayout,
+) -> Schema {
+    let positional = layout.header.is_none();
+    let columns = if positional {
+        layout.columns.max(output_schema.fields().len())
+    } else {
+        layout.columns
+    };
+    let fields: Vec<Field> = (0..columns)
+        .map(|i| {
+            let source = if let Some(header) = &layout.header {
+                header
+                    .get(i)
+                    .and_then(|name| schema_index.get(name.as_str()).copied())
+            } else {
+                (i < output_schema.fields().len()).then_some(i)
+            };
+            if let Some(source) = source {
+                let output_field = output_schema.fields()[source].as_ref();
+                let data_type = match output_field.data_type() {
+                    // Arrow's Float64 decoder would round bare integer tokens
+                    // before Mosaic can enforce exactness. Preserve raw text
+                    // for inferred Float64 and local timestamp fields.
+                    DataType::Float64 | DataType::Timestamp(_, _) => DataType::Utf8,
+                    data_type => data_type.clone(),
+                };
+                // Read as nullable: not-null enforcement happens when the batch
+                // is re-attached to the output schema, where the error carries
+                // the real column name rather than a positional one.
+                output_field
+                    .clone()
+                    .with_data_type(data_type)
+                    .with_name(format!("field_{i}"))
+                    .with_nullable(true)
+            } else {
+                Field::new(format!("field_{i}"), DataType::Utf8, true)
+            }
+        })
+        .collect();
+    Schema::new(fields)
+}
+
+fn csv_output_mapping(
+    output_schema: &Schema,
+    schema_index: &std::collections::HashMap<&str, usize>,
+    layout: &CsvInputLayout,
+) -> Vec<Option<usize>> {
+    if let Some(header) = &layout.header {
+        let mut mapping = vec![None; output_schema.fields().len()];
+        for (csv_index, name) in header.iter().enumerate() {
+            if let Some(field_index) = schema_index.get(name.as_str()).copied() {
+                mapping[field_index] = Some(csv_index);
+            }
+        }
+        mapping
+    } else {
+        (0..output_schema.fields().len()).map(Some).collect()
+    }
+}
+
+fn csv_projection(mapping: &[Option<usize>]) -> (Vec<usize>, Vec<Option<usize>>) {
+    let mut projection = Vec::new();
+    let projected_mapping = mapping
+        .iter()
+        .map(|source| {
+            source.map(|source| {
+                let projected = projection.len();
+                projection.push(source);
+                projected
+            })
+        })
+        .collect();
+    (projection, projected_mapping)
+}
+
+/// A schema field absent from the CSV header becomes an all-null column, so
+/// refuse the conversions that can only be mistakes: a header matching no
+/// schema field at all, and a required field that the data cannot supply.
+fn validate_csv_mapping(
+    schema: &Schema,
+    layout: &CsvInputLayout,
+    mapping: &[Option<usize>],
+    input: &Path,
+) -> std::io::Result<()> {
+    if layout.header.is_some() && !schema.fields().is_empty() && mapping.iter().all(Option::is_none)
+    {
+        return Err(invalid_schema(format!(
+            "none of the schema fields were found in the CSV header of {}; use --no-header if the file has no header row",
+            fmt::safe_path(input)
+        )));
+    }
+    for (field, index) in schema.fields().iter().zip(mapping) {
+        if index.is_none() && !field.is_nullable() {
+            return Err(invalid_schema(format!(
+                "required field '{}' was not found in the CSV header of {}",
+                fmt::safe(field.name()),
+                fmt::safe_path(input)
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn align_csv_batch_to_schema(
+    batch: RecordBatch,
+    schema: &Schema,
+    mapping: &[Option<usize>],
+    input: &Path,
+) -> std::io::Result<RecordBatch> {
+    let (_, source_columns, rows) = batch.into_parts();
+    let mut source_columns: Vec<Option<ArrayRef>> = source_columns.into_iter().map(Some).collect();
+    let columns: Vec<ArrayRef> = schema
+        .fields()
+        .iter()
+        .zip(mapping)
+        .map(|(field, index)| match *index {
+            Some(index) => {
+                let source = source_columns[index]
+                    .take()
+                    .ok_or_else(|| invalid_schema("invalid duplicate CSV projection"))?;
+                if source.data_type() != &DataType::Utf8 {
+                    Ok(source)
+                } else {
+                    match field.data_type() {
+                        DataType::Float64 => parse_inferred_csv_float64(&source, field, input),
+                        DataType::Timestamp(_, _) => {
+                            parse_inferred_csv_timestamp_column(&source, field, input)
+                        }
+                        _ => Ok(source),
+                    }
+                }
+            }
+            None => Ok(new_null_array(field.data_type(), rows)),
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    RecordBatch::try_new(Arc::new(schema.clone()), columns)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))
+}
+
+fn parse_inferred_csv_timestamp_column(
+    array: &ArrayRef,
+    field: &Field,
+    input: &Path,
+) -> std::io::Result<ArrayRef> {
+    let values = array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| invalid_schema("expected a Utf8 CSV timestamp column"))?;
+    let DataType::Timestamp(unit, timezone) = field.data_type() else {
+        return Err(invalid_schema("expected a Timestamp CSV field"));
+    };
+    let parser_timezone: Tz = timezone
+        .as_deref()
+        .unwrap_or("+00:00")
+        .parse()
+        .map_err(|e| invalid_schema(format!("invalid timestamp timezone: {e}")))?;
+    let values = values
+        .iter()
+        .map(|value| {
+            let Some(value) = value else {
+                return Ok(None);
+            };
+            parse_csv_timestamp_value(
+                value,
+                field,
+                unit,
+                &parser_timezone,
+                timezone.is_none(),
+                input,
+            )
+            .map(Some)
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    csv_timestamp_array(values, unit, timezone.clone())
+}
+
+fn parse_csv_timestamp_value(
+    value: &str,
+    field: &Field,
+    unit: &TimeUnit,
+    parser_timezone: &Tz,
+    reject_timezone: bool,
+    input: &Path,
+) -> std::io::Result<i64> {
+    if reject_timezone && timestamp_has_explicit_timezone(value) {
+        return Err(invalid_schema(format!(
+            "CSV field '{}' in {} must not include a timezone for an inferred local timestamp",
+            fmt::safe(field.name()),
+            fmt::safe_path(input)
+        )));
+    }
+    let parse_error = || {
+        invalid_schema(format!(
+            "cannot parse '{}' as {} for CSV field '{}' in {}",
+            fmt::safe(value),
+            field.data_type(),
+            fmt::safe(field.name()),
+            fmt::safe_path(input)
+        ))
+    };
+    let datetime = string_to_datetime(parser_timezone, value).map_err(|_| parse_error())?;
+    match unit {
+        TimeUnit::Millisecond => Ok(datetime.timestamp_millis()),
+        TimeUnit::Microsecond => Ok(datetime.timestamp_micros()),
+        TimeUnit::Nanosecond => datetime.timestamp_nanos_opt().ok_or_else(parse_error),
+        unit => Err(invalid_schema(format!(
+            "CSV conversion does not support timestamp unit {unit:?}"
+        ))),
+    }
+}
+
+fn csv_timestamp_array(
+    values: Vec<Option<i64>>,
+    unit: &TimeUnit,
+    timezone: Option<Arc<str>>,
+) -> std::io::Result<ArrayRef> {
+    Ok(match unit {
+        TimeUnit::Millisecond => Arc::new(
+            PrimitiveArray::<TimestampMillisecondType>::from(values)
+                .with_timezone_opt(timezone.clone()),
+        ),
+        TimeUnit::Microsecond => Arc::new(
+            PrimitiveArray::<TimestampMicrosecondType>::from(values)
+                .with_timezone_opt(timezone.clone()),
+        ),
+        TimeUnit::Nanosecond => Arc::new(
+            PrimitiveArray::<TimestampNanosecondType>::from(values).with_timezone_opt(timezone),
+        ),
+        unit => {
+            return Err(invalid_schema(format!(
+                "CSV conversion does not support timestamp unit {unit:?}"
+            )));
+        }
+    })
+}
+
+fn parse_inferred_csv_float64(
+    array: &ArrayRef,
+    field: &Field,
+    input: &Path,
+) -> std::io::Result<ArrayRef> {
+    let values = array
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| invalid_schema("expected a Utf8 CSV column"))?;
+    let values = values
+        .iter()
+        .map(|value| {
+            let Some(value) = value else {
+                return Ok(None);
+            };
+            let promoted = Float64Type::parse(value)
+                .ok_or_else(|| csv_inferred_float_parse_error(value, field, input))?;
+            if !promoted.is_finite() {
+                return Err(if is_non_finite_float_literal(value) {
+                    csv_non_finite_float_error(value, field, input)
+                } else {
+                    csv_inferred_float_parse_error(value, field, input)
+                });
+            }
+            let unsigned = value
+                .strip_prefix('+')
+                .or_else(|| value.strip_prefix('-'))
+                .unwrap_or(value);
+            let integer_token =
+                !unsigned.is_empty() && unsigned.bytes().all(|byte| byte.is_ascii_digit());
+            if integer_token {
+                let exact = value
+                    .parse::<i128>()
+                    .map_err(|_| csv_inferred_float_parse_error(value, field, input))?;
+                if exact_i128_from_f64(promoted) != Some(exact) {
+                    return Err(csv_inferred_float_parse_error(value, field, input));
+                }
+            }
+            Ok(Some(promoted))
+        })
+        .collect::<std::io::Result<Vec<_>>>()?;
+    Ok(Arc::new(
+        values.into_iter().collect::<PrimitiveArray<Float64Type>>(),
+    ))
+}
+
+fn exact_i128_from_f64(value: f64) -> Option<i128> {
+    let upper_exclusive = 2.0_f64.powi(127);
+    if !value.is_finite() || value >= upper_exclusive || value < -upper_exclusive {
+        return None;
+    }
+    let integer = value as i128;
+    (integer as f64 == value).then_some(integer)
+}
+
+fn is_non_finite_float_literal(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "nan" | "+nan" | "-nan" | "inf" | "+inf" | "-inf" | "infinity" | "+infinity" | "-infinity"
+    )
+}
+
+fn csv_inferred_float_parse_error(value: &str, field: &Field, input: &Path) -> std::io::Error {
+    invalid_schema(format!(
+        "numeric value '{}' in CSV field '{}' of {} cannot be represented exactly as Float64",
+        fmt::safe(value),
+        fmt::safe(field.name()),
+        fmt::safe_path(input)
+    ))
+}
+
+fn csv_non_finite_float_error(value: &str, field: &Field, input: &Path) -> std::io::Error {
+    invalid_schema(format!(
+        "non-finite Float64 value '{}' in CSV field '{}' of {} is not supported",
+        fmt::safe(value),
+        fmt::safe(field.name()),
+        fmt::safe_path(input)
+    ))
+}
+
+fn timestamp_has_explicit_timezone(value: &str) -> bool {
+    let bytes = value.trim().as_bytes();
+    if bytes.len() <= 10 {
+        return false;
+    }
+    let after_date = &bytes[10..];
+    matches!(after_date.last(), Some(b'Z' | b'z'))
+        || after_date.iter().any(|b| matches!(b, b'+' | b'-'))
+}
+
+fn csv_schema_with_csv_names(
+    schema: Schema,
+    options: &CsvConvertOptions,
+) -> std::io::Result<Schema> {
+    let names = if let Some(header) = &options.header {
+        Some(parse_csv_header(header, options)?)
+    } else if options.no_header {
+        Some(
+            (0..schema.fields().len())
+                .map(|i| format!("field_{i}"))
+                .collect(),
+        )
+    } else {
+        None
+    };
+    let Some(names) = names else {
+        return Ok(schema);
+    };
+    if names.len() != schema.fields().len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "CSV header has {} fields but inferred schema has {} fields",
+                names.len(),
+                schema.fields().len()
+            ),
+        ));
+    }
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .zip(names)
+        .map(|(field, name)| field.as_ref().clone().with_name(name))
+        .collect();
+    Ok(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+fn parse_csv_header(header: &str, options: &CsvConvertOptions) -> std::io::Result<Vec<String>> {
+    let delimiter = parse_csv_byte(&options.delimiter, "delimiter")?;
+    let escape = parse_optional_csv_byte(options.escape.as_deref(), "escape")?;
+    let quote = parse_csv_byte(&options.quote, "quote")?;
+    let mut builder = csv::ReaderBuilder::new();
+    builder
+        .has_headers(false)
+        .delimiter(delimiter)
+        .quote(quote)
+        .escape(escape);
+    let mut reader = builder.from_reader(header.as_bytes());
+    let mut records = reader.records();
+    let record = records
+        .next()
+        .ok_or_else(|| invalid_schema("--header must contain at least one field"))?
+        .map_err(|e| invalid_schema(format!("invalid --header CSV: {e}")))?;
+    if let Some(next) = records.next() {
+        next.map_err(|e| invalid_schema(format!("invalid --header CSV: {e}")))?;
+        return Err(invalid_schema(
+            "--header must contain exactly one CSV record",
+        ));
+    }
+    let header: Vec<String> = record.iter().map(ToString::to_string).collect();
+    validate_csv_header_names(&header)?;
+    Ok(header)
+}
+
+fn validate_csv_header_names(header: &[String]) -> std::io::Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for name in header {
+        if name.is_empty() {
+            return Err(invalid_schema("empty column name"));
+        }
+        if !seen.insert(name.as_str()) {
+            return Err(invalid_schema(format!(
+                "duplicate CSV header field '{}'",
+                fmt::safe(name)
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn csv_schema_with_null_fallback(schema: Schema) -> Schema {
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let field = field.as_ref().clone();
+            if matches!(field.data_type(), DataType::Null) {
+                field.with_data_type(DataType::Utf8)
+            } else {
+                field
+            }
+        })
+        .collect();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+fn promote_second_precision_csv_timestamps(schema: Schema) -> Schema {
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let field = field.as_ref().clone();
+            match field.data_type().clone() {
+                DataType::Timestamp(TimeUnit::Second, timezone) => {
+                    field.with_data_type(DataType::Timestamp(TimeUnit::Millisecond, timezone))
+                }
+                _ => field,
+            }
+        })
+        .collect();
+    Schema::new_with_metadata(fields, schema.metadata().clone())
+}
+
+fn merge_csv_inferred_schema(
+    prev: Schema,
+    next: Schema,
+    input: &Path,
+    merge_by_name: bool,
+) -> std::io::Result<Schema> {
+    if !merge_by_name && prev.fields().len() != next.fields().len() {
+        return Err(csv_schema_mismatch(input));
+    }
+    let next_fields: std::collections::HashMap<&str, &Field> = next
+        .fields()
+        .iter()
+        .map(|field| (field.name().as_str(), field.as_ref()))
+        .collect();
+    let prev_names: std::collections::HashSet<&str> = prev
+        .fields()
+        .iter()
+        .map(|field| field.name().as_str())
+        .collect();
+    let mut fields: Vec<Field> = prev
+        .fields()
+        .iter()
+        .map(
+            |left| match next_fields.get(left.name().as_str()).copied() {
+                Some(right) => merge_csv_inferred_field(left.as_ref(), right, input),
+                None if merge_by_name => Ok(left.as_ref().clone().with_nullable(true)),
+                None => Err(csv_schema_mismatch(input)),
+            },
+        )
+        .collect::<std::io::Result<_>>()?;
+    if merge_by_name {
+        fields.extend(
+            next.fields()
+                .iter()
+                .filter(|field| !prev_names.contains(field.name().as_str()))
+                .map(|field| field.as_ref().clone().with_nullable(true)),
+        );
+    }
+    Ok(Schema::new_with_metadata(fields, prev.metadata().clone()))
+}
+
+fn merge_csv_inferred_field(left: &Field, right: &Field, input: &Path) -> std::io::Result<Field> {
+    if left.name() != right.name() {
+        return Err(csv_schema_mismatch(input));
+    }
+    let nullable = left.is_nullable() || right.is_nullable();
+    let field = match (left.data_type(), right.data_type()) {
+        (left_type, right_type) if left_type == right_type => left.clone().with_nullable(nullable),
+        (DataType::Null, _) => right.clone().with_nullable(true),
+        (_, DataType::Null) => left.clone().with_nullable(true),
+        (DataType::Int64, DataType::Float64) | (DataType::Float64, DataType::Int64) => left
+            .clone()
+            .with_data_type(DataType::Float64)
+            .with_nullable(nullable),
+        (
+            DataType::Timestamp(left_unit, left_timezone),
+            DataType::Timestamp(right_unit, right_timezone),
+        ) if left_timezone == right_timezone => left
+            .clone()
+            .with_data_type(DataType::Timestamp(
+                finer_timestamp_unit(left_unit, right_unit),
+                left_timezone.clone(),
+            ))
+            .with_nullable(nullable),
+        _ => return Err(csv_schema_mismatch(input)),
+    };
+    Ok(field)
+}
+
+fn finer_timestamp_unit(left: &TimeUnit, right: &TimeUnit) -> TimeUnit {
+    match (left, right) {
+        (TimeUnit::Nanosecond, _) | (_, TimeUnit::Nanosecond) => TimeUnit::Nanosecond,
+        (TimeUnit::Microsecond, _) | (_, TimeUnit::Microsecond) => TimeUnit::Microsecond,
+        (TimeUnit::Millisecond, _) | (_, TimeUnit::Millisecond) => TimeUnit::Millisecond,
+        _ => TimeUnit::Second,
+    }
+}
+
+fn csv_schema_mismatch(input: &Path) -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!(
+            "{} has a schema that is incompatible with the other CSV inputs",
+            fmt::safe_path(input)
+        ),
+    )
+}
+
+fn apply_required_fields(schema: Schema, required_fields: &[String]) -> std::io::Result<Schema> {
+    if required_fields.is_empty() {
+        return Ok(schema);
+    }
+    let schema_names: std::collections::HashSet<&str> = schema
+        .fields()
+        .iter()
+        .map(|field| field.name().as_str())
+        .collect();
+    let mut required = std::collections::HashSet::with_capacity(required_fields.len());
+    for name in required_fields {
+        if name.is_empty() {
+            return Err(invalid_schema("--require field name cannot be empty"));
+        }
+        if !schema_names.contains(name.as_str()) {
+            return Err(invalid_schema(format!(
+                "--require column '{}' not found in schema",
+                fmt::safe(name)
+            )));
+        }
+        required.insert(name.as_str());
+    }
+    let fields: Vec<Field> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let field = field.as_ref().clone();
+            if required.contains(field.name().as_str()) {
+                field.with_nullable(false)
+            } else {
+                field
+            }
+        })
+        .collect();
+    Ok(Schema::new_with_metadata(fields, schema.metadata().clone()))
+}
+
+fn invalid_schema(msg: impl Into<String>) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, msg.into())
 }
 
 fn cat(
@@ -745,8 +2607,8 @@ fn dictionary(file: &Path, column: &str, json: bool) -> std::io::Result<()> {
             )
         })?;
     // For nested columns the first physical slot is the ARRAY/MAP length column,
-    // not the logical values — its dictionary would mislead. parquet-cli only
-    // resolves primitive leaves, so reject List/Map here rather than print junk.
+    // not the logical values — its dictionary would mislead. Only primitive
+    // leaves have a meaningful one, so reject List/Map rather than print junk.
     use arrow::datatypes::DataType;
     if matches!(
         reader.schema().columns[col].data_type,
@@ -828,4 +2690,368 @@ fn buckets(file: &Path, json: bool) -> std::io::Result<()> {
         println!("{}", jsonout::line(&jsonout::Buckets { row_groups: rgs }));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod install_tests {
+    use super::*;
+
+    #[test]
+    fn lossless_json_parser_rejects_out_of_range_value() {
+        let mut inexact = std::collections::BTreeSet::new();
+
+        let error =
+            parse_json_record_lossless(r#"{"value":1e400}"#, None, &mut inexact).unwrap_err();
+
+        let error = error.to_string();
+        assert!(error.contains("out of range for Float64"), "{error}");
+        assert!(inexact.is_empty());
+    }
+
+    #[test]
+    fn projected_json_parser_does_not_rescan_large_nested_subtrees() {
+        let payload = serde_json::to_string(&"x".repeat(8 << 20)).unwrap();
+        let columns = std::collections::HashSet::from(["v"]);
+        let parse_at_depth = |depth: usize| {
+            let nested = format!("{}{payload}{}", "[".repeat(depth), "]".repeat(depth));
+            let record = format!(r#"{{"v":{nested}}}"#);
+            let mut inexact = std::collections::BTreeSet::new();
+            let started = std::time::Instant::now();
+            let value = parse_json_record_lossless(&record, Some(&columns), &mut inexact).unwrap();
+            assert!(value.get("v").is_some());
+            assert!(inexact.is_empty());
+            started.elapsed()
+        };
+
+        let shallow = parse_at_depth(1);
+        let deep = parse_at_depth(96);
+        assert!(
+            deep <= shallow.saturating_mul(4) + std::time::Duration::from_millis(500),
+            "projected parse scaled with depth: shallow={shallow:?}, deep={deep:?}"
+        );
+    }
+
+    #[test]
+    fn json_number_scanner_records_nested_inexact_integer_paths() {
+        let mut inexact = std::collections::BTreeSet::new();
+        let mut inexact_index = JsonNumberPathTrie::default();
+
+        for _ in 0..2 {
+            scan_json_numbers(
+                r#"{"integer":9007199254740993,"nested":[1.5,9007199254740993]}"#,
+                &mut inexact,
+                &mut inexact_index,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            inexact,
+            std::collections::BTreeSet::from([
+                vec![JsonNumberPathSegment::Field("integer".to_string())],
+                vec![
+                    JsonNumberPathSegment::Field("nested".to_string()),
+                    JsonNumberPathSegment::Element,
+                ],
+            ])
+        );
+    }
+
+    #[test]
+    fn json_value_fast_gate_only_scans_large_numbers() {
+        let common =
+            serde_json::from_str::<Value>(r#"{"id":9007199254740992,"v":1.5,"s":"1e400"}"#)
+                .unwrap();
+        let large_integer = serde_json::from_str::<Value>(r#"{"id":9007199254740993}"#).unwrap();
+        let negative_out_of_i64 =
+            serde_json::from_str::<Value>(r#"{"id":-9223372036854775809}"#).unwrap();
+        let large_float = serde_json::from_str::<Value>(r#"{"value":1e308}"#).unwrap();
+
+        assert!(!json_value_might_need_lossless_numbers(&common));
+        assert!(json_value_might_need_lossless_numbers(&large_integer));
+        assert!(json_value_might_need_lossless_numbers(&negative_out_of_i64));
+        assert!(json_value_might_need_lossless_numbers(&large_float));
+    }
+
+    #[test]
+    fn csv_layout_inspection_rewinds_reader_after_skip_lines() {
+        let options = CsvConvertOptions {
+            delimiter: ",".to_string(),
+            escape: None,
+            quote: "\"".to_string(),
+            no_header: false,
+            header: None,
+            skip_lines: 1,
+        };
+        let format = csv_format(&options).unwrap();
+        let reader = std::io::BufReader::new(std::io::Cursor::new(
+            b"ignored preamble\nid,name\n1,alice\n2,bob\n".to_vec(),
+        ));
+
+        let schema = inspect_csv_input(reader, &options, &format)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "id");
+        assert_eq!(schema.field(1).name(), "name");
+    }
+
+    #[test]
+    fn inexact_json_path_only_matches_float64_schema_fields() {
+        let schema = Schema::new(vec![
+            Field::new("integer", DataType::Int64, true),
+            Field::new("float", DataType::Float64, true),
+        ]);
+        let inexact = std::collections::BTreeSet::from([
+            vec![JsonNumberPathSegment::Field("integer".to_string())],
+            vec![JsonNumberPathSegment::Field("float".to_string())],
+        ]);
+
+        let path = find_inexact_f64_path(&schema, &inexact).unwrap();
+
+        assert_eq!(format_json_number_path(path), "float");
+    }
+
+    #[test]
+    fn inexact_json_path_traverses_nested_structs_and_lists() {
+        let schema = Schema::new(vec![Field::new(
+            "payload",
+            DataType::Struct(
+                vec![
+                    Field::new(
+                        "integers",
+                        DataType::List(Arc::new(Field::new("item", DataType::Int64, true))),
+                        true,
+                    ),
+                    Field::new(
+                        "floats",
+                        DataType::List(Arc::new(Field::new("item", DataType::Float64, true))),
+                        true,
+                    ),
+                ]
+                .into(),
+            ),
+            true,
+        )]);
+        let inexact = std::collections::BTreeSet::from([
+            vec![
+                JsonNumberPathSegment::Field("payload".to_string()),
+                JsonNumberPathSegment::Field("integers".to_string()),
+                JsonNumberPathSegment::Element,
+            ],
+            vec![
+                JsonNumberPathSegment::Field("payload".to_string()),
+                JsonNumberPathSegment::Field("floats".to_string()),
+                JsonNumberPathSegment::Element,
+            ],
+        ]);
+
+        let path = find_inexact_f64_path(&schema, &inexact).unwrap();
+
+        assert_eq!(format_json_number_path(path), "payload.floats[]");
+    }
+
+    #[test]
+    fn no_replace_install_falls_back_when_hard_links_are_unsupported() {
+        let dir = std::env::temp_dir().join(format!(
+            "mosaic_install_fallback_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let tmp = dir.join("out.tmp");
+        let out = dir.join("out.mosaic");
+        std::fs::write(&tmp, b"complete").unwrap();
+
+        let outcome = install_mosaic_output_no_replace(
+            &tmp,
+            &out,
+            |_, _| {
+                // Linux VFAT reports EPERM (PermissionDenied) for hard links.
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "hard links unsupported",
+                ))
+            },
+            rename_no_replace,
+            |path| std::fs::remove_file(path),
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, InstallOutcome::Clean));
+        assert_eq!(std::fs::read(&out).unwrap(), b"complete");
+        assert!(!tmp.exists());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        windows
+    ))]
+    #[test]
+    fn no_replace_fallback_preserves_an_existing_output() {
+        let dir = std::env::temp_dir().join(format!(
+            "mosaic_install_no_clobber_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let tmp = dir.join("out.tmp");
+        let out = dir.join("out.mosaic");
+        std::fs::write(&tmp, b"complete").unwrap();
+        std::fs::write(&out, b"sentinel").unwrap();
+
+        let error = install_mosaic_output_no_replace(
+            &tmp,
+            &out,
+            |_, _| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "hard links unsupported",
+                ))
+            },
+            rename_no_replace,
+            |path| std::fs::remove_file(path),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(&out).unwrap(), b"sentinel");
+        assert_eq!(std::fs::read(&tmp).unwrap(), b"complete");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn no_replace_install_succeeds_after_output_commit_when_temp_cleanup_fails() {
+        let dir = std::env::temp_dir().join(format!(
+            "mosaic_install_cleanup_failure_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let tmp = dir.join("out.tmp");
+        let out = dir.join("out.mosaic");
+        std::fs::write(&tmp, b"complete").unwrap();
+
+        let outcome = install_mosaic_output_no_replace(
+            &tmp,
+            &out,
+            |from, to| std::fs::hard_link(from, to),
+            |_, _| panic!("hard-link success must not fall back to rename"),
+            |_| Err(std::io::Error::from_raw_os_error(libc::EIO)),
+        )
+        .unwrap();
+
+        let InstallOutcome::CommittedWithCleanupError(error) = outcome else {
+            panic!("expected committed output with cleanup error");
+        };
+        assert_eq!(error.raw_os_error(), Some(libc::EIO));
+        assert_eq!(std::fs::read(&out).unwrap(), b"complete");
+        assert!(tmp.exists());
+        std::fs::remove_file(&tmp).unwrap();
+        std::fs::remove_file(&out).unwrap();
+        std::fs::remove_dir(&dir).unwrap();
+    }
+
+    #[test]
+    fn csv_replay_rejects_truncated_rows() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+        let format = arrow::csv::reader::Format::default().with_header(true);
+        let mut reader = build_csv_replay_reader(
+            schema,
+            format,
+            vec![0, 1],
+            2,
+            std::io::Cursor::new(b"a,b\n1\n"),
+        )
+        .unwrap();
+
+        let error = reader.next().unwrap().unwrap_err();
+        assert!(error.to_string().contains("expected 2 got 1"), "{error}");
+    }
+
+    #[test]
+    fn csv_replay_batch_size_bounds_wide_batches() {
+        assert_eq!(csv_replay_batch_size(0), DEFAULT_CSV_BATCH_SIZE);
+        assert_eq!(csv_replay_batch_size(1), DEFAULT_CSV_BATCH_SIZE);
+        assert_eq!(csv_replay_batch_size(1024), 1024);
+        assert_eq!(csv_replay_batch_size(16_384), 64);
+        assert_eq!(csv_replay_batch_size(CSV_REPLAY_CELL_BUDGET * 2), 1);
+    }
+
+    #[test]
+    fn csv_replay_batch_size_uses_final_union_width() {
+        let schema = Schema::new(vec![Field::new("only", DataType::Int64, true)]);
+        let format = arrow::csv::reader::Format::default().with_header(true);
+        let rows = (0..100)
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let input = format!("only\n{rows}\n");
+        let mut reader =
+            build_csv_replay_reader(schema, format, vec![0], 65_536, std::io::Cursor::new(input))
+                .unwrap();
+
+        assert_eq!(reader.next().unwrap().unwrap().num_rows(), 16);
+    }
+
+    #[test]
+    fn csv_alignment_moves_and_converts_columns_without_changing_values() {
+        use arrow::array::{Array, Float64Array, Int64Array};
+
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("field_0", DataType::Utf8, true),
+            Field::new("field_1", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            source_schema,
+            vec![
+                Arc::new(StringArray::from(vec!["1.5", "2.0"])),
+                Arc::new(Int64Array::from(vec![1, 2])),
+            ],
+        )
+        .unwrap();
+        let output_schema = Schema::new(vec![
+            Field::new("value", DataType::Float64, true),
+            Field::new("id", DataType::Int64, true),
+            Field::new("missing", DataType::Utf8, true),
+        ]);
+
+        let aligned = align_csv_batch_to_schema(
+            batch,
+            &output_schema,
+            &[Some(0), Some(1), None],
+            Path::new("input.csv"),
+        )
+        .unwrap();
+
+        let values = aligned
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let ids = aligned
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(values.values(), &[1.5, 2.0]);
+        assert_eq!(ids.values(), &[1, 2]);
+        assert_eq!(aligned.column(2).null_count(), 2);
+    }
 }

--- a/cli/tests/e2e.rs
+++ b/cli/tests/e2e.rs
@@ -21,7 +21,9 @@
 use std::process::Command;
 use std::sync::Arc;
 
-use arrow::array::{BooleanArray, Float32Array, Int32Array, RecordBatch, StringArray};
+use arrow::array::{
+    BooleanArray, Date32Array, Float32Array, Int32Array, Int64Array, RecordBatch, StringArray,
+};
 use arrow::datatypes::{DataType, Field, Schema};
 use paimon_mosaic_core::writer::{FileSink, MosaicWriter, WriterOptions};
 
@@ -79,6 +81,31 @@ fn run(args: &[&str]) -> (String, String, bool) {
         String::from_utf8(out.stderr).unwrap(),
         out.status.success(),
     )
+}
+
+fn sibling_temp_exists(dir: &std::path::Path, output_name: &str) -> bool {
+    let prefix = format!("{output_name}.");
+    std::fs::read_dir(dir).unwrap().any(|entry| {
+        let name = entry.unwrap().file_name();
+        let name = name.to_string_lossy();
+        name.starts_with(&prefix) && name.ends_with(".tmp")
+    })
+}
+
+fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "mosaic_e2e_{name}_{}_{}",
+        std::process::id(),
+        nonce
+    ));
+    std::fs::create_dir(&dir).unwrap();
+    dir
 }
 
 #[test]
@@ -284,6 +311,65 @@ fn fixture_f32(name: &str) -> String {
     path
 }
 
+fn fixture_i64(name: &str) -> String {
+    let path = format!(
+        "{}/mosaic_e2e_{}.mosaic",
+        std::env::temp_dir().display(),
+        name
+    );
+    let schema = Schema::new(vec![Field::new("id", DataType::Int64, false)]);
+    let out = FileSink::create(std::path::Path::new(&path)).unwrap();
+    let mut w = MosaicWriter::new(
+        out,
+        &schema,
+        WriterOptions {
+            num_buckets: 1,
+            stats_columns: vec!["id".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(Int64Array::from(vec![
+            1_700_000_000_000_000_001i64,
+            1_700_000_000_000_000_003i64,
+        ]))],
+    )
+    .unwrap();
+    w.write_batch(&batch).unwrap();
+    w.close().unwrap();
+    path
+}
+
+fn fixture_date32(name: &str) -> String {
+    let path = format!(
+        "{}/mosaic_e2e_{}.mosaic",
+        std::env::temp_dir().display(),
+        name
+    );
+    let schema = Schema::new(vec![Field::new("d", DataType::Date32, false)]);
+    let out = FileSink::create(std::path::Path::new(&path)).unwrap();
+    let mut w = MosaicWriter::new(
+        out,
+        &schema,
+        WriterOptions {
+            num_buckets: 1,
+            stats_columns: vec!["d".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(Date32Array::from(vec![18_262, 18_628]))],
+    )
+    .unwrap();
+    w.write_batch(&batch).unwrap();
+    w.close().unwrap();
+    path
+}
+
 #[test]
 fn cat_where_float32_precision() {
     let f = fixture_f32("wheref32");
@@ -297,12 +383,646 @@ fn convert_csv_then_inspect() {
     let csv = format!("{}/mosaic_e2e_in.csv", std::env::temp_dir().display());
     std::fs::write(&csv, "id,kind,score\n1,a,10.5\n2,b,20\n3,a,30.5\n").unwrap();
     let out = format!("{}/mosaic_e2e_conv.mosaic", std::env::temp_dir().display());
-    let (msg, _, ok) = run(&["convert", &csv, "-o", &out, "--stats", "id", "--overwrite"]);
+    let (msg, _, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
     assert!(ok && msg.contains("3 rows"));
     let (c, _, _) = run(&["count", &out]);
     assert_eq!(c.trim(), "3");
     let (s, _, _) = run(&["schema", &out]);
     assert!(s.contains("id:") && s.contains("score:")); // inferred schema
+}
+
+#[test]
+fn convert_csv_keeps_out_long_option_alias() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_convert_csv_out_alias.csv", dir.display());
+    std::fs::write(&csv, "id\n1\n").unwrap();
+    let out = format!("{}/mosaic_e2e_convert_csv_out_alias.mosaic", dir.display());
+    let _ = std::fs::remove_file(&out);
+    let (msg, err, ok) = run(&["convert-csv", &csv, "--out", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (count, err, ok) = run(&["count", &out]);
+    assert!(ok, "stdout: {count}\nstderr: {err}");
+    assert_eq!(count.trim(), "1");
+}
+
+#[test]
+fn convert_csv_help_requires_at_least_one_input() {
+    let (help, err, ok) = run(&["convert-csv", "--help"]);
+    assert!(ok, "stdout: {help}\nstderr: {err}");
+    assert!(help.contains("<INPUTS>..."), "{help}");
+    assert!(!help.contains("[INPUTS]..."), "{help}");
+}
+
+#[test]
+fn convert_csv_applies_dialect_flags() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_csv_dialect.csv", dir.display());
+    std::fs::write(&csv, "ignored preamble\nid|name\n1|'a\\'b'\n").unwrap();
+    let out = format!("{}/mosaic_e2e_csv_dialect.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--delimiter",
+        "|",
+        "--quote",
+        "'",
+        "--escape",
+        "\\",
+        "--skip-lines",
+        "1",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"id\":1,\"name\":\"a'b\"}\n");
+}
+
+#[test]
+fn convert_csv_skip_lines_discards_non_utf8_preamble() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_csv_non_utf8_preamble.csv", dir.display());
+    std::fs::write(&csv, b"\xff\nid,name\n1,ok\n").unwrap();
+    let out = format!("{}/mosaic_e2e_csv_non_utf8_preamble.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--skip-lines",
+        "1",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"id\":1,\"name\":\"ok\"}\n");
+}
+
+#[test]
+fn convert_csv_preserves_backslashes_by_default() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_backslashes.csv", dir.display());
+    std::fs::write(
+        &csv,
+        r#"path
+"C:\temp\file"
+"#,
+    )
+    .unwrap();
+    let out = format!("{}/mosaic_e2e_backslashes.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"path\":\"C:\\\\temp\\\\file\"}\n");
+}
+
+#[test]
+fn convert_csv_promotes_ints_and_floats_without_rounding_integers() {
+    let dir = std::env::temp_dir();
+    let ints = format!("{}/mosaic_e2e_multi_numeric_ints.csv", dir.display());
+    let floats = format!("{}/mosaic_e2e_multi_numeric_floats.csv", dir.display());
+    std::fs::write(&ints, "value\n1\n9007199254740992\n").unwrap();
+    std::fs::write(&floats, "value\n3.5\n4.5\n").unwrap();
+    let out = format!("{}/mosaic_e2e_multi_numeric.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &ints, &floats, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (schema, _, ok) = run(&["schema", &out]);
+    assert!(ok && schema.contains("value: Float64"), "{schema}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert_eq!(
+        rows.lines().collect::<Vec<_>>(),
+        [
+            r#"{"value":1.0}"#,
+            r#"{"value":9.007199254740992e15}"#,
+            r#"{"value":3.5}"#,
+            r#"{"value":4.5}"#
+        ]
+    );
+}
+
+#[test]
+fn convert_csv_rejects_lossy_bare_integer_float_promotion() {
+    let dir = std::env::temp_dir();
+    for (case, integer) in [
+        ("f64_boundary", "9007199254740993"),
+        ("i64_max", "9223372036854775807"),
+    ] {
+        let ints = format!("{}/mosaic_e2e_lossy_{case}_integer.csv", dir.display());
+        let floats = format!("{}/mosaic_e2e_lossy_{case}_float.csv", dir.display());
+        std::fs::write(&ints, format!("value\n{integer}\n")).unwrap();
+        std::fs::write(&floats, "value\n1.5\n").unwrap();
+        for (order, first, second) in [
+            ("integer_first", ints.as_str(), floats.as_str()),
+            ("float_first", floats.as_str(), ints.as_str()),
+        ] {
+            let out = format!("{}/mosaic_e2e_lossy_{case}_{order}.mosaic", dir.display());
+            let _ = std::fs::remove_file(&out);
+            let (_, err, ok) = run(&["convert-csv", first, second, "-o", &out, "--overwrite"]);
+            assert!(!ok, "{case}/{order} unexpectedly succeeded");
+            assert!(
+                err.contains("cannot be represented exactly as Float64"),
+                "{case}/{order}: {err}"
+            );
+            assert!(!std::path::Path::new(&out).exists(), "{case}/{order}");
+        }
+    }
+}
+
+#[test]
+fn convert_csv_rejects_finite_float_overflow() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_float_overflow.csv", dir.display());
+    std::fs::write(&csv, "value\n1.5\n1e400\n").unwrap();
+    let out = format!("{}/mosaic_e2e_float_overflow.mosaic", dir.display());
+    let _ = std::fs::remove_file(&out);
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!std::path::Path::new(&out).exists());
+}
+
+#[test]
+fn convert_csv_rejects_non_finite_float_values() {
+    let dir = std::env::temp_dir();
+    for (case, value) in [("nan", "NaN"), ("infinity", "inf")] {
+        let csv = format!("{}/mosaic_e2e_non_finite_{case}.csv", dir.display());
+        std::fs::write(&csv, format!("value\n{value}\n1.5\n")).unwrap();
+        let out = format!("{}/mosaic_e2e_non_finite_{case}.mosaic", dir.display());
+        let _ = std::fs::remove_file(&out);
+        let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out]);
+        assert!(!ok, "{case} unexpectedly succeeded");
+        assert!(err.contains("non-finite Float64"), "{case}: {err}");
+        assert!(!std::path::Path::new(&out).exists(), "{case}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn convert_csv_numeric_errors_sanitize_input_path() {
+    let dir = unique_temp_dir("csv_safe_input_path");
+    let csv = dir.join("bad\x1b]0;owned\x07.csv");
+    std::fs::write(&csv, "value\n1.5\n1e400\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert-csv",
+        csv.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!err.contains('\x1b'), "{err:?}");
+    assert!(!err.contains('\x07'), "{err:?}");
+}
+
+#[test]
+fn convert_csv_preserves_inferred_timestamp_precision() {
+    let dir = std::env::temp_dir();
+    let seconds = format!("{}/mosaic_e2e_timestamp_seconds.csv", dir.display());
+    let nanos = format!("{}/mosaic_e2e_timestamp_nanos.csv", dir.display());
+    std::fs::write(&seconds, "ts\n2026-08-20T12:34:56\n").unwrap();
+    std::fs::write(&nanos, "ts\n2026-08-20T12:34:56.123456789\n").unwrap();
+    let out = format!("{}/mosaic_e2e_timestamp_precision.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &seconds, &nanos, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (schema, _, ok) = run(&["schema", &out]);
+    assert!(
+        ok && schema.contains("ts: Timestamp(Nanosecond, None)"),
+        "{schema}"
+    );
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert_eq!(
+        rows.lines().collect::<Vec<_>>(),
+        [
+            r#"{"ts":"2026-08-20T12:34:56"}"#,
+            r#"{"ts":"2026-08-20T12:34:56.123456789"}"#
+        ]
+    );
+}
+
+#[test]
+fn convert_csv_rejects_offsets_for_inferred_local_timestamps() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_timestamp_offset.csv", dir.display());
+    std::fs::write(&csv, "ts\n2026-08-20T12:34:56+08:00\n").unwrap();
+    let out = format!("{}/mosaic_e2e_timestamp_offset.mosaic", dir.display());
+    let _ = std::fs::remove_file(&out);
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("must not include a timezone"), "{err}");
+    assert!(!std::path::Path::new(&out).exists());
+}
+
+#[test]
+fn convert_csv_matches_multi_input_fields_by_name() {
+    let dir = std::env::temp_dir();
+    let first = format!("{}/mosaic_e2e_multi_order_first.csv", dir.display());
+    let reordered = format!("{}/mosaic_e2e_multi_order_reordered.csv", dir.display());
+    std::fs::write(&first, "id,kind\n1,a\n").unwrap();
+    std::fs::write(&reordered, "kind,id\nb,2\n").unwrap();
+    let out = format!("{}/mosaic_e2e_multi_order.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &first, &reordered, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert!(rows.contains(r#"{"id":1,"kind":"a"}"#), "{rows}");
+    assert!(rows.contains(r#"{"id":2,"kind":"b"}"#), "{rows}");
+}
+
+#[test]
+fn convert_csv_unions_missing_fields_by_name() {
+    let dir = unique_temp_dir("csv_union_missing_fields");
+    let first = dir.join("first.csv");
+    let second = dir.join("second.csv");
+    let out = dir.join("out.mosaic");
+    std::fs::write(&first, "id,left\n1,a\n").unwrap();
+    std::fs::write(&second, "id,right\n2,b\n").unwrap();
+
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        first.to_str().unwrap(),
+        second.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+
+    let (rows, err, ok) = run(&["cat", out.to_str().unwrap(), "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(
+        rows.lines().collect::<Vec<_>>(),
+        [
+            r#"{"id":1,"left":"a","right":null}"#,
+            r#"{"id":2,"left":null,"right":"b"}"#
+        ]
+    );
+}
+
+#[test]
+fn convert_csv_custom_header_preserves_first_data_row() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_custom_header.csv", dir.display());
+    std::fs::write(&csv, "1,a\n2,b\n").unwrap();
+    let out = format!("{}/mosaic_e2e_custom_header.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--header",
+        "id,kind",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert_eq!(
+        rows.lines().collect::<Vec<_>>(),
+        [r#"{"id":1,"kind":"a"}"#, r#"{"id":2,"kind":"b"}"#]
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn convert_csv_rejects_non_regular_inferred_input_without_opening_it() {
+    let dir = std::env::temp_dir();
+    let fifo = format!("{}/mosaic_e2e_inferred_fifo.csv", dir.display());
+    let out = format!("{}/mosaic_e2e_inferred_fifo.mosaic", dir.display());
+    let _ = std::fs::remove_file(&fifo);
+    let _ = std::fs::remove_file(&out);
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .unwrap()
+        .success());
+    let output = std::process::Command::new("timeout")
+        .args([
+            "5",
+            env!("CARGO_BIN_EXE_mosaic"),
+            "convert-csv",
+            &fifo,
+            "-o",
+            &out,
+            "--overwrite",
+        ])
+        .output()
+        .unwrap();
+    let _ = std::fs::remove_file(&fifo);
+    assert_ne!(
+        output.status.code(),
+        Some(124),
+        "conversion blocked on FIFO"
+    );
+    let err = String::from_utf8_lossy(&output.stderr);
+    assert!(err.contains("requires a regular file"), "{err}");
+    assert!(!std::path::Path::new(&out).exists());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn convert_json_projection_rejects_non_regular_input_without_opening_it() {
+    let dir = unique_temp_dir("json_projection_fifo");
+    let fifo = dir.join("input.jsonl");
+    let out = dir.join("out.mosaic");
+    assert!(std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .unwrap()
+        .success());
+    let output = std::process::Command::new("timeout")
+        .args([
+            "5",
+            env!("CARGO_BIN_EXE_mosaic"),
+            "convert",
+            fifo.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+            "-c",
+            "id",
+        ])
+        .output()
+        .unwrap();
+    assert_ne!(
+        output.status.code(),
+        Some(124),
+        "conversion blocked on FIFO"
+    );
+    let err = String::from_utf8_lossy(&output.stderr);
+    assert!(err.contains("requires a regular file"), "{err}");
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_csv_all_null_column_falls_back_to_utf8() {
+    let csv = format!(
+        "{}/mosaic_e2e_all_null_col.csv",
+        std::env::temp_dir().display()
+    );
+    std::fs::write(&csv, "id,empty\n1,\n2,\n").unwrap();
+    let out = format!(
+        "{}/mosaic_e2e_all_null_col.mosaic",
+        std::env::temp_dir().display()
+    );
+    let (msg, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (s, _, _) = run(&["schema", &out]);
+    assert!(s.contains("empty: Utf8"), "{s}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert!(
+        rows.lines().all(|line| line.contains("\"empty\":null")),
+        "{rows}"
+    );
+}
+
+#[test]
+fn convert_csv_rejects_empty_header_field() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_empty_header_field.csv", dir.display());
+    std::fs::write(&csv, ",id\nx,1\n").unwrap();
+    let out = format!("{}/mosaic_e2e_empty_header_field.mosaic", dir.display());
+    let _ = std::fs::remove_file(&out);
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("empty column name"), "{err}");
+    assert!(!std::path::Path::new(&out).exists());
+}
+
+#[test]
+fn convert_csv_errors_on_duplicate_header_field() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_duplicate_header.csv", dir.display());
+    std::fs::write(&csv, "id,id\n1,2\n3,4\n").unwrap();
+    let out = format!("{}/mosaic_e2e_duplicate_header.mosaic", dir.display());
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("duplicate CSV header field 'id'"), "{err}");
+}
+
+#[test]
+fn convert_csv_require_marks_inferred_field_not_null() {
+    let csv = format!("{}/mosaic_e2e_require.csv", std::env::temp_dir().display());
+    std::fs::write(&csv, "id,name\n1,a\n2,b\n").unwrap();
+    let out = format!(
+        "{}/mosaic_e2e_require.mosaic",
+        std::env::temp_dir().display()
+    );
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--require",
+        "id",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (s, _, _) = run(&["schema", &out]);
+    assert!(s.contains("id: Int64 not null"), "{s}");
+    assert!(s.contains("name: Utf8"), "{s}");
+}
+
+#[test]
+fn convert_csv_stats_enables_where_pushdown() {
+    // stats on id let id>100 skip the row group; boundaries must not drop matches.
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_csv_stats.csv", dir.display());
+    std::fs::write(&csv, "id,kind\n1,a\n2,b\n3,a\n").unwrap();
+    let out = format!("{}/mosaic_e2e_csv_stats.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--stats",
+        "id",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (meta, err, ok) = run(&["meta", &out, "--json"]);
+    assert!(ok, "stdout: {meta}\nstderr: {err}");
+    let meta: serde_json::Value = serde_json::from_str(meta.trim()).unwrap();
+    let stats = &meta["row_groups"][0]["stats"][0];
+    assert_eq!(stats["column"], "id");
+    assert_eq!(stats["min"], "1");
+    assert_eq!(stats["max"], "3");
+    let (none, _, _) = run(&["cat", &out, "--where", "id>100"]);
+    assert!(none.contains("(no rows)"), "{none}");
+    let (keep, _, _) = run(&["cat", &out, "--where", "id>=3", "--json"]);
+    assert_eq!(keep.lines().count(), 1, "{keep}");
+}
+
+#[test]
+fn convert_json_supports_stats() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_json_stats.json", dir.display());
+    std::fs::write(&js, "{\"id\":1}\n{\"id\":2}\n").unwrap();
+    let out = format!("{}/mosaic_e2e_json_stats.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "--stats", "id", "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (meta, err, ok) = run(&["meta", &out, "--json"]);
+    assert!(ok, "stdout: {meta}\nstderr: {err}");
+    let meta: serde_json::Value = serde_json::from_str(meta.trim()).unwrap();
+    let stats = &meta["row_groups"][0]["stats"][0];
+    assert_eq!(stats["column"], "id");
+    assert_eq!(stats["min"], "1");
+    assert_eq!(stats["max"], "2");
+    let (none, _, _) = run(&["cat", &out, "--where", "id>100"]);
+    assert!(none.contains("(no rows)"), "{none}");
+}
+
+#[test]
+fn convert_csv_multiple_inputs_share_schema() {
+    let dir = std::env::temp_dir();
+    let a = format!("{}/mosaic_e2e_multi_a.csv", dir.display());
+    let b = format!("{}/mosaic_e2e_multi_b.csv", dir.display());
+    std::fs::write(&a, "id,kind\n1,a\n2,b\n").unwrap();
+    std::fs::write(&b, "id,kind\n3,c\n").unwrap();
+    let out = format!("{}/mosaic_e2e_multi.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &a, &b, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (c, _, _) = run(&["count", &out]);
+    assert_eq!(c.trim(), "3");
+    // A file whose inferred schema differs must be rejected with a hint.
+    let c_path = format!("{}/mosaic_e2e_multi_c.csv", dir.display());
+    std::fs::write(&c_path, "id,kind\nx,y\n").unwrap();
+    let (_, err, ok) = run(&["convert-csv", &a, &c_path, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("incompatible"), "{err}");
+}
+
+#[test]
+fn convert_csv_multiple_inputs_merges_null_and_typed_columns() {
+    let dir = std::env::temp_dir();
+    let a = format!("{}/mosaic_e2e_multi_null_a.csv", dir.display());
+    let b = format!("{}/mosaic_e2e_multi_null_b.csv", dir.display());
+    std::fs::write(&a, "id,value\n1,\n2,\n").unwrap();
+    std::fs::write(&b, "id,value\n3,9\n4,10\n").unwrap();
+    let out = format!("{}/mosaic_e2e_multi_null.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &a, &b, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (schema, _, ok) = run(&["schema", &out]);
+    assert!(ok, "{schema}");
+    assert!(schema.contains("value: Int64"), "{schema}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert!(rows.contains(r#"{"id":1,"value":null}"#), "{rows}");
+    assert!(rows.contains(r#"{"id":4,"value":10}"#), "{rows}");
+}
+
+#[test]
+fn convert_csv_skips_empty_inputs_and_rejects_all_empty() {
+    let dir = std::env::temp_dir();
+    let a = format!("{}/mosaic_e2e_empty_shard_a.csv", dir.display());
+    let empty = format!("{}/mosaic_e2e_empty_shard_b.csv", dir.display());
+    std::fs::write(&a, "id,kind\n1,a\n2,b\n").unwrap();
+    std::fs::write(&empty, "").unwrap();
+    let out = format!("{}/mosaic_e2e_empty_shard.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert-csv", &a, &empty, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (c, _, _) = run(&["count", &out]);
+    assert_eq!(c.trim(), "2");
+    let (_, err, ok) = run(&["convert-csv", &empty, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("no CSV data"), "{err}");
+}
+
+#[test]
+fn convert_csv_skips_header_only_inputs() {
+    let dir = std::env::temp_dir();
+    let header_only = format!("{}/mosaic_e2e_header_only_shard_a.csv", dir.display());
+    let data = format!("{}/mosaic_e2e_header_only_shard_b.csv", dir.display());
+    std::fs::write(&header_only, "id,kind\n").unwrap();
+    std::fs::write(&data, "id,kind\n1,a\n2,b\n").unwrap();
+    let out = format!("{}/mosaic_e2e_header_only_shard.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &header_only,
+        &data,
+        "-o",
+        &out,
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (c, _, _) = run(&["count", &out]);
+    assert_eq!(c.trim(), "2");
+}
+
+#[test]
+fn convert_csv_skips_header_only_inputs_with_unrelated_or_duplicate_headers() {
+    let dir = std::env::temp_dir();
+    let unrelated = format!("{}/mosaic_e2e_header_only_unrelated.csv", dir.display());
+    let duplicate = format!("{}/mosaic_e2e_header_only_duplicate.csv", dir.display());
+    let data = format!("{}/mosaic_e2e_header_only_data.csv", dir.display());
+    std::fs::write(&unrelated, "other,value\n").unwrap();
+    std::fs::write(&duplicate, "id,id\n").unwrap();
+    std::fs::write(&data, "id,kind\n1,a\n2,b\n").unwrap();
+    let out = format!("{}/mosaic_e2e_header_only_extra.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &unrelated,
+        &duplicate,
+        &data,
+        "-o",
+        &out,
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert_eq!(rows.lines().count(), 2, "{rows}");
+}
+
+#[test]
+fn convert_csv_not_null_violation_names_the_schema_field() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_null_violation.csv", dir.display());
+    std::fs::write(&csv, "id,name\n1,a\n,b\n").unwrap();
+    let out = format!("{}/mosaic_e2e_null_violation.mosaic", dir.display());
+    let (_, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--require",
+        "id",
+        "--overwrite",
+    ]);
+    assert!(!ok);
+    assert!(err.contains("'id'") && !err.contains("field_0"), "{err}");
+}
+
+#[test]
+fn convert_csv_no_header_maps_fields_by_position() {
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_no_header.csv", dir.display());
+    std::fs::write(&csv, "1,a\n2,b\n").unwrap();
+    let out = format!("{}/mosaic_e2e_no_header.mosaic", dir.display());
+    let (msg, err, ok) = run(&[
+        "convert-csv",
+        &csv,
+        "-o",
+        &out,
+        "--no-header",
+        "--overwrite",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (s, _, _) = run(&["schema", &out]);
+    assert!(s.contains("field_0: Int64"), "{s}");
+    assert!(s.contains("field_1: Utf8"), "{s}");
 }
 
 #[test]
@@ -317,15 +1037,334 @@ fn convert_refuses_existing_output_without_overwrite() {
         std::env::temp_dir().display()
     );
     std::fs::write(&out, "keep me").unwrap();
-    let (_, err, ok) = run(&["convert", &csv, "-o", &out]);
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", &out]);
     assert!(!ok);
     assert!(err.contains("use --overwrite"), "{err}");
     assert_eq!(std::fs::read_to_string(&out).unwrap(), "keep me");
 }
 
+#[cfg(unix)]
+#[test]
+fn convert_refuses_dangling_symlink_output_without_overwrite() {
+    use std::os::unix::fs::symlink;
+
+    let dir = std::env::temp_dir();
+    let csv = format!("{}/mosaic_e2e_dangling_output.csv", dir.display());
+    std::fs::write(&csv, "id\n1\n").unwrap();
+    let target = dir.join("mosaic_e2e_dangling_output_missing_target");
+    let out = dir.join("mosaic_e2e_dangling_output.mosaic");
+    let _ = std::fs::remove_file(&out);
+    symlink(&target, &out).unwrap();
+
+    let (_, err, ok) = run(&["convert-csv", &csv, "-o", out.to_str().unwrap()]);
+    assert!(!ok);
+    assert!(err.contains("use --overwrite"), "{err}");
+    assert_eq!(std::fs::read_link(&out).unwrap(), target);
+}
+
+#[cfg(unix)]
+fn run_output_creation_race_attempt() -> bool {
+    use std::fmt::Write;
+    use std::time::{Duration, Instant};
+
+    const RACE_WINDOW_ROWS: usize = 50_000;
+    const RACE_WINDOW_PAYLOAD_BYTES: usize = 64;
+
+    let dir = unique_temp_dir("concurrent_output");
+    let csv = dir.join("input.csv");
+    let mut contents = String::from("id,payload\n");
+    let payload = "x".repeat(RACE_WINDOW_PAYLOAD_BYTES);
+    for id in 0..RACE_WINDOW_ROWS {
+        writeln!(&mut contents, "{id},{payload}").unwrap();
+    }
+    std::fs::write(&csv, contents).unwrap();
+    let out = dir.join("out.mosaic");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mosaic"))
+        .args([
+            "convert-csv",
+            csv.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if sibling_temp_exists(&dir, "out.mosaic") {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&out)
+            {
+                Ok(mut sentinel) => {
+                    std::io::Write::write_all(&mut sentinel, b"keep me").unwrap();
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    let output = child.wait_with_output().unwrap();
+                    assert!(
+                        output.status.success(),
+                        "stdout: {}\nstderr: {}",
+                        String::from_utf8_lossy(&output.stdout),
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                    std::fs::remove_dir_all(&dir).unwrap();
+                    return false;
+                }
+                Err(error) => panic!("cannot create competing output: {error}"),
+            }
+        }
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "conversion exited before creating its sibling temp"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for sibling temp"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        !output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("use --overwrite"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "keep me");
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+    std::fs::remove_dir_all(&dir).unwrap();
+    true
+}
+
+#[cfg(unix)]
+#[test]
+fn convert_refuses_output_created_during_conversion() {
+    assert!(
+        (0..3).any(|_| run_output_creation_race_attempt()),
+        "conversion won all attempts before the competing output could be created"
+    );
+}
+
+#[test]
+fn convert_cleans_temp_when_output_install_fails() {
+    let dir = unique_temp_dir("install_failure");
+    let csv = dir.join("input.csv");
+    std::fs::write(&csv, "id\n1\n").unwrap();
+    let out = dir.join("out.mosaic");
+    std::fs::create_dir(&out).unwrap();
+
+    let (_, err, ok) = run(&[
+        "convert-csv",
+        csv.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "--overwrite",
+    ]);
+    assert!(!ok);
+    assert!(
+        err.contains("Is a directory") || err.contains("Access is denied"),
+        "{err}"
+    );
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+#[test]
+fn convert_refuses_existing_output_before_opening_input() {
+    let dir = std::env::temp_dir();
+
+    let csv_out = format!(
+        "{}/mosaic_e2e_existing_before_input_csv.mosaic",
+        dir.display()
+    );
+    std::fs::write(&csv_out, "keep csv").unwrap();
+    let missing_csv = format!("{}/mosaic_e2e_missing_before_existing.csv", dir.display());
+    let _ = std::fs::remove_file(&missing_csv);
+    let (_, err, ok) = run(&["convert-csv", &missing_csv, "-o", &csv_out]);
+    assert!(!ok);
+    assert!(err.contains("use --overwrite"), "{err}");
+    assert_eq!(std::fs::read_to_string(&csv_out).unwrap(), "keep csv");
+
+    let json_out = format!(
+        "{}/mosaic_e2e_existing_before_input_json.mosaic",
+        dir.display()
+    );
+    std::fs::write(&json_out, "keep json").unwrap();
+    let missing_json = format!("{}/mosaic_e2e_missing_before_existing.json", dir.display());
+    let _ = std::fs::remove_file(&missing_json);
+    let (_, err, ok) = run(&["convert", &missing_json, "-o", &json_out]);
+    assert!(!ok);
+    assert!(err.contains("use --overwrite"), "{err}");
+    assert_eq!(std::fs::read_to_string(&json_out).unwrap(), "keep json");
+}
+
+#[test]
+fn convert_keeps_legacy_csv_entrypoint() {
+    let dir = unique_temp_dir("convert_legacy_csv");
+    let csv = dir.join("input.csv");
+    std::fs::write(&csv, "id\n1\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (msg, err, ok) = run(&[
+        "convert",
+        csv.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", out.to_str().unwrap(), "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"id\":1}\n");
+}
+
+#[test]
+fn convert_keeps_legacy_empty_csv_entrypoint() {
+    let dir = unique_temp_dir("convert_legacy_empty_csv");
+    let csv = dir.join("empty.csv");
+    std::fs::write(&csv, "").unwrap();
+    let out = dir.join("out.mosaic");
+
+    let (msg, err, ok) = run(&[
+        "convert",
+        csv.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+    ]);
+
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (schema, err, ok) = run(&["schema", out.to_str().unwrap()]);
+    assert!(ok, "stdout: {schema}\nstderr: {err}");
+    assert_eq!(schema, "0 columns, 1 buckets\n");
+    let (count, err, ok) = run(&["count", out.to_str().unwrap()]);
+    assert!(ok, "stdout: {count}\nstderr: {err}");
+    assert_eq!(count, "0\n");
+}
+
+#[test]
+fn convert_legacy_schema_less_nonempty_csv_still_errors() {
+    let dir = unique_temp_dir("convert_legacy_schema_less_nonempty_csv");
+    for (name, contents) in [
+        ("header-only.csv", "id,name\n"),
+        ("blank-lines.csv", "\n\n"),
+    ] {
+        let csv = dir.join(name);
+        std::fs::write(&csv, contents).unwrap();
+        let out = dir.join(format!("{name}.mosaic"));
+
+        let (_, err, ok) = run(&[
+            "convert",
+            csv.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ]);
+
+        assert!(!ok, "{name} unexpectedly succeeded");
+        assert!(!err.is_empty(), "{name} should report why inference failed");
+        assert!(!out.exists(), "{name} should not create an output");
+    }
+}
+
+#[test]
+fn convert_keeps_out_long_option_alias() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_convert_out_alias.json", dir.display());
+    std::fs::write(&js, "{\"id\":1}\n").unwrap();
+    let out = format!("{}/mosaic_e2e_convert_out_alias.mosaic", dir.display());
+    let _ = std::fs::remove_file(&out);
+    let (msg, err, ok) = run(&["convert", &js, "--out", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (count, err, ok) = run(&["count", &out]);
+    assert!(ok, "stdout: {count}\nstderr: {err}");
+    assert_eq!(count.trim(), "1");
+}
+
+#[test]
+fn convert_accepts_json_extensions_and_legacy_csv_fallback() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_convert_jsonl.jsonl", dir.display());
+    std::fs::write(&js, "{\"id\":1}\n").unwrap();
+    let out = format!("{}/mosaic_e2e_convert_jsonl.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+
+    let upper = format!("{}/mosaic_e2e_convert_upper.JSON", dir.display());
+    std::fs::write(&upper, "{\"id\":1}\n").unwrap();
+    let (msg, err, ok) = run(&["convert", &upper, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+
+    let csv = format!("{}/mosaic_e2e_convert_legacy_csv.txt", dir.display());
+    std::fs::write(&csv, "id\n2\n").unwrap();
+    let (msg, err, ok) = run(&["convert", &csv, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"id\":2}\n");
+}
+
+#[test]
+fn convert_json_rejects_multiline_records_for_default_and_projection() {
+    let dir = unique_temp_dir("json_multiline_record");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\n\"id\":1\n}\n").unwrap();
+    for (case, columns) in [("default", &[][..]), ("projected", &["-c", "id"][..])] {
+        let out = dir.join(format!("{case}.mosaic"));
+        let mut args = vec!["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()];
+        args.extend_from_slice(columns);
+        let (_, _, ok) = run(&args);
+        assert!(!ok, "{case} unexpectedly accepted a multiline record");
+        assert!(!out.exists(), "{case}");
+    }
+}
+
+#[test]
+fn convert_json_all_null_column_errors_with_column_name() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_json_all_null.json", dir.display());
+    std::fs::write(&js, "{\"id\":1,\"v\":null}\n{\"id\":2,\"v\":null}\n").unwrap();
+    let out = format!("{}/mosaic_e2e_json_all_null.mosaic", dir.display());
+    let (_, err, ok) = run(&["convert", &js, "-o", &out, "--overwrite"]);
+    assert!(!ok);
+    assert!(err.contains("'v'"), "{err}");
+    // Projecting the unusable column away converts the rest.
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "-c", "id", "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+}
+
+#[test]
+fn convert_json_infers_fields_after_initial_records() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_json_late_field.json", dir.display());
+    let mut text = String::new();
+    for id in 0..20 {
+        text.push_str(&format!(r#"{{"id":{id}}}"#));
+        text.push('\n');
+    }
+    text.push_str(r#"{"id":20,"late":"present"}"#);
+    text.push('\n');
+    std::fs::write(&js, text).unwrap();
+    let out = format!("{}/mosaic_e2e_json_late_field.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (schema, _, ok) = run(&["schema", &out]);
+    assert!(ok, "{schema}");
+    assert!(schema.contains("late: Utf8"), "{schema}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert!(rows.contains(r#"{"id":20,"late":"present"}"#), "{rows}");
+}
+
 #[test]
 fn convert_json_then_inspect() {
-    let js = format!("{}/mosaic_e2e_in.ndjson", std::env::temp_dir().display());
+    let js = format!("{}/mosaic_e2e_in.json", std::env::temp_dir().display());
     std::fs::write(
         &js,
         "{\"id\":1,\"kind\":\"a\"}\n{\"id\":2,\"kind\":\"b\"}\n",
@@ -340,26 +1379,336 @@ fn convert_json_then_inspect() {
 }
 
 #[test]
+fn convert_json_projects_columns() {
+    let js = format!(
+        "{}/mosaic_e2e_json_project.json",
+        std::env::temp_dir().display()
+    );
+    std::fs::write(
+        &js,
+        "{\"id\":1,\"kind\":\"a\",\"drop\":\"x\"}\n{\"id\":2,\"kind\":\"b\",\"drop\":\"y\"}\n",
+    )
+    .unwrap();
+    let out = format!(
+        "{}/mosaic_e2e_json_project.mosaic",
+        std::env::temp_dir().display()
+    );
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "-c", "kind,id", "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, _, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "{rows}");
+    assert!(rows.contains(r#"{"kind":"a","id":1}"#), "{rows}");
+    assert!(!rows.contains("drop"), "{rows}");
+}
+
+#[test]
+fn convert_json_projection_ignores_unselected_type_conflicts() {
+    let dir = std::env::temp_dir();
+    let js = format!("{}/mosaic_e2e_json_project_conflict.json", dir.display());
+    std::fs::write(
+        &js,
+        "{\"id\":1,\"drop\":7}\n{\"id\":2,\"drop\":{\"nested\":true}}\n",
+    )
+    .unwrap();
+    let out = format!("{}/mosaic_e2e_json_project_conflict.mosaic", dir.display());
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "-c", "id", "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"id\":1}\n{\"id\":2}\n");
+}
+
+#[test]
+fn convert_json_projection_ignores_unselected_out_of_range_number() {
+    let dir = std::env::temp_dir();
+    let js = format!(
+        "{}/mosaic_e2e_json_project_out_of_range.json",
+        dir.display()
+    );
+    std::fs::write(&js, "{\"id\":1,\"drop\":1e400}\n").unwrap();
+    let out = format!(
+        "{}/mosaic_e2e_json_project_out_of_range.mosaic",
+        dir.display()
+    );
+    let (msg, err, ok) = run(&["convert", &js, "-o", &out, "-c", "id", "--overwrite"]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", &out, "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows.trim(), r#"{"id":1}"#);
+}
+
+#[test]
+fn convert_json_rejects_out_of_range_float_for_default_and_projection() {
+    let dir = unique_temp_dir("json_float_overflow");
+    let js = dir.join("input.jsonl");
+
+    for (case, input, columns, expected_path) in [
+        ("default", "{\"v\":1e400}\n", &[][..], None),
+        (
+            "projected",
+            "{\"v\":1e400}\n",
+            &["-c", "v"][..],
+            Some("'v'"),
+        ),
+        (
+            "nested",
+            "{\"v\":[1e400]}\n",
+            &["-c", "v"][..],
+            Some("'v[]'"),
+        ),
+    ] {
+        std::fs::write(&js, input).unwrap();
+        let out = dir.join(format!("{case}.mosaic"));
+        let mut args = vec!["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()];
+        args.extend_from_slice(columns);
+        let (_, err, ok) = run(&args);
+        assert!(!ok, "{case} unexpectedly succeeded");
+        assert!(
+            err.contains("number out of range")
+                || err.contains("cannot be represented")
+                || err.contains("Json error"),
+            "{case}: {err}"
+        );
+        if let Some(path) = expected_path {
+            assert!(err.contains(path), "{case}: {err}");
+        }
+        assert!(!out.exists(), "{case}");
+        assert!(!sibling_temp_exists(&dir, &format!("{case}.mosaic")));
+    }
+}
+
+#[test]
+fn convert_json_deep_nesting_returns_an_error_without_aborting() {
+    let dir = unique_temp_dir("json_deep_nesting");
+    let js = dir.join("input.jsonl");
+    std::fs::write(
+        &js,
+        format!(
+            "{{\"v\":{}1e400{}}}\n",
+            "[".repeat(100_000),
+            "]".repeat(100_000)
+        ),
+    )
+    .unwrap();
+
+    for (case, columns) in [("default", &[][..]), ("projected", &["-c", "v"][..])] {
+        let out = dir.join(format!("{case}.mosaic"));
+        let mut args = vec!["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()];
+        args.extend_from_slice(columns);
+        let (_, err, ok) = run(&args);
+
+        assert!(!ok, "{case} unexpectedly succeeded");
+        assert!(err.contains("recursion limit exceeded"), "{case}: {err}");
+        assert!(!out.exists(), "{case}");
+        assert!(!sibling_temp_exists(&dir, &format!("{case}.mosaic")));
+    }
+}
+
+#[test]
+fn convert_json_preserves_syntax_error_before_later_numeric_overflow() {
+    let dir = unique_temp_dir("json_syntax_before_numeric_overflow");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"s\":\"\\q\",\"v\":1e400}\n").unwrap();
+    let out = dir.join("out.mosaic");
+
+    let (_, err, ok) = run(&["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()]);
+
+    assert!(!ok);
+    assert!(err.contains("invalid escape"), "{err}");
+    assert!(!err.contains("out of range for Float64"), "{err}");
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_numeric_errors_sanitize_field_path() {
+    let dir = unique_temp_dir("json_safe_field_path");
+    let js = dir.join("input.jsonl");
+    let field = "v\x1b]0;owned\x07";
+    let encoded_field = serde_json::to_string(field).unwrap();
+    std::fs::write(&js, format!("{{{encoded_field}:1e400}}\n")).unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        field,
+    ]);
+    assert!(!ok);
+    assert!(err.contains("out of range for Float64"), "{err}");
+    assert!(!err.contains('\x1b'), "{err:?}");
+    assert!(!err.contains('\x07'), "{err:?}");
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_missing_projection_sanitizes_field_name() {
+    let dir = unique_temp_dir("json_safe_missing_projection");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"id\":1}\n").unwrap();
+    let field = "missing\x1b]0;owned\x07";
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        field,
+    ]);
+    assert!(!ok);
+    assert!(err.contains("not found in schema"), "{err}");
+    assert!(!err.contains('\x1b'), "{err:?}");
+    assert!(!err.contains('\x07'), "{err:?}");
+    assert!(!out.exists());
+}
+
+#[test]
+fn convert_json_default_rejects_lossy_integer_float_promotion() {
+    let dir = unique_temp_dir("json_default_lossy_float");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":1.5}\n{\"v\":9007199254740993}\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()]);
+    assert!(!ok);
+    assert!(err.contains("'v'"), "{err}");
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_default_rejects_lossy_negative_out_of_i64_integer() {
+    let dir = unique_temp_dir("json_default_negative_out_of_i64");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":-9223372036854775809}\n").unwrap();
+    let out = dir.join("out.mosaic");
+
+    let (_, err, ok) = run(&["convert", js.to_str().unwrap(), "-o", out.to_str().unwrap()]);
+
+    assert!(!ok);
+    assert!(err.contains("'v'"), "{err}");
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_projection_rejects_lossy_integer_float_promotion() {
+    let dir = unique_temp_dir("json_project_lossy_float");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":1.5}\n{\"v\":9007199254740993}\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        "v",
+    ]);
+    assert!(!ok);
+    assert!(err.contains("'v'"), "{err}");
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_projection_rejects_out_of_u64_lossy_integer_float_promotion() {
+    let dir = unique_temp_dir("json_project_out_of_u64_lossy_float");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":1.5}\n{\"v\":18446744073709551617}\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        "v",
+    ]);
+    assert!(!ok);
+    assert!(err.contains("'v'"), "{err}");
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
+fn convert_json_projection_allows_exact_out_of_i64_integer_float_promotion() {
+    let dir = unique_temp_dir("json_project_exact_out_of_i64_float");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":1.5}\n{\"v\":18446744073709551616}\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (msg, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        "v",
+    ]);
+    assert!(ok, "stdout: {msg}\nstderr: {err}");
+    let (rows, err, ok) = run(&["cat", out.to_str().unwrap(), "--json"]);
+    assert!(ok, "stdout: {rows}\nstderr: {err}");
+    assert_eq!(rows, "{\"v\":1.5}\n{\"v\":1.8446744073709552e19}\n");
+}
+
+#[test]
+fn convert_json_projection_rejects_nested_lossy_integer_float_promotion() {
+    let dir = unique_temp_dir("json_project_nested_lossy_float");
+    let js = dir.join("input.jsonl");
+    std::fs::write(&js, "{\"v\":[1.5,9007199254740993]}\n").unwrap();
+    let out = dir.join("out.mosaic");
+    let (_, err, ok) = run(&[
+        "convert",
+        js.to_str().unwrap(),
+        "-o",
+        out.to_str().unwrap(),
+        "-c",
+        "v",
+    ]);
+    assert!(!ok);
+    assert!(err.contains("'v[]'"), "{err}");
+    assert!(
+        err.contains("cannot be represented exactly as Float64"),
+        "{err}"
+    );
+    assert!(!out.exists());
+    assert!(!sibling_temp_exists(&dir, "out.mosaic"));
+}
+
+#[test]
 fn where_pushdown_keeps_correct_rows() {
     // stats on id let id>100 skip the row group; boundaries must not drop matches.
-    let csv = format!("{}/mosaic_e2e_pd.csv", std::env::temp_dir().display());
-    std::fs::write(&csv, "id,kind\n1,a\n2,b\n3,a\n").unwrap();
-    let out = format!("{}/mosaic_e2e_pd.mosaic", std::env::temp_dir().display());
-    run(&["convert", &csv, "-o", &out, "--stats", "id", "--overwrite"]);
-    let (none, _, _) = run(&["cat", &out, "--where", "id>100"]);
+    let f = fixture("pd");
+    let (none, _, _) = run(&["cat", &f, "--where", "id>1000"]);
     assert!(none.contains("(no rows)"));
-    let (keep, _, _) = run(&["cat", &out, "--where", "id>=3", "--json"]);
+    let (keep, _, _) = run(&["cat", &f, "--where", "id>=199", "--json"]);
     assert_eq!(keep.lines().count(), 1); // boundary kept, not skipped
 }
 
 #[test]
 fn bigint_where_is_exact() {
     // Snowflake-scale ids differ below f64 precision; equality must be exact.
-    let csv = format!("{}/mosaic_e2e_sf.csv", std::env::temp_dir().display());
-    std::fs::write(&csv, "id\n1700000000000000001\n1700000000000000003\n").unwrap();
-    let out = format!("{}/mosaic_e2e_sf.mosaic", std::env::temp_dir().display());
-    run(&["convert", &csv, "-o", &out, "--stats", "id", "--overwrite"]);
-    let (j, _, ok) = run(&["cat", &out, "--where", "id=1700000000000000003", "--json"]);
+    let f = fixture_i64("sf");
+    let (j, _, ok) = run(&["cat", &f, "--where", "id=1700000000000000003", "--json"]);
     assert!(ok && j.lines().count() == 1 && j.contains("003"), "{j}");
 }
 
@@ -367,11 +1716,8 @@ fn bigint_where_is_exact() {
 fn date_column_pushdown_keeps_match() {
     // Date filters accept ISO literals while stats pushdown still compares the
     // stored epoch-day bounds.
-    let csv = format!("{}/mosaic_e2e_date.csv", std::env::temp_dir().display());
-    std::fs::write(&csv, "d\n2020-01-01\n2021-01-01\n").unwrap();
-    let out = format!("{}/mosaic_e2e_date.mosaic", std::env::temp_dir().display());
-    run(&["convert", &csv, "-o", &out, "--stats", "d", "--overwrite"]);
-    let (j, _, ok) = run(&["cat", &out, "--where", "d>2020-12-31", "--json"]);
+    let f = fixture_date32("date");
+    let (j, _, ok) = run(&["cat", &f, "--where", "d>2020-12-31", "--json"]);
     assert!(
         ok && j.lines().count() == 1 && j.contains("2021-01-01"),
         "{j}"

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -79,10 +79,11 @@ mosaic schema data.mosaic</code></pre>
                     <tr><td><code>column-size</code></td><td>on-disk bytes per column</td><td>footer + index + paged directories</td></tr>
                     <tr><td><code>cat</code> / <code>head</code></td><td>cat: all rows by default (<code>-n</code> to limit); head: first 10; <code>-c</code>, <code>--where</code></td><td>column data</td></tr>
                     <tr><td><code>count</code></td><td>total row count</td><td>footer + index</td></tr>
-                    <tr><td><code>convert</code></td><td>import CSV or JSON lines into a new Mosaic file</td><td>writes file</td></tr>
+                    <tr><td><code>convert</code></td><td>import JSON; legacy single-file CSV calls remain compatible</td><td>writes file</td></tr>
+                    <tr><td><code>convert-csv</code></td><td>import CSV into a new Mosaic file</td><td>writes file</td></tr>
                 </tbody>
             </table>
-            <p>Inspection and query commands accept <code>--json</code> (<code>convert</code> writes a file). <code>cat</code> scans all rows by default (<code>-n</code> to limit); <code>head</code> prints 10 rows by default. <code>cat</code>/<code>head</code>/<code>pages</code>/<code>column-size</code> take <code>-c a,b</code>; <code>dictionary</code> takes <code>-c &lt;col&gt;</code>.</p>
+            <p>Inspection and query commands accept <code>--json</code> (<code>convert</code> and <code>convert-csv</code> write files). <code>cat</code> scans all rows by default (<code>-n</code> to limit); <code>head</code> prints 10 rows by default. <code>cat</code>/<code>head</code>/<code>pages</code>/<code>column-size</code> take <code>-c a,b</code>; <code>dictionary</code> takes <code>-c &lt;col&gt;</code>.</p>
 
             <h2>schema</h2>
             <p>Columns, Arrow types, nullability and bucket assignment, in original input order. Footer only.</p>
@@ -173,10 +174,15 @@ row group 0: 3 entries
 200</code></pre>
 
             <h2>convert</h2>
-            <p>Import a CSV (with header) or JSON lines (one object per line) into a new Mosaic file; the schema is inferred. <code>--stats id,score</code> builds min/max stats for those columns, which <code>cat --where</code> then uses to skip non-matching row groups. Refuses to replace an existing output unless <code>--overwrite</code> is given.</p>
-<pre><code><span class="cmt">$ mosaic convert data.csv -o data.mosaic --stats id</span>
+            <p>Import a regular JSON data file (<code>.json</code>/<code>.ndjson</code>/<code>.jsonl</code>, one object per line) into a new Mosaic file with a schema inferred from the complete input. Existing <code>mosaic convert data.csv -o data.mosaic</code> calls remain supported with the default CSV dialect; use <code>convert-csv</code> for multiple inputs or CSV options. FIFOs and devices are rejected because inference and conversion read the input separately. <code>-c</code>/<code>--column</code> projects top-level fields before inference; each occurrence accepts a comma-separated list. <code>--stats id,score</code> builds min/max stats for those columns, which <code>cat --where</code> then uses to skip non-matching row groups. Refuses to replace an existing output unless <code>--overwrite</code> is given.</p>
+<pre><code><span class="cmt">$ mosaic convert data.ndjson -o data.mosaic --stats id</span>
 wrote data.mosaic (200 rows, 5 columns)
-<span class="cmt">$ mosaic convert data.ndjson -o data.mosaic</span>
+<span class="cmt">$ mosaic convert data.json -o projected.mosaic -c id,kind</span>
+wrote projected.mosaic (200 rows, 2 columns)</code></pre>
+
+            <h2>convert-csv</h2>
+            <p>Import one or more regular CSV files with an inferred schema. Header fields are matched by name across inputs; fields missing from a shard are nullable and written as null, and compatible integer/float and timestamp precisions are promoted, while lossy bare-integer-to-<code>Float64</code> promotion and explicit timezones in inferred local timestamps are rejected. Empty files are skipped, all-empty columns fall back to nullable <code>Utf8</code>, and <code>--require col</code> marks a field as not null. Backslash escaping is disabled by default. <code>--delimiter</code>/<code>--quote</code>/<code>--escape</code>/<code>--no-header</code>/<code>--header</code>/<code>--skip-lines</code> control parsing; FIFOs and other non-regular inferred inputs are rejected, and input files must remain unchanged while conversion runs. <code>--stats</code> and <code>--overwrite</code> work as for <code>convert</code>.</p>
+<pre><code><span class="cmt">$ mosaic convert-csv data.csv -o data.mosaic --stats id</span>
 wrote data.mosaic (200 rows, 5 columns)</code></pre>
 
             <div class="tip">


### PR DESCRIPTION
## Purpose

Replace the closed #69 with a review-converged, single-commit implementation that splits inferred JSON and CSV conversion into independently reviewable CLI commands, hardens conversion correctness and bounded replay behavior, and defers explicit-schema/Avro semantics plus global input byte/complexity limits to follow-up PRs.

## Changes

- keep `convert` for inferred JSON and add `convert-csv` for inferred CSV
- preserve the existing `--out` option as an alias of `--output`
- support JSON projection and stats, with projection applied before schema inference
- support multi-input CSV inference, dialect/header options, all-null fallback, and `--require`
- merge headered CSV schemas by name, union shard-specific fields as nullable nulls, and preserve compatible numeric/timestamp semantics
- reject lossy bare-integer `Float64` promotion, finite overflow, and explicit offsets in inferred local timestamps
- disable CSV backslash escaping by default
- reject non-regular inferred CSV paths before opening them; inputs must remain stable during the two-pass conversion
- keep projection, required-field, and header mappings indexed for wide schemas
- size CSV replay batches from the final union schema width to bound sparse multi-file alignment memory
- replace recursive projected-JSON numeric traversal with a linear scan per selected subtree, with a fixed nesting guard

## Scope

This PR adds user-visible CLI behavior but does not change the Mosaic file format or core library APIs. It intentionally does **not** add `--schema` or Avro semantics. Targeted replay/resource hardening is included; global input byte/complexity limits and replay-integrity verification remain deferred.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --workspace -- -D warnings`
- `cargo build --locked --all-targets`
- regression RED→GREEN: `convert_csv_unions_missing_fields_by_name`
- regression: `csv_replay_batch_size_uses_final_union_width`
- regression: `projected_json_parser_does_not_rescan_large_nested_subtrees`
- `cargo test --locked -p paimon-mosaic-cli` (25 unit + 82 E2E passed)
- `cargo test --locked --workspace`
- `cargo deny check licenses`
- `python3 tools/dependencies.py check`
- `git diff --check`
