### PR TITLE
feat(jni): add streaming columnar text JSON export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
  "arrow-schema",
  "jni",
  "paimon-mosaic-core",
+ "ryu",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 A columnar-bucket hybrid format optimized for wide tables of Apache Paimon. 
 
+## Column-oriented text export
+
+The Java API can stream a row group as JSON containing comma-separated text columns,
+directly from Mosaic encodings without intermediate Arrow arrays.
+See the [format and API contract](docs/columnar-text-json.md).
+
 ## Java Linux compatibility
 
 Published Java artifacts include JNI libraries for Linux. The Linux GNU
@@ -48,4 +54,3 @@ Submit [issues](https://github.com/apache/paimon-mosaic/issues/new/choose) for b
 ## License
 
 Licensed under <a href="./LICENSE">Apache License, Version 2.0</a>.
-

--- a/core/src/bucket_reader.rs
+++ b/core/src/bucket_reader.rs
@@ -133,6 +133,44 @@ impl<'a> EncodedColumn<'a> {
             done: false,
         }
     }
+
+    /// Visits each dictionary entry exactly once and validates every encoded row index.
+    ///
+    /// Returns `Ok(false)` when this column is not dictionary-encoded. Null rows do not carry a
+    /// dictionary index and are skipped while validating the index stream.
+    pub fn visit_dictionary<F>(&self, mut visitor: F) -> io::Result<bool>
+    where
+        F: FnMut(EncodedValueRef<'a>) -> io::Result<()>,
+    {
+        if self.encoding != ENCODING_DICT {
+            return Ok(false);
+        }
+
+        for value in self.dict_values {
+            visitor(encoded_value_ref(self.data_type, value)?)?;
+        }
+
+        let mut bit_offset = 0usize;
+        for row in 0..self.num_rows {
+            if self.is_null(row) {
+                continue;
+            }
+            let index = read_bit_packed_checked(
+                self.data,
+                self.data_cursor,
+                bit_offset,
+                self.dict_bit_width,
+            )?;
+            bit_offset += self.dict_bit_width;
+            if index >= self.dict_values.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "corrupt dict index",
+                ));
+            }
+        }
+        Ok(true)
+    }
 }
 
 /// Borrowed scalar value returned by [`EncodedColumnValues`].
@@ -2915,6 +2953,10 @@ mod encoded_column_tests {
             truncated.values().next().unwrap().unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
+        assert_eq!(
+            truncated.visit_dictionary(|_| Ok(())).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
 
         let out_of_range = EncodedColumn::new(
             &data_type,
@@ -2932,6 +2974,54 @@ mod encoded_column_tests {
             out_of_range.values().next().unwrap().unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
+        assert_eq!(
+            out_of_range
+                .visit_dictionary(|_| Ok(()))
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn visits_dictionary_entries_once_and_checks_the_last_index() {
+        let data_type = DataType::Utf8;
+        let placeholder = Value::Null;
+        let dict_values = [
+            Value::String(b"alpha".to_vec()),
+            Value::String(b"beta".to_vec()),
+            Value::String(b"gamma".to_vec()),
+        ];
+        let column = EncodedColumn::new(
+            &data_type,
+            ENCODING_DICT,
+            false,
+            &[],
+            &placeholder,
+            &dict_values,
+            2,
+            &[0x24, 0x03],
+            0,
+            5,
+        );
+
+        let mut entries = Vec::new();
+        let error = column
+            .visit_dictionary(|value| {
+                let EncodedValueRef::Utf8(value) = value else {
+                    panic!("unexpected dictionary value: {value:?}");
+                };
+                entries.push(value.to_vec());
+                Ok(())
+            })
+            .unwrap_err();
+
+        assert_eq!(
+            entries,
+            [b"alpha".to_vec(), b"beta".to_vec(), b"gamma".to_vec()]
+        );
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("corrupt dict index"));
     }
 
     #[test]

--- a/core/src/reader.rs
+++ b/core/src/reader.rs
@@ -1436,9 +1436,25 @@ enum BucketState {
     },
 }
 
+fn build_global_to_local(num_columns: usize, bucket_to_global: &[Vec<usize>]) -> Vec<usize> {
+    let mut global_to_local = vec![usize::MAX; num_columns];
+    for global_indices in bucket_to_global {
+        for (local_index, &global_index) in global_indices.iter().enumerate() {
+            if global_index < num_columns {
+                debug_assert_eq!(global_to_local[global_index], usize::MAX);
+                global_to_local[global_index] = local_index;
+            } else {
+                debug_assert!(false, "global column index out of bounds");
+            }
+        }
+    }
+    global_to_local
+}
+
 pub struct RowGroupReader {
     bucket_states: Vec<Option<BucketState>>,
     bucket_to_global: Vec<Vec<usize>>,
+    global_to_local: Vec<usize>,
     active_buckets: Vec<usize>,
     schema: MosaicSchema,
     num_rows: usize,
@@ -1462,9 +1478,11 @@ impl RowGroupReader {
             .enumerate()
             .filter_map(|(i, s)| if s.is_some() { Some(i) } else { None })
             .collect();
+        let global_to_local = build_global_to_local(num_columns, &bucket_to_global);
         RowGroupReader {
             bucket_states,
             bucket_to_global,
+            global_to_local,
             active_buckets,
             schema,
             num_rows,
@@ -1477,9 +1495,10 @@ impl RowGroupReader {
     /// Dictionary entries for a projected column, or `None` if not dict-encoded.
     pub fn take_dictionary(&self, global_col: usize) -> Option<Vec<Value>> {
         let bucket = self.schema.columns[global_col].bucket_id;
-        let local = self.bucket_to_global[bucket]
-            .iter()
-            .position(|&g| g == global_col)?;
+        let local = *self.global_to_local.get(global_col)?;
+        if local == usize::MAX {
+            return None;
+        }
         match self.bucket_states[bucket].as_ref()? {
             BucketState::Paged { column_readers } => {
                 let d = column_readers[local].as_ref()?.dict_values();
@@ -1542,9 +1561,11 @@ impl RowGroupReader {
 
             let column = &self.schema.columns[global_index];
             let bucket_id = column.bucket_id;
-            let local_index = self.bucket_to_global[bucket_id]
-                .iter()
-                .position(|&index| index == global_index)
+            let local_index = self
+                .global_to_local
+                .get(global_index)
+                .copied()
+                .filter(|&index| index != usize::MAX)
                 .ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,

--- a/core/src/reader_tests.rs
+++ b/core/src/reader_tests.rs
@@ -68,6 +68,14 @@ impl InputFile for ByteArrayInputFile {
     }
 }
 
+#[test]
+fn builds_constant_time_global_to_local_column_mapping() {
+    assert_eq!(
+        build_global_to_local(6, &[vec![4, 1], vec![5], vec![0, 3, 2]]),
+        vec![0, 1, 2, 1, 0, 0]
+    );
+}
+
 struct MemOutputFile {
     buf: Vec<u8>,
 }

--- a/docs/columnar-text-json.md
+++ b/docs/columnar-text-json.md
@@ -1,0 +1,105 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Columnar text JSON
+
+`ColumnarTextJsonWriter` exports one Mosaic row group as a JSON object containing
+comma-separated text columns. This is useful when a downstream interface accepts
+each column as a text sequence rather than individual typed rows.
+
+The writer consumes Mosaic's encoded scalar columns directly. It avoids creating
+intermediate Arrow arrays, reuses formatted constants, and streams the result to
+the caller's `OutputStream`. It does not compress the result or manage storage.
+
+## Format
+
+For these logical columns:
+
+| Row | speed | state |
+| --- | --- | --- |
+| 0 | 10 | on |
+| 1 | null | off |
+| 2 | 12 | null |
+
+the output is:
+
+```json
+{"speed":"10,,12","state":"on,off,"}
+```
+
+- Each object key is a column name. Columns follow the reader's projection order.
+- Each value is one JSON string, **not** a JSON array. Entries follow logical row
+  order and are separated by a comma.
+- Null and empty strings both produce empty entries. Commas within string values
+  remain literal. Quotes, backslashes, and control characters receive JSON escaping,
+  but there is no additional CSV quoting or delimiter escaping.
+- Integers use base ten without grouping. Finite doubles follow `Double.toString`
+  on the calling JVM, including negative zero. Decimals follow
+  `BigDecimal.toPlainString`, preserving their scale.
+
+This is a text aggregation format, not a lossless encoding of typed rows. In
+particular, null cannot be distinguished from an empty string, and commas in values
+cannot be distinguished from entry separators. Consumers needing that distinction
+should use typed Arrow access or another serialization format.
+
+## Java API
+
+```java
+try (MosaicReader reader = MosaicReader.open(input, fileLength, allocator);
+        MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+    ColumnarTextJsonWriter.Status status =
+            ColumnarTextJsonWriter.write(rowGroup, output);
+}
+```
+
+Projection can be set on `MosaicReader` before opening the row group. The writer
+uses the row group's actual schema; callers do not supply a second schema or make
+a separate assertion that the input has been validated.
+
+The supported value types are signed integers, DOUBLE, Decimal128, and UTF8 in
+ALL_NULL, CONST, DICT, and PLAIN encodings. All-null columns of other scalar types
+are also supported. Nested columns are not supported.
+
+## Results and failures
+
+| Result | Output | Caller action |
+| --- | --- | --- |
+| `WRITTEN` | One complete JSON object | Use the result |
+| `UNSUPPORTED` | Unchanged | Use `rowGroup.readColumns(allocator)` or another exporter |
+| Exception | May contain an incomplete object | Discard this result; do not append a fallback |
+
+Capability checks and DOUBLE formatting happen before output starts. Non-finite
+doubles and more than 65,536 distinct values needing JVM formatting return
+`UNSUPPORTED`. Other values are validated during streaming, so invalid UTF8,
+malformed values, or output failures can be reported after bytes have been written.
+`UNSUPPORTED` is a capability result, not a certificate that all input is valid.
+
+The writer neither flushes nor closes the caller's stream. Callers must ensure
+failed results do not become visible downstream. Compression, buffering, and
+publication belong to the caller; they are not part of the text format.
+
+## Ownership and memory
+
+Close the row-group reader when finished. It allows one active operation and
+rejects concurrent or reentrant reads and writes. Closing during an operation
+prevents new calls and releases the native handle after that operation returns.
+
+The encoding views borrow buffers owned by the row group. The writer uses bounded
+scratch buffers instead of accumulating a whole text column. This does not bound
+the size of the loaded row group or any output that the caller chooses to retain.

--- a/java/src/main/binary-resources/META-INF/licenses/aarch64-apple-darwin/THIRD-PARTY-LICENSES.html
+++ b/java/src/main/binary-resources/META-INF/licenses/aarch64-apple-darwin/THIRD-PARTY-LICENSES.html
@@ -45,7 +45,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (38)</li>
             <li><a href="#MIT">MIT License</a> (6)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -1545,6 +1545,7 @@ limitations under the License.
                     <li><a href="https://github.com/rust-lang/libc">libc 0.2.189</a></li>
                     <li><a href="https://github.com/dtolnay/proc-macro2">proc-macro2 1.0.107</a></li>
                     <li><a href="https://github.com/dtolnay/quote">quote 1.0.47</a></li>
+                    <li><a href="https://github.com/dtolnay/ryu">ryu 1.0.23</a></li>
                     <li><a href="https://github.com/dtolnay/syn">syn 2.0.119</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror-impl 1.0.69</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror 1.0.69</a></li>

--- a/java/src/main/binary-resources/META-INF/licenses/aarch64-unknown-linux-gnu/THIRD-PARTY-LICENSES.html
+++ b/java/src/main/binary-resources/META-INF/licenses/aarch64-unknown-linux-gnu/THIRD-PARTY-LICENSES.html
@@ -45,7 +45,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
             <li><a href="#MIT">MIT License</a> (6)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -1544,6 +1544,7 @@ limitations under the License.
                     <li><a href="https://github.com/rust-lang/libc">libc 0.2.189</a></li>
                     <li><a href="https://github.com/dtolnay/proc-macro2">proc-macro2 1.0.107</a></li>
                     <li><a href="https://github.com/dtolnay/quote">quote 1.0.47</a></li>
+                    <li><a href="https://github.com/dtolnay/ryu">ryu 1.0.23</a></li>
                     <li><a href="https://github.com/dtolnay/syn">syn 2.0.119</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror-impl 1.0.69</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror 1.0.69</a></li>

--- a/java/src/main/binary-resources/META-INF/licenses/x86_64-pc-windows-msvc/THIRD-PARTY-LICENSES.html
+++ b/java/src/main/binary-resources/META-INF/licenses/x86_64-pc-windows-msvc/THIRD-PARTY-LICENSES.html
@@ -45,7 +45,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (38)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (39)</li>
             <li><a href="#MIT">MIT License</a> (6)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -1546,6 +1546,7 @@ limitations under the License.
                     <li><a href="https://github.com/jni-rs/jni-sys">jni-sys-macros 0.4.1</a></li>
                     <li><a href="https://github.com/dtolnay/proc-macro2">proc-macro2 1.0.107</a></li>
                     <li><a href="https://github.com/dtolnay/quote">quote 1.0.47</a></li>
+                    <li><a href="https://github.com/dtolnay/ryu">ryu 1.0.23</a></li>
                     <li><a href="https://github.com/dtolnay/syn">syn 2.0.119</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror-impl 1.0.69</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror 1.0.69</a></li>

--- a/java/src/main/binary-resources/META-INF/licenses/x86_64-unknown-linux-gnu/THIRD-PARTY-LICENSES.html
+++ b/java/src/main/binary-resources/META-INF/licenses/x86_64-unknown-linux-gnu/THIRD-PARTY-LICENSES.html
@@ -45,7 +45,7 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
             <li><a href="#MIT">MIT License</a> (6)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (1)</li>
         </ul>
@@ -1544,6 +1544,7 @@ limitations under the License.
                     <li><a href="https://github.com/rust-lang/libc">libc 0.2.189</a></li>
                     <li><a href="https://github.com/dtolnay/proc-macro2">proc-macro2 1.0.107</a></li>
                     <li><a href="https://github.com/dtolnay/quote">quote 1.0.47</a></li>
+                    <li><a href="https://github.com/dtolnay/ryu">ryu 1.0.23</a></li>
                     <li><a href="https://github.com/dtolnay/syn">syn 2.0.119</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror-impl 1.0.69</a></li>
                     <li><a href="https://github.com/dtolnay/thiserror">thiserror 1.0.69</a></li>

--- a/java/src/main/java/org/apache/paimon/mosaic/ColumnarTextJsonWriter.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/ColumnarTextJsonWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.mosaic;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
+/**
+ * Streams a row group as a JSON object whose values are comma-separated text columns.
+ *
+ * <p>For example, an integer column {@code [10, null, 12]} becomes {@code {"speed":"10,,12"}}.
+ * Columns follow the reader's projection order and values follow logical row order. Null and empty
+ * strings both produce empty entries. Commas in string values remain literal; only JSON escaping
+ * is applied. This format aggregates text and is not a lossless representation of typed rows.
+ *
+ * <p>Finite doubles follow {@link Double#toString(double)} on the calling JVM. Decimals follow
+ * {@link java.math.BigDecimal#toPlainString()}. Integers use base ten without grouping.
+ */
+public final class ColumnarTextJsonWriter {
+
+    /** Normal outcomes that do not represent corrupt input or I/O failure. */
+    public enum Status {
+        WRITTEN,
+        UNSUPPORTED
+    }
+
+    private ColumnarTextJsonWriter() {}
+
+    /**
+     * Writes one row group directly from its scalar column encodings, without Arrow arrays.
+     *
+     * <p>Supports integer, DOUBLE, Decimal128, and UTF8 columns in ALL_NULL, CONST, DICT, and PLAIN
+     * encodings, plus all-null columns of other scalar types. Nested columns, non-finite doubles,
+     * and more than 65,536 distinct doubles requiring JVM formatting return {@link
+     * Status#UNSUPPORTED} before touching {@code output}. The same row group remains available for
+     * {@link MosaicRowGroupReader#readColumns}.
+     *
+     * <p>Structure and DOUBLE text are checked before output starts. Other values are validated
+     * during streaming. If decoding or I/O fails, discard the partial result; do not append a
+     * fallback to it. The caller owns {@code output}; this method never closes or flushes it.
+     */
+    public static Status write(MosaicRowGroupReader rowGroup, OutputStream output)
+            throws IOException {
+        Objects.requireNonNull(rowGroup, "rowGroup");
+        Objects.requireNonNull(output, "output");
+        return rowGroup.writeColumnarTextJson(output) ? Status.WRITTEN : Status.UNSUPPORTED;
+    }
+}

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicReader.java
@@ -38,12 +38,16 @@ public class MosaicReader implements AutoCloseable {
 
     private MosaicReader(long handle, BufferAllocator allocator) {
         this.handle = handle;
+        this.schema = exportSchema(handle, allocator);
+    }
+
+    private static Schema exportSchema(long handle, BufferAllocator allocator) {
         try (ArrowSchema cSchema = ArrowSchema.allocateNew(allocator)) {
             int rc = NativeLib.nativeReaderExportSchema(handle, cSchema.memoryAddress());
             if (rc != 0) {
                 throw new RuntimeException("failed to export schema");
             }
-            this.schema = Data.importSchema(allocator, cSchema, null);
+            return Data.importSchema(allocator, cSchema, null);
         }
     }
 
@@ -59,11 +63,15 @@ public class MosaicReader implements AutoCloseable {
         if (handle == 0) {
             throw new RuntimeException("failed to open reader");
         }
+        boolean opened = false;
         try {
-            return new MosaicReader(handle, allocator);
-        } catch (RuntimeException | Error e) {
-            NativeLib.nativeReaderFree(handle);
-            throw e;
+            MosaicReader reader = new MosaicReader(handle, allocator);
+            opened = true;
+            return reader;
+        } finally {
+            if (!opened) {
+                NativeLib.nativeReaderFree(handle);
+            }
         }
     }
 
@@ -80,32 +88,38 @@ public class MosaicReader implements AutoCloseable {
     }
 
     /**
+     * Opens one row group for reusable encoded or Arrow access.
+     *
+     * <p>The caller must close the returned reader.
+     *
+     * @throws IOException if {@link InputFile#readFully(long, byte[], int, int)} throws one while
+     *     preparing row-group data; the original exception is propagated
+     */
+    public MosaicRowGroupReader openRowGroup(int rgIndex) throws IOException {
+        if (handle == 0) {
+            throw new IllegalStateException("reader is closed");
+        }
+        long rgHandle = NativeLib.nativeReaderOpenRowGroup(handle, rgIndex);
+        if (rgHandle == 0) {
+            throw new RuntimeException("failed to open row group " + rgIndex);
+        }
+        try {
+            return new MosaicRowGroupReader(rgHandle);
+        } catch (RuntimeException | Error e) {
+            NativeLib.nativeRowGroupReaderFree(rgHandle);
+            throw e;
+        }
+    }
+
+    /**
      * Reads a row group.
      *
      * @throws IOException if {@link InputFile#readFully(long, byte[], int, int)} throws one while
      *     reading row-group data; the original exception is propagated
      */
     public VectorSchemaRoot readRowGroup(int rgIndex, BufferAllocator allocator) throws IOException {
-        long rgHandle = NativeLib.nativeReaderOpenRowGroup(handle, rgIndex);
-        if (rgHandle == 0) {
-            throw new RuntimeException("failed to open row group " + rgIndex);
-        }
-        try {
-            return readRowGroupHandle(rgHandle, allocator);
-        } finally {
-            NativeLib.nativeRowGroupReaderFree(rgHandle);
-        }
-    }
-
-    private VectorSchemaRoot readRowGroupHandle(long rgHandle, BufferAllocator allocator) {
-        try (ArrowArray arrowArray = ArrowArray.allocateNew(allocator);
-             ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator)) {
-            int rc = NativeLib.nativeRowGroupReaderReadColumns(
-                    rgHandle, arrowArray.memoryAddress(), arrowSchema.memoryAddress());
-            if (rc != 0) {
-                throw new RuntimeException("readColumns failed");
-            }
-            return Data.importVectorSchemaRoot(allocator, arrowArray, arrowSchema, null);
+        try (MosaicRowGroupReader rowGroup = openRowGroup(rgIndex)) {
+            return rowGroup.readColumns(allocator);
         }
     }
 

--- a/java/src/main/java/org/apache/paimon/mosaic/MosaicRowGroupReader.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/MosaicRowGroupReader.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.paimon.mosaic;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/**
+ * One prepared Mosaic row group.
+ *
+ * <p>The same native row-group state can be reused for Arrow fallback when a product consumer
+ * reports that its fast path is unsupported.
+ *
+ * <p>An instance permits only one active read or write. Concurrent or reentrant use fails instead
+ * of waiting. Calling {@link #close()} during an active operation immediately closes the instance
+ * to new calls and defers native release until that operation returns.
+ */
+public final class MosaicRowGroupReader implements AutoCloseable {
+
+    private enum State {
+        IDLE,
+        IN_USE,
+        CLOSE_PENDING,
+        CLOSED
+    }
+
+    private long handle;
+    private State state = State.IDLE;
+
+    MosaicRowGroupReader(long handle) {
+        this.handle = handle;
+    }
+
+    /**
+     * Materializes this row group's selected columns as Arrow vectors.
+     *
+     * <p>The caller owns and must close the returned root.
+     */
+    public VectorSchemaRoot readColumns(BufferAllocator allocator) {
+        long currentHandle = beginUse();
+        try {
+            try (ArrowArray arrowArray = ArrowArray.allocateNew(allocator);
+                    ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator)) {
+                int rc =
+                        NativeLib.nativeRowGroupReaderReadColumns(
+                                currentHandle,
+                                arrowArray.memoryAddress(),
+                                arrowSchema.memoryAddress());
+                if (rc != 0) {
+                    throw new RuntimeException("readColumns failed");
+                }
+                return Data.importVectorSchemaRoot(allocator, arrowArray, arrowSchema, null);
+            }
+        } finally {
+            endUse();
+        }
+    }
+
+    boolean writeColumnarTextJson(OutputStream output) throws IOException {
+        long currentHandle = beginUse();
+        try {
+            return NativeLib.nativeRowGroupReaderWriteColumnarTextJson(currentHandle, output);
+        } finally {
+            endUse();
+        }
+    }
+
+    private synchronized long beginUse() {
+        switch (state) {
+            case IDLE:
+                state = State.IN_USE;
+                return handle;
+            case IN_USE:
+                throw new IllegalStateException("row group reader is already in use");
+            case CLOSE_PENDING:
+            case CLOSED:
+                throw new IllegalStateException("row group reader is closed");
+            default:
+                throw new AssertionError("unknown row group reader state " + state);
+        }
+    }
+
+    private synchronized void endUse() {
+        switch (state) {
+            case IN_USE:
+                state = State.IDLE;
+                break;
+            case CLOSE_PENDING:
+                freeHandleWhileLocked();
+                break;
+            default:
+                throw new AssertionError("cannot end row group reader use in state " + state);
+        }
+    }
+
+    private void freeHandleWhileLocked() {
+        NativeLib.nativeRowGroupReaderFree(handle);
+        handle = 0;
+        state = State.CLOSED;
+    }
+
+    @Override
+    public synchronized void close() {
+        switch (state) {
+            case IDLE:
+                freeHandleWhileLocked();
+                break;
+            case IN_USE:
+                state = State.CLOSE_PENDING;
+                break;
+            case CLOSE_PENDING:
+            case CLOSED:
+                break;
+            default:
+                throw new AssertionError("unknown row group reader state " + state);
+        }
+    }
+}

--- a/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
+++ b/java/src/main/java/org/apache/paimon/mosaic/NativeLib.java
@@ -127,7 +127,19 @@ final class NativeLib {
     // RowGroupReader
     static native int nativeRowGroupReaderNumRows(long handle);
     static native int nativeRowGroupReaderReadColumns(long handle, long arrayAddr, long schemaAddr);
+    static native boolean nativeRowGroupReaderWriteColumnarTextJson(
+            long handle, OutputStream output) throws IOException;
     static native void nativeRowGroupReaderFree(long handle);
+
+    // Called from jni/src/lib.rs by this exact name and JNI signature. Double.toString keeps the
+    // native output byte-for-byte aligned with the Java fallback on the current JVM.
+    private static String[] formatColumnarTextJsonDoubles(long[] bits) {
+        String[] values = new String[bits.length];
+        for (int index = 0; index < bits.length; index++) {
+            values[index] = Double.toString(Double.longBitsToDouble(bits[index]));
+        }
+        return values;
+    }
 
     // Row group num rows
     static native int nativeReaderRowGroupNumRows(long handle, int rgIndex);

--- a/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
+++ b/java/src/test/java/org/apache/paimon/mosaic/MosaicRoundtripTest.java
@@ -23,14 +23,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.ref.WeakReference;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.arrow.c.jni.JniWrapper;
 import org.apache.arrow.memory.ArrowBuf;
@@ -39,6 +43,7 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
@@ -67,6 +72,11 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class MosaicRoundtripTest {
+
+    private static final long TINY_DOUBLE_ROUNDING_REGRESSION_BITS = 0x3d20000000000000L;
+    private static final long LARGE_DOUBLE_ROUNDING_REGRESSION_BITS = 0x43d406c0c77e23e0L;
+    // Produces enough JSON to force more than one native-to-Java output callback.
+    private static final int ROW_COUNT_FOR_MULTIPLE_OUTPUT_WRITES = 500_000;
 
     private BufferAllocator allocator;
 
@@ -111,6 +121,7 @@ public class MosaicRoundtripTest {
 
         private final ByteArrayOutputStream delegate = new ByteArrayOutputStream();
         private final FailurePoint failurePoint;
+        private final int failOnWriteCall;
         private final IllegalStateException failureCause;
         private final IOException failure;
         private boolean failed;
@@ -118,7 +129,13 @@ public class MosaicRoundtripTest {
         private int flushCalls;
 
         private FailOnceOutputStream(FailurePoint failurePoint, String message) {
+            this(failurePoint, 1, message);
+        }
+
+        private FailOnceOutputStream(
+                FailurePoint failurePoint, int failOnWriteCall, String message) {
             this.failurePoint = failurePoint;
+            this.failOnWriteCall = failOnWriteCall;
             this.failureCause = new IllegalStateException(message + "-cause");
             this.failure = new IOException(message, failureCause);
         }
@@ -131,7 +148,9 @@ public class MosaicRoundtripTest {
         @Override
         public void write(byte[] bytes, int offset, int length) throws IOException {
             writeCalls++;
-            if (!failed && failurePoint == FailurePoint.WRITE) {
+            if (!failed
+                    && failurePoint == FailurePoint.WRITE
+                    && writeCalls == failOnWriteCall) {
                 failed = true;
                 throw failure;
             }
@@ -149,6 +168,99 @@ public class MosaicRoundtripTest {
 
         private int size() {
             return delegate.size();
+        }
+    }
+
+    private static final class ReentrantWriteOutputStream extends ByteArrayOutputStream {
+
+        private final MosaicRowGroupReader rowGroup;
+        private Throwable reentrantFailure;
+        private boolean attempted;
+
+        private ReentrantWriteOutputStream(MosaicRowGroupReader rowGroup) {
+            this.rowGroup = rowGroup;
+        }
+
+        @Override
+        public synchronized void write(byte[] bytes, int offset, int length) {
+            if (!attempted) {
+                attempted = true;
+                try {
+                    ColumnarTextJsonWriter.write(rowGroup, new ByteArrayOutputStream());
+                } catch (Throwable failure) {
+                    reentrantFailure = failure;
+                }
+            }
+            super.write(bytes, offset, length);
+        }
+    }
+
+    private static final class CloseOnFirstWriteOutputStream extends ByteArrayOutputStream {
+
+        private final MosaicRowGroupReader rowGroup;
+        private boolean closeRequested;
+        private int writeCalls;
+        private int firstWriteBytes;
+        private long nativeHandleAfterClose;
+
+        private CloseOnFirstWriteOutputStream(MosaicRowGroupReader rowGroup) {
+            this.rowGroup = rowGroup;
+        }
+
+        @Override
+        public synchronized void write(byte[] bytes, int offset, int length) {
+            writeCalls++;
+            if (!closeRequested) {
+                closeRequested = true;
+                firstWriteBytes = length;
+                rowGroup.close();
+                nativeHandleAfterClose = nativeHandle(rowGroup);
+            }
+            super.write(bytes, offset, length);
+        }
+    }
+
+    private static final class BlockingWriteOutputStream extends ByteArrayOutputStream {
+
+        private final CountDownLatch enteredWrite = new CountDownLatch(1);
+        private final CountDownLatch releaseWrite = new CountDownLatch(1);
+        private boolean blocked;
+        private int writeCalls;
+        private int firstWriteBytes;
+
+        @Override
+        public synchronized void write(byte[] bytes, int offset, int length) {
+            writeCalls++;
+            if (!blocked) {
+                blocked = true;
+                firstWriteBytes = length;
+                enteredWrite.countDown();
+                try {
+                    releaseWrite.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("interrupted while blocking native output", e);
+                }
+            }
+            super.write(bytes, offset, length);
+        }
+    }
+
+    private static final class OwnershipTrackingOutputStream extends ByteArrayOutputStream {
+
+        private int flushCalls;
+        private int closeCalls;
+
+        @Override
+        public void flush() throws IOException {
+            flushCalls++;
+            throw new IOException("unexpected flush");
+        }
+
+        @Override
+        public void close() throws IOException {
+            closeCalls++;
+            throw new IOException("unexpected close");
         }
     }
 
@@ -179,6 +291,17 @@ public class MosaicRoundtripTest {
             System.arraycopy(data, (int) position, buffer, offset, length);
         };
         return MosaicReader.open(inputFile, data.length, allocator);
+    }
+
+    private static long nativeHandle(MosaicRowGroupReader rowGroup) {
+        try {
+            java.lang.reflect.Field field =
+                    MosaicRowGroupReader.class.getDeclaredField("handle");
+            field.setAccessible(true);
+            return field.getLong(rowGroup);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("cannot inspect row-group native handle", e);
+        }
     }
 
     private static Schema wideIntSchema(int width) {
@@ -241,6 +364,30 @@ public class MosaicRoundtripTest {
             assertSame(expected, error);
         }
         return Arrays.asList(inputReference, exceptionReference);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <E extends Throwable> void throwUnchecked(Throwable failure) throws E {
+        throw (E) failure;
+    }
+
+    private WeakReference<InputFile> openReaderWithCheckedAllocatorFailure(byte[] data)
+            throws Exception {
+        IOException expected = new IOException("schema allocation callback failed");
+        InputFile input = (position, buffer, offset, length) ->
+                System.arraycopy(data, (int) position, buffer, offset, length);
+        WeakReference<InputFile> reference = new WeakReference<>(input);
+        try (BufferAllocator failingAllocator = new RootAllocator() {
+            @Override
+            public ArrowBuf buffer(long size) {
+                MosaicRoundtripTest.<RuntimeException>throwUnchecked(expected);
+                throw new AssertionError("unreachable");
+            }
+        }) {
+            assertSame(expected, assertThrows(IOException.class,
+                    () -> MosaicReader.open(input, data.length, failingAllocator)));
+        }
+        return reference;
     }
 
     private List<WeakReference<?>> readRowGroupWithFailingInput(byte[] data) throws IOException {
@@ -1488,6 +1635,14 @@ public class MosaicRoundtripTest {
     }
 
     @Test
+    public void testReaderOpenReleasesNativeHandleOnCheckedAllocatorFailure() throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.nullable("value", new ArrowType.Int(32, true))));
+        byte[] data = writeToBytes(schema, writer -> {});
+        awaitGarbageCollection(openReaderWithCheckedAllocatorFailure(data));
+    }
+
+    @Test
     public void testReaderRestoresBackgroundInputExceptionAndReleasesGlobalRef()
             throws Exception {
         Schema schema = new Schema(Arrays.asList(
@@ -1503,6 +1658,1353 @@ public class MosaicRoundtripTest {
         }
 
         awaitGarbageCollection(readRowGroupWithFailingInput(data));
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesExactPrimitiveProtocol() throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.nullable("i\"8", new ArrowType.Int(8, true)),
+                Field.nullable("i16", new ArrowType.Int(16, true)),
+                Field.nullable("i32", new ArrowType.Int(32, true)),
+                Field.nullable("i64", new ArrowType.Int(64, true)),
+                Field.nullable(
+                        "double",
+                        new ArrowType.FloatingPoint(
+                                org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE)),
+                Field.nullable("text", ArrowType.Utf8.INSTANCE)
+        ));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            TinyIntVector i8 = (TinyIntVector) root.getVector("i\"8");
+            SmallIntVector i16 = (SmallIntVector) root.getVector("i16");
+            IntVector i32 = (IntVector) root.getVector("i32");
+            BigIntVector i64 = (BigIntVector) root.getVector("i64");
+            Float8Vector doubles = (Float8Vector) root.getVector("double");
+            VarCharVector text = (VarCharVector) root.getVector("text");
+            i8.allocateNew(3);
+            i16.allocateNew(3);
+            i32.allocateNew(3);
+            i64.allocateNew(3);
+            doubles.allocateNew(3);
+            text.allocateNew();
+
+            i8.set(0, -1);
+            i8.setNull(1);
+            i8.set(2, 9);
+            i16.set(0, 0);
+            i16.set(1, -7);
+            i16.set(2, 12);
+            i32.set(0, Integer.MIN_VALUE);
+            i32.set(1, 0);
+            i32.set(2, Integer.MAX_VALUE);
+            i64.set(0, Long.MIN_VALUE);
+            i64.setNull(1);
+            i64.set(2, Long.MAX_VALUE);
+            doubles.set(0, -0.0);
+            doubles.set(1, 1.2);
+            doubles.set(2, 9_999_999.0);
+            text.setSafe(0, "a\"\n".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            text.setNull(1);
+            text.setSafe(2, "中\t".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            root.setRowCount(3);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"i\\\"8\":\"-1,,9\",\"i16\":\"0,-7,12\","
+                            + "\"i32\":\"-2147483648,0,2147483647\","
+                            + "\"i64\":\"-9223372036854775808,,9223372036854775807\","
+                            + "\"double\":\"-0.0,1.2,9999999.0\","
+                            + "\"text\":\"a\\\"\\n,,中\\t\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterMatchesJavaDoubleFormatting() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value",
+                                        new ArrowType.FloatingPoint(
+                                                FloatingPointPrecision.DOUBLE))));
+        int rowCount = 4096;
+        double[] values = new double[rowCount];
+        double[] fixedValues = {
+            0.0,
+            -0.0,
+            Math.nextDown(1.0e-6),
+            1.0e-6,
+            Math.nextUp(1.0e-6),
+            -Math.nextDown(1.0e-6),
+            -1.0e-6,
+            -Math.nextUp(1.0e-6),
+            Math.nextDown(1.0e9),
+            1.0e9,
+            Math.nextUp(1.0e9),
+            -Math.nextDown(1.0e9),
+            -1.0e9,
+            -Math.nextUp(1.0e9),
+            1_234_567.0,
+            -1_234_567.0,
+            1_234_567.8,
+            -1_234_567.8,
+            Double.MIN_VALUE,
+            -Double.MIN_VALUE,
+            Double.MAX_VALUE,
+            -Double.MAX_VALUE,
+            Double.longBitsToDouble(TINY_DOUBLE_ROUNDING_REGRESSION_BITS),
+            Double.longBitsToDouble(LARGE_DOUBLE_ROUNDING_REGRESSION_BITS)
+        };
+        System.arraycopy(fixedValues, 0, values, 0, fixedValues.length);
+        java.util.Random random = new java.util.Random(20260820L);
+        int randomBitPatternEnd = fixedValues.length + 256;
+        for (int row = fixedValues.length; row < randomBitPatternEnd; row++) {
+            double value;
+            do {
+                value = Double.longBitsToDouble(random.nextLong());
+            } while (!Double.isFinite(value));
+            values[row] = value;
+        }
+        for (int row = randomBitPatternEnd; row < rowCount; row++) {
+            int exponent = random.nextInt(15) - 6;
+            double significand = 1.0 + random.nextDouble() * 9.0;
+            double value = significand * Math.pow(10.0, exponent);
+            values[row] = random.nextBoolean() ? value : -value;
+            assertTrue(Math.abs(values[row]) >= 1.0e-6);
+            assertTrue(Math.abs(values[row]) <= 1.0e9);
+        }
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            Float8Vector vector = (Float8Vector) root.getVector("value");
+            vector.allocateNew(rowCount);
+            for (int row = 0; row < rowCount; row++) {
+                vector.set(row, values[row]);
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            String actual =
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8);
+            String prefix = "{\"value\":\"";
+            assertTrue(actual.startsWith(prefix));
+            assertTrue(actual.endsWith("\"}"));
+            String[] rendered =
+                    actual.substring(prefix.length(), actual.length() - 2).split(",", -1);
+            assertEquals(rowCount, rendered.length);
+            for (int row = 0; row < rowCount; row++) {
+                assertEquals(
+                        "DOUBLE mismatch at row " + row,
+                        Double.toString(values[row]),
+                        rendered[row]);
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterNestedColumnFallsBackWithoutTouchingOutput()
+            throws Exception {
+        Field element =
+                new Field(
+                        "item",
+                        FieldType.nullable(new ArrowType.Int(32, true)),
+                        null);
+        Field list =
+                new Field(
+                        "items",
+                        FieldType.nullable(ArrowType.List.INSTANCE),
+                        Arrays.asList(element));
+        Schema schema = new Schema(Arrays.asList(
+                Field.notNullable("id", new ArrowType.Int(32, true)),
+                list
+        ));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector ids = (IntVector) root.getVector("id");
+            ListVector items = (ListVector) root.getVector("items");
+            ids.allocateNew(1);
+            items.allocateNew();
+            ids.set(0, 7);
+            UnionListWriter writer = items.getWriter();
+            writer.setPosition(0);
+            writer.startList();
+            writer.writeInt(11);
+            writer.endList();
+            root.setRowCount(1);
+            data = writeToBytes(schema, mosaicWriter -> mosaicWriter.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            output.write(9);
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.UNSUPPORTED,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertArrayEquals(new byte[] {9}, output.toByteArray());
+
+            try (VectorSchemaRoot fallback = rowGroup.readColumns(allocator)) {
+                assertEquals(1, fallback.getRowCount());
+                assertEquals(7, ((IntVector) fallback.getVector("id")).get(0));
+                assertEquals(
+                        11,
+                        ((java.util.List<?>) fallback.getVector("items").getObject(0))
+                                .get(0));
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesProjectedRowGroup() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable("id", new ArrowType.Int(32, true)),
+                                Field.notNullable("value", new ArrowType.Int(32, true))));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector ids = (IntVector) root.getVector("id");
+            IntVector values = (IntVector) root.getVector("value");
+            ids.allocateNew(1);
+            values.allocateNew(1);
+            ids.set(0, 7);
+            values.set(0, 11);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data)) {
+            reader.project(new String[] {"id"});
+            try (MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                assertEquals(
+                        ColumnarTextJsonWriter.Status.WRITTEN,
+                        ColumnarTextJsonWriter.write(rowGroup, output));
+                assertEquals("{\"id\":\"7\"}", output.toString("UTF-8"));
+
+                try (VectorSchemaRoot fallback = rowGroup.readColumns(allocator)) {
+                    assertEquals(1, fallback.getFieldVectors().size());
+                    assertEquals(7, ((IntVector) fallback.getVector("id")).get(0));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonValidatesUtf8DuringStreamingWrite() throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.notNullable("padding", ArrowType.Utf8.INSTANCE),
+                Field.notNullable("text", ArrowType.Utf8.INSTANCE)));
+        byte[] padding = new byte[1024 * 1024 + 1];
+        Arrays.fill(padding, (byte) 'x');
+        byte[] marker = "invalid_utf8_marker".getBytes("UTF-8");
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            VarCharVector first = (VarCharVector) root.getVector("padding");
+            VarCharVector second = (VarCharVector) root.getVector("text");
+            first.allocateNew();
+            second.allocateNew();
+            first.setSafe(0, padding);
+            second.setSafe(0, marker);
+            root.setRowCount(1);
+            data = writeToBytes(schema, new WriterOptions().compression(0).numBuckets(1),
+                    writer -> writer.write(root));
+        }
+        int markerOffset = -1;
+        for (int i = 0; i <= data.length - marker.length; i++) {
+            if (data[i] == marker[0]
+                    && Arrays.equals(marker, Arrays.copyOfRange(data, i, i + marker.length))) {
+                markerOffset = i;
+                break;
+            }
+        }
+        assertTrue("test marker must be in the uncompressed data", markerOffset >= 0);
+        data[markerOffset] = (byte) 0xff;
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            RuntimeException failure = assertThrows(RuntimeException.class,
+                    () -> ColumnarTextJsonWriter.write(rowGroup, output));
+            assertTrue(failure.getMessage().contains("invalid UTF-8"));
+            assertTrue("the public writer must stream instead of pre-reading all text",
+                    output.size() > 0);
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreservesTextAggregationSemantics() throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.nullable("text", ArrowType.Utf8.INSTANCE),
+                Field.notNullable("index", new ArrowType.Int(32, true))));
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            VarCharVector text = (VarCharVector) root.getVector("text");
+            IntVector indexes = (IntVector) root.getVector("index");
+            text.allocateNew();
+            indexes.allocateNew(4);
+            text.setNull(0);
+            text.setSafe(1, new byte[0]);
+            text.setSafe(2, "a,b".getBytes("UTF-8"));
+            text.setSafe(3, "x\"\n".getBytes("UTF-8"));
+            for (int i = 0; i < 4; i++) {
+                indexes.set(i, i);
+            }
+            root.setRowCount(4);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+        try (MosaicReader reader = readerFromBytes(data)) {
+            reader.project(new String[] {"index", "text"});
+            try (MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                assertEquals(ColumnarTextJsonWriter.Status.WRITTEN,
+                        ColumnarTextJsonWriter.write(rowGroup, output));
+                assertEquals("{\"index\":\"0,1,2,3\",\"text\":\",,a,b,x\\\"\\n\"}",
+                        output.toString("UTF-8"));
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterUnsupportedBooleanDoesNotTouchOutput() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "id", new ArrowType.Int(32, true)),
+                                Field.notNullable("value", ArrowType.Bool.INSTANCE)));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector ids = (IntVector) root.getVector("id");
+            BitVector values = (BitVector) root.getVector("value");
+            ids.allocateNew(1);
+            values.allocateNew(1);
+            ids.set(0, 7);
+            values.set(0, 1);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            output.write(9);
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.UNSUPPORTED,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertArrayEquals(new byte[] {9}, output.toByteArray());
+
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesAllNullUnsupportedScalarType() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(Field.nullable("value", ArrowType.Bool.INSTANCE)));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            BitVector values = (BitVector) root.getVector("value");
+            values.allocateNew(3);
+            root.setRowCount(3);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\",,\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesDecimal128AsPlainString() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.nullable(
+                                        "value",
+                                        new ArrowType.Decimal(20, 0, 128))));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            DecimalVector values = (DecimalVector) root.getVector("value");
+            values.allocateNew(3);
+            values.set(0, new BigDecimal("18446744073709551615"));
+            values.setNull(1);
+            values.set(2, new BigDecimal("-9223372036854775809"));
+            root.setRowCount(3);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\"18446744073709551615,,-9223372036854775809\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreservesDecimal128Scale() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value",
+                                        new ArrowType.Decimal(18, 3, 128))));
+        BigDecimal[] expectedValues = {
+            new BigDecimal("12.340"),
+            new BigDecimal("-0.005"),
+            new BigDecimal("0.000")
+        };
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            DecimalVector values = (DecimalVector) root.getVector("value");
+            values.allocateNew(expectedValues.length);
+            for (int row = 0; row < expectedValues.length; row++) {
+                values.set(row, expectedValues[row]);
+            }
+            root.setRowCount(expectedValues.length);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\"12.340,-0.005,0.000\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreservesNegativeDecimalScale() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value",
+                                        new ArrowType.Decimal(18, -2, 128))));
+        BigDecimal[] expectedValues = {
+            new BigDecimal(BigInteger.ZERO, -2),
+            new BigDecimal(BigInteger.valueOf(123), -2)
+        };
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            DecimalVector values = (DecimalVector) root.getVector("value");
+            values.allocateNew(expectedValues.length);
+            for (int row = 0; row < expectedValues.length; row++) {
+                values.set(row, expectedValues[row]);
+            }
+            root.setRowCount(expectedValues.length);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\"0,12300\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreserves128BitDecimalValuesAcrossScales() throws Exception {
+        assertLargeDecimalJson(
+                new ArrowType.Decimal(20, 3, 128),
+                new BigDecimal[] {
+                    new BigDecimal("18446744073709551.615"),
+                    new BigDecimal("-9223372036854775.809"),
+                    new BigDecimal("0.000")
+                },
+                "{\"value\":\"18446744073709551.615,-9223372036854775.809,0.000\"}");
+        assertLargeDecimalJson(
+                new ArrowType.Decimal(20, -2, 128),
+                new BigDecimal[] {
+                    new BigDecimal(new BigInteger("18446744073709551615"), -2),
+                    new BigDecimal(new BigInteger("-9223372036854775809"), -2),
+                    new BigDecimal(BigInteger.ZERO, -2)
+                },
+                "{\"value\":\"1844674407370955161500,-922337203685477580900,0\"}");
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterMatchesArrowDecimalPlainStringOracle() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.nullable(
+                                        "scale_minus_1",
+                                        new ArrowType.Decimal(18, -1, 128)),
+                                Field.nullable(
+                                        "scale_minus_2",
+                                        new ArrowType.Decimal(19, -2, 128)),
+                                Field.nullable(
+                                        "scale_minus_3",
+                                        new ArrowType.Decimal(19, -3, 128)),
+                                Field.nullable(
+                                        "precision_19_scale_4",
+                                        new ArrowType.Decimal(19, 4, 128)),
+                                Field.nullable(
+                                        "precision_19_scale_0",
+                                        new ArrowType.Decimal(19, 0, 128))));
+        BigDecimal[][] values = {
+            {
+                new BigDecimal(BigInteger.ZERO, -1),
+                new BigDecimal(new BigInteger("123456789012345678"), -1),
+                new BigDecimal(new BigInteger("-123456789012345678"), -1),
+                null
+            },
+            {
+                new BigDecimal(BigInteger.ZERO, -2),
+                new BigDecimal(new BigInteger("1234567890123456789"), -2),
+                new BigDecimal(new BigInteger("-1234567890123456789"), -2),
+                null
+            },
+            {
+                new BigDecimal(BigInteger.ZERO, -3),
+                new BigDecimal(new BigInteger("9876543210123456789"), -3),
+                new BigDecimal(new BigInteger("-9876543210123456789"), -3),
+                null
+            },
+            {
+                new BigDecimal("0.0000"),
+                new BigDecimal("123456789012345.6789"),
+                new BigDecimal("-999999999999999.9999"),
+                null
+            },
+            {
+                new BigDecimal("0"),
+                new BigDecimal("9999999999999999999"),
+                new BigDecimal("-9223372036854775809"),
+                null
+            }
+        };
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            for (int column = 0; column < values.length; column++) {
+                DecimalVector vector = (DecimalVector) root.getVector(column);
+                vector.allocateNew(values[column].length);
+                for (int row = 0; row < values[column].length; row++) {
+                    if (values[column][row] == null) {
+                        vector.setNull(row);
+                    } else {
+                        vector.set(row, values[column][row]);
+                    }
+                }
+            }
+            root.setRowCount(values[0].length);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            try (VectorSchemaRoot arrow = rowGroup.readColumns(allocator)) {
+                assertEquals(
+                        renderDecimalColumnarJson(arrow),
+                        new String(
+                                output.toByteArray(),
+                                java.nio.charset.StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesReadableDecimalBeyondDeclaredPrecision()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value",
+                                        new ArrowType.Decimal(1, 0, 128))));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            DecimalVector value = (DecimalVector) root.getVector("value");
+            value.allocateNew(1);
+            value.set(0, 123L);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            try (VectorSchemaRoot arrow = rowGroup.readColumns(allocator)) {
+                assertEquals(new BigDecimal("123"), arrow.getVector("value").getObject(0));
+            }
+
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\"123\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    private void assertLargeDecimalJson(
+            ArrowType.Decimal type, BigDecimal[] values, String expected) throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable("value", type)));
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            DecimalVector vector = (DecimalVector) root.getVector("value");
+            vector.allocateNew(values.length);
+            for (int row = 0; row < values.length; row++) {
+                vector.set(row, values[row]);
+            }
+            root.setRowCount(values.length);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    expected,
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterFormatsDoublesOutsideNativeRangeWithJava() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value",
+                                        new ArrowType.FloatingPoint(
+                                                FloatingPointPrecision.DOUBLE))));
+
+        double[] expectedValues = {
+            Double.MIN_VALUE,
+            Double.longBitsToDouble(TINY_DOUBLE_ROUNDING_REGRESSION_BITS),
+            Double.longBitsToDouble(LARGE_DOUBLE_ROUNDING_REGRESSION_BITS)
+        };
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            Float8Vector values = (Float8Vector) root.getVector("value");
+            values.allocateNew(expectedValues.length);
+            for (int row = 0; row < expectedValues.length; row++) {
+                values.set(row, expectedValues[row]);
+            }
+            root.setRowCount(expectedValues.length);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"value\":\"4.9E-324,2.8421709430404007E-14,"
+                            + "5.7722107746645115E18\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterNonFiniteDoubleDoesNotTouchOutput() throws Exception {
+        for (double value :
+                new double[] {
+                    Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY
+                }) {
+            Schema schema =
+                    new Schema(
+                            Arrays.asList(
+                                    Field.notNullable(
+                                            "value",
+                                            new ArrowType.FloatingPoint(
+                                                    FloatingPointPrecision.DOUBLE))));
+
+            byte[] data;
+            try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+                Float8Vector values = (Float8Vector) root.getVector("value");
+                values.allocateNew(1);
+                values.set(0, value);
+                root.setRowCount(1);
+                data = writeToBytes(schema, writer -> writer.write(root));
+            }
+
+            try (MosaicReader reader = readerFromBytes(data);
+                    MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                output.write(9);
+                assertEquals(
+                        ColumnarTextJsonWriter.Status.UNSUPPORTED,
+                        ColumnarTextJsonWriter.write(rowGroup, output));
+                assertArrayEquals(new byte[] {9}, output.toByteArray());
+
+            }
+        }
+    }
+
+    private static String renderDecimalColumnarJson(VectorSchemaRoot root) {
+        StringBuilder expected = new StringBuilder("{");
+        for (int column = 0; column < root.getFieldVectors().size(); column++) {
+            if (column > 0) {
+                expected.append(',');
+            }
+            DecimalVector vector = (DecimalVector) root.getVector(column);
+            expected.append('"').append(vector.getName()).append("\":\"");
+            for (int row = 0; row < root.getRowCount(); row++) {
+                if (row > 0) {
+                    expected.append(',');
+                }
+                if (!vector.isNull(row)) {
+                    expected.append(vector.getObject(row).toPlainString());
+                }
+            }
+            expected.append('"');
+        }
+        return expected.append('}').toString();
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterStreamsRowGroupAboveFormerRowBudget()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.nullable(
+                                        "value", new ArrowType.Int(8, true))));
+        int rowCount = 1_000_001;
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            TinyIntVector values = (TinyIntVector) root.getVector("value");
+            values.allocateNew(rowCount);
+            root.setRowCount(rowCount);
+            data =
+                    writeToBytes(
+                            schema,
+                            new WriterOptions().rowGroupMaxSize(512L * 1024 * 1024),
+                            writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            byte[] bytes = output.toByteArray();
+            assertEquals(rowCount + 11, bytes.length);
+            assertEquals('{', bytes[0]);
+            assertEquals('}', bytes[bytes.length - 1]);
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterStreamsWhenWorstCaseEstimateExceedsFormerBudget()
+            throws Exception {
+        int rowCount = 1_000_000;
+        List<Field> fields = new ArrayList<>();
+        for (int column = 0; column < 4; column++) {
+            fields.add(
+                    Field.notNullable(
+                            "value_" + column,
+                            new ArrowType.Decimal(38, -128, 128)));
+        }
+        Schema schema = new Schema(fields);
+        BigDecimal zero = new BigDecimal(BigInteger.ZERO, -128);
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            for (FieldVector fieldVector : root.getFieldVectors()) {
+                DecimalVector vector = (DecimalVector) fieldVector;
+                vector.allocateNew(rowCount);
+                for (int row = 0; row < rowCount; row++) {
+                    vector.set(row, zero);
+                }
+            }
+            root.setRowCount(rowCount);
+            data =
+                    writeToBytes(
+                            schema,
+                            new WriterOptions().rowGroupMaxSize(512L * 1024 * 1024),
+                            writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(8_000_049, output.size());
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterWritesDictionaryAndAllNullColumns() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.nullable("all_null", ArrowType.Utf8.INSTANCE),
+                                Field.nullable("dict", ArrowType.Utf8.INSTANCE)));
+        int rowCount = 128;
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            VarCharVector allNull = (VarCharVector) root.getVector("all_null");
+            VarCharVector dict = (VarCharVector) root.getVector("dict");
+            allNull.allocateNew();
+            dict.allocateNew();
+            for (int row = 0; row < rowCount; row++) {
+                if (row % 5 != 0) {
+                    dict.setSafe(
+                            row,
+                            (row % 2 == 0 ? "alpha" : "beta")
+                                    .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                }
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        StringBuilder allNull = new StringBuilder();
+        StringBuilder dict = new StringBuilder();
+        for (int row = 0; row < rowCount; row++) {
+            if (row > 0) {
+                allNull.append(',');
+                dict.append(',');
+            }
+            if (row % 5 != 0) {
+                dict.append(row % 2 == 0 ? "alpha" : "beta");
+            }
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"all_null\":\""
+                            + allNull
+                            + "\",\"dict\":\""
+                            + dict
+                            + "\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterBatchesNullableConstantsAcrossSupportedTypes()
+            throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.nullable("i16", new ArrowType.Int(16, true)),
+                Field.nullable("i64", new ArrowType.Int(64, true)),
+                Field.nullable("text", ArrowType.Utf8.INSTANCE)
+        ));
+        int rowCount = 26;
+
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            SmallIntVector i16 = (SmallIntVector) root.getVector("i16");
+            BigIntVector i64 = (BigIntVector) root.getVector("i64");
+            VarCharVector text = (VarCharVector) root.getVector("text");
+            i16.allocateNew(rowCount);
+            i64.allocateNew(rowCount);
+            text.allocateNew();
+            for (int row = 0; row < rowCount; row++) {
+                int bit = row & 7;
+                if (bit == 1 || bit == 3 || bit == 4 || bit == 7) {
+                    i16.set(row, 0);
+                    i64.set(row, -7);
+                    text.setSafe(
+                            row,
+                            "x".getBytes(
+                                    java.nio.charset.StandardCharsets.UTF_8));
+                }
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        StringBuilder zero = new StringBuilder();
+        StringBuilder minusSeven = new StringBuilder();
+        StringBuilder text = new StringBuilder();
+        for (int row = 0; row < rowCount; row++) {
+            if (row > 0) {
+                zero.append(',');
+                minusSeven.append(',');
+                text.append(',');
+            }
+            int bit = row & 7;
+            if (bit == 1 || bit == 3 || bit == 4 || bit == 7) {
+                zero.append('0');
+                minusSeven.append("-7");
+                text.append('x');
+            }
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals(
+                    "{\"i16\":\""
+                            + zero
+                            + "\",\"i64\":\""
+                            + minusSeven
+                            + "\",\"text\":\""
+                            + text
+                            + "\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreservesOutputException() throws Exception {
+        Schema schema = new Schema(Arrays.asList(
+                Field.notNullable("id", new ArrowType.Int(32, true))
+        ));
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector ids = (IntVector) root.getVector("id");
+            ids.allocateNew(1);
+            ids.set(0, 7);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            FailOnceOutputStream output =
+                    new FailOnceOutputStream(
+                            FailurePoint.WRITE,
+                            "sentinel-columnar-text-json");
+            IOException error =
+                    assertThrows(
+                            IOException.class,
+                            () -> ColumnarTextJsonWriter.write(rowGroup, output));
+            assertSame(output.failure, error);
+            assertEquals("sentinel-columnar-text-json", error.getMessage());
+            assertEquals(1, output.writeCalls);
+            assertEquals(0, output.flushCalls);
+
+            try (VectorSchemaRoot fallback = rowGroup.readColumns(allocator)) {
+                assertEquals(7, ((IntVector) fallback.getVector("id")).get(0));
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterPreservesMidStreamOutputException() throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        int rowCount = ROW_COUNT_FOR_MULTIPLE_OUTPUT_WRITES;
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(rowCount);
+            for (int row = 0; row < rowCount; row++) {
+                values.set(row, row);
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            FailOnceOutputStream output =
+                    new FailOnceOutputStream(
+                            FailurePoint.WRITE,
+                            2,
+                            "sentinel-columnar-text-json-mid-stream");
+            IOException error =
+                    assertThrows(
+                            IOException.class,
+                            () -> ColumnarTextJsonWriter.write(rowGroup, output));
+            assertSame(output.failure, error);
+            assertEquals("sentinel-columnar-text-json-mid-stream", error.getMessage());
+            assertEquals(2, output.writeCalls);
+            assertTrue(output.size() > 0);
+            assertEquals(0, output.flushCalls);
+
+            try (VectorSchemaRoot fallback = rowGroup.readColumns(allocator)) {
+                assertEquals(rowCount, fallback.getRowCount());
+                assertEquals(0, ((IntVector) fallback.getVector("value")).get(0));
+                assertEquals(
+                        rowCount - 1,
+                        ((IntVector) fallback.getVector("value")).get(rowCount - 1));
+            }
+        }
+    }
+
+    @Test
+    public void testColumnarTextJsonWriterNeverFlushesOrClosesCallerOutput()
+            throws Exception {
+        Schema supportedSchema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        byte[] supportedData;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(supportedSchema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(1);
+            values.set(0, 7);
+            root.setRowCount(1);
+            supportedData = writeToBytes(supportedSchema, writer -> writer.write(root));
+        }
+        try (MosaicReader reader = readerFromBytes(supportedData);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            OwnershipTrackingOutputStream output = new OwnershipTrackingOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertEquals("{\"value\":\"7\"}", output.toString("UTF-8"));
+            assertEquals(0, output.flushCalls);
+            assertEquals(0, output.closeCalls);
+        }
+
+        Schema unsupportedSchema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable("value", ArrowType.Bool.INSTANCE)));
+        byte[] unsupportedData;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(unsupportedSchema, allocator)) {
+            BitVector values = (BitVector) root.getVector("value");
+            values.allocateNew(1);
+            values.set(0, 1);
+            root.setRowCount(1);
+            unsupportedData =
+                    writeToBytes(unsupportedSchema, writer -> writer.write(root));
+        }
+        try (MosaicReader reader = readerFromBytes(unsupportedData);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            OwnershipTrackingOutputStream output = new OwnershipTrackingOutputStream();
+            output.write(9);
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.UNSUPPORTED,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertArrayEquals(new byte[] {9}, output.toByteArray());
+            assertEquals(0, output.flushCalls);
+            assertEquals(0, output.closeCalls);
+        }
+    }
+
+    @Test
+    public void testMosaicRowGroupReaderRejectsReentrantUseFromOutputCallback()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(1);
+            values.set(0, 7);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            ReentrantWriteOutputStream output = new ReentrantWriteOutputStream(rowGroup);
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertTrue(output.reentrantFailure instanceof IllegalStateException);
+            assertEquals(
+                    "row group reader is already in use",
+                    output.reentrantFailure.getMessage());
+        }
+    }
+
+    @Test
+    public void testMosaicRowGroupReaderDefersReentrantCloseUntilWriteCompletes()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        int rowCount = ROW_COUNT_FOR_MULTIPLE_OUTPUT_WRITES;
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(rowCount);
+            for (int row = 0; row < rowCount; row++) {
+                values.set(row, row);
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            long nativeHandle = nativeHandle(rowGroup);
+            assertTrue(nativeHandle != 0);
+            CloseOnFirstWriteOutputStream output =
+                    new CloseOnFirstWriteOutputStream(rowGroup);
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(rowGroup, output));
+            assertTrue(output.closeRequested);
+            assertEquals(nativeHandle, output.nativeHandleAfterClose);
+            assertTrue(output.writeCalls > 1);
+            assertTrue(output.size() > output.firstWriteBytes);
+            assertEquals(0, nativeHandle(rowGroup));
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> rowGroup.readColumns(allocator));
+        }
+    }
+
+    @Test
+    public void testMosaicRowGroupReaderDefersConcurrentCloseUntilWriteCompletes()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        int rowCount = 500_000;
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(rowCount);
+            for (int row = 0; row < rowCount; row++) {
+                values.set(row, row);
+            }
+            root.setRowCount(rowCount);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        try (MosaicReader reader = readerFromBytes(data);
+                MosaicRowGroupReader rowGroup = reader.openRowGroup(0)) {
+            long nativeHandle = nativeHandle(rowGroup);
+            assertTrue(nativeHandle != 0);
+            BlockingWriteOutputStream output = new BlockingWriteOutputStream();
+            AtomicReference<Throwable> writeFailure = new AtomicReference<>();
+            AtomicReference<Throwable> closeFailure = new AtomicReference<>();
+            CountDownLatch closeReturned = new CountDownLatch(1);
+            Thread writer =
+                    new Thread(
+                            () -> {
+                                try {
+                                    assertEquals(
+                                            ColumnarTextJsonWriter.Status.WRITTEN,
+                                            ColumnarTextJsonWriter.write(rowGroup, output));
+                                } catch (Throwable failure) {
+                                    writeFailure.set(failure);
+                                }
+                            },
+                            "mosaic-row-group-writer");
+            Thread closer =
+                    new Thread(
+                            () -> {
+                                try {
+                                    rowGroup.close();
+                                } catch (Throwable failure) {
+                                    closeFailure.set(failure);
+                                } finally {
+                                    closeReturned.countDown();
+                                }
+                            },
+                            "mosaic-row-group-closer");
+            writer.setDaemon(true);
+            closer.setDaemon(true);
+
+            writer.start();
+            try {
+                assertTrue(
+                        output.enteredWrite.await(
+                                5, java.util.concurrent.TimeUnit.SECONDS));
+                closer.start();
+                assertTrue(
+                        closeReturned.await(
+                                5, java.util.concurrent.TimeUnit.SECONDS));
+                assertNull(closeFailure.get());
+                assertEquals(nativeHandle, nativeHandle(rowGroup));
+                assertThrows(
+                        IllegalStateException.class,
+                        () -> rowGroup.readColumns(allocator));
+            } finally {
+                output.releaseWrite.countDown();
+                writer.join(5_000L);
+                closer.join(5_000L);
+                if (writer.isAlive()) {
+                    writer.interrupt();
+                    writer.join(1_000L);
+                }
+                if (closer.isAlive()) {
+                    closer.interrupt();
+                    closer.join(1_000L);
+                }
+            }
+
+            assertFalse(writer.isAlive());
+            assertFalse(closer.isAlive());
+            assertNull(writeFailure.get());
+            assertTrue(output.writeCalls > 1);
+            assertTrue(output.size() > output.firstWriteBytes);
+            assertEquals(0, nativeHandle(rowGroup));
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> rowGroup.readColumns(allocator));
+        }
+    }
+
+    @Test
+    public void testMosaicRowGroupReaderCloseIsIdempotentAndRejectsFurtherUse()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector values = (IntVector) root.getVector("value");
+            values.allocateNew(1);
+            values.set(0, 7);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        MosaicReader reader = readerFromBytes(data);
+        MosaicRowGroupReader rowGroup = reader.openRowGroup(0);
+        rowGroup.close();
+        rowGroup.close();
+
+        assertThrows(IllegalStateException.class, () -> rowGroup.readColumns(allocator));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write(9);
+        assertThrows(
+                IllegalStateException.class,
+                () -> ColumnarTextJsonWriter.write(rowGroup, output));
+        assertArrayEquals(new byte[] {9}, output.toByteArray());
+
+        reader.close();
+        assertThrows(IllegalStateException.class, () -> reader.openRowGroup(0));
+    }
+
+    @Test
+    public void testMosaicRowGroupReaderOutlivesReaderAndFreezesProjection()
+            throws Exception {
+        Schema schema =
+                new Schema(
+                        Arrays.asList(
+                                Field.notNullable(
+                                        "id", new ArrowType.Int(32, true)),
+                                Field.notNullable(
+                                        "value", new ArrowType.Int(32, true))));
+        byte[] data;
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            IntVector ids = (IntVector) root.getVector("id");
+            IntVector values = (IntVector) root.getVector("value");
+            ids.allocateNew(1);
+            values.allocateNew(1);
+            ids.set(0, 7);
+            values.set(0, 11);
+            root.setRowCount(1);
+            data = writeToBytes(schema, writer -> writer.write(root));
+        }
+
+        MosaicReader reader = readerFromBytes(data);
+        MosaicRowGroupReader rowGroup = reader.openRowGroup(0);
+        reader.project(new String[] {"id"});
+        reader.close();
+
+        try (MosaicRowGroupReader ownedRowGroup = rowGroup) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            assertEquals(
+                    ColumnarTextJsonWriter.Status.WRITTEN,
+                    ColumnarTextJsonWriter.write(ownedRowGroup, output));
+            assertEquals(
+                    "{\"id\":\"7\",\"value\":\"11\"}",
+                    new String(
+                            output.toByteArray(),
+                            java.nio.charset.StandardCharsets.UTF_8));
+        }
     }
 
     @Test

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -30,3 +30,4 @@ mosaic-core = { path = "../core", package = "paimon-mosaic-core" }
 jni = "0.21"
 arrow-schema = "58"
 arrow-array = { version = "58", features = ["ffi"] }
+ryu = "1"

--- a/jni/DEPENDENCIES.rust.tsv
+++ b/jni/DEPENDENCIES.rust.tsv
@@ -1,94 +1,95 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-ahash@0.8.12	X					X
-android_system_properties@0.1.6	X					X
-arrow-array@58.4.0	X					X
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSL-1.0	CC0-1.0	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
+ahash@0.8.12	X						X
+android_system_properties@0.1.6	X						X
+arrow-array@58.4.0	X						X
 arrow-buffer@58.4.0	X
 arrow-data@58.4.0	X
 arrow-schema@58.4.0	X
-autocfg@1.5.1	X					X
-bitflags@2.13.1	X					X
-bumpalo@3.20.3	X					X
-bytes@1.12.1						X
-cc@1.4.3	X					X
-cesu8@1.1.0	X					X
-cfg-if@1.0.4	X					X
-chrono@0.4.45	X					X
-combine@4.6.7						X
-const-random@0.1.18	X					X
-const-random-macro@0.1.16	X					X
-core-foundation-sys@0.8.7	X					X
-crunchy@0.2.4						X
-find-msvc-tools@0.1.11	X					X
-futures-core@0.3.34	X					X
-futures-task@0.3.34	X					X
-futures-util@0.3.34	X					X
-getrandom@0.2.17	X					X
-getrandom@0.3.4	X					X
-getrandom@0.4.3	X					X
-half@2.7.1	X					X
-hashbrown@0.17.1	X					X
-iana-time-zone@0.1.65	X					X
-iana-time-zone-haiku@0.1.2	X					X
-jni@0.21.1	X					X
-jni-sys@0.3.1	X					X
-jni-sys@0.4.1	X					X
-jni-sys-macros@0.4.1	X					X
-jobserver@0.1.35	X					X
-js-sys@0.3.104	X					X
-libc@0.2.189	X					X
-libm@0.2.16						X
-log@0.4.33	X					X
-memchr@2.8.3						X		X
-num-bigint@0.4.8	X					X
-num-complex@0.4.6	X					X
-num-integer@0.1.47	X					X
-num-traits@0.2.19	X					X
-once_cell@1.21.4	X					X
+autocfg@1.5.1	X						X
+bitflags@2.13.1	X						X
+bumpalo@3.20.3	X						X
+bytes@1.12.1							X
+cc@1.4.3	X						X
+cesu8@1.1.0	X						X
+cfg-if@1.0.4	X						X
+chrono@0.4.45	X						X
+combine@4.6.7							X
+const-random@0.1.18	X						X
+const-random-macro@0.1.16	X						X
+core-foundation-sys@0.8.7	X						X
+crunchy@0.2.4							X
+find-msvc-tools@0.1.11	X						X
+futures-core@0.3.34	X						X
+futures-task@0.3.34	X						X
+futures-util@0.3.34	X						X
+getrandom@0.2.17	X						X
+getrandom@0.3.4	X						X
+getrandom@0.4.3	X						X
+half@2.7.1	X						X
+hashbrown@0.17.1	X						X
+iana-time-zone@0.1.65	X						X
+iana-time-zone-haiku@0.1.2	X						X
+jni@0.21.1	X						X
+jni-sys@0.3.1	X						X
+jni-sys@0.4.1	X						X
+jni-sys-macros@0.4.1	X						X
+jobserver@0.1.35	X						X
+js-sys@0.3.104	X						X
+libc@0.2.189	X						X
+libm@0.2.16							X
+log@0.4.33	X						X
+memchr@2.8.3							X		X
+num-bigint@0.4.8	X						X
+num-complex@0.4.6	X						X
+num-integer@0.1.47	X						X
+num-traits@0.2.19	X						X
+once_cell@1.21.4	X						X
 paimon-mosaic-core@0.3.0	X
 paimon-mosaic-jni@0.3.0	X
-pin-project-lite@0.2.17	X					X
-pkg-config@0.3.34	X					X
-proc-macro2@1.0.107	X					X
-quote@1.0.47	X					X
-r-efi@5.3.0	X				X	X
-r-efi@6.0.0	X				X	X
-rustversion@1.0.23	X					X
-same-file@1.0.6						X		X
-shlex@2.0.1	X					X
-slab@0.4.12						X
-syn@2.0.119	X					X
-thiserror@1.0.69	X					X
-thiserror-impl@1.0.69	X					X
-tiny-keccak@2.0.2				X
-unicode-ident@1.0.24	X					X	X
-version_check@0.9.5	X					X
-walkdir@2.5.0						X		X
-wasi@0.11.1+wasi-snapshot-preview1	X	X				X
-wasip2@1.0.4+wasi-0.2.12	X	X				X
-wasm-bindgen@0.2.127	X					X
-wasm-bindgen-macro@0.2.127	X					X
-wasm-bindgen-macro-support@0.2.127	X					X
-wasm-bindgen-shared@0.2.127	X					X
-winapi-util@0.1.11						X		X
-windows-core@0.62.2	X					X
-windows-implement@0.60.2	X					X
-windows-interface@0.59.3	X					X
-windows-link@0.2.1	X					X
-windows-result@0.4.1	X					X
-windows-strings@0.5.1	X					X
-windows-sys@0.45.0	X					X
-windows-sys@0.61.2	X					X
-windows-targets@0.42.2	X					X
-windows_aarch64_gnullvm@0.42.2	X					X
-windows_aarch64_msvc@0.42.2	X					X
-windows_i686_gnu@0.42.2	X					X
-windows_i686_msvc@0.42.2	X					X
-windows_x86_64_gnu@0.42.2	X					X
-windows_x86_64_gnullvm@0.42.2	X					X
-windows_x86_64_msvc@0.42.2	X					X
-wit-bindgen@0.57.1	X	X				X
-zerocopy@0.8.56	X		X			X
-zerocopy-derive@0.8.56	X		X			X
-zstd@0.13.3						X
-zstd-safe@7.2.4	X					X
-zstd-sys@2.0.16+zstd.1.5.7	X					X
+pin-project-lite@0.2.17	X						X
+pkg-config@0.3.34	X						X
+proc-macro2@1.0.107	X						X
+quote@1.0.47	X						X
+r-efi@5.3.0	X					X	X
+r-efi@6.0.0	X					X	X
+rustversion@1.0.23	X						X
+ryu@1.0.23	X			X
+same-file@1.0.6							X		X
+shlex@2.0.1	X						X
+slab@0.4.12							X
+syn@2.0.119	X						X
+thiserror@1.0.69	X						X
+thiserror-impl@1.0.69	X						X
+tiny-keccak@2.0.2					X
+unicode-ident@1.0.24	X						X	X
+version_check@0.9.5	X						X
+walkdir@2.5.0							X		X
+wasi@0.11.1+wasi-snapshot-preview1	X	X					X
+wasip2@1.0.4+wasi-0.2.12	X	X					X
+wasm-bindgen@0.2.127	X						X
+wasm-bindgen-macro@0.2.127	X						X
+wasm-bindgen-macro-support@0.2.127	X						X
+wasm-bindgen-shared@0.2.127	X						X
+winapi-util@0.1.11							X		X
+windows-core@0.62.2	X						X
+windows-implement@0.60.2	X						X
+windows-interface@0.59.3	X						X
+windows-link@0.2.1	X						X
+windows-result@0.4.1	X						X
+windows-strings@0.5.1	X						X
+windows-sys@0.45.0	X						X
+windows-sys@0.61.2	X						X
+windows-targets@0.42.2	X						X
+windows_aarch64_gnullvm@0.42.2	X						X
+windows_aarch64_msvc@0.42.2	X						X
+windows_i686_gnu@0.42.2	X						X
+windows_i686_msvc@0.42.2	X						X
+windows_x86_64_gnu@0.42.2	X						X
+windows_x86_64_gnullvm@0.42.2	X						X
+windows_x86_64_msvc@0.42.2	X						X
+wit-bindgen@0.57.1	X	X					X
+zerocopy@0.8.56	X		X				X
+zerocopy-derive@0.8.56	X		X				X
+zstd@0.13.3							X
+zstd-safe@7.2.4	X						X
+zstd-sys@2.0.16+zstd.1.5.7	X						X

--- a/jni/src/columnar_text_json.rs
+++ b/jni/src/columnar_text_json.rs
@@ -1,0 +1,2019 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::BTreeSet;
+use std::io::{self, Write};
+
+use arrow_schema::DataType;
+use mosaic_core::bucket_reader::{EncodedColumn, EncodedValueRef};
+use mosaic_core::reader::{Encoding, RowGroupReader};
+
+const MIN_EXACT_DOUBLE_ABS: f64 = 1.0e-6;
+const MAX_EXACT_DOUBLE_ABS: f64 = 1.0e9;
+const MAX_DISTINCT_JAVA_DOUBLE_VALUES: usize = 65_536;
+const COMMA_BLOCK: [u8; 64] = [b','; 64];
+const REPEATED_VALUE_BUFFER_BYTES: usize = 64 * 1024;
+const NULLABLE_CONST_PATTERN_COUNT: usize = 256;
+const NULLABLE_CONST_CACHE_BYTES: usize = 64 * 1024;
+
+pub(crate) struct EncodedJsonPreflight {
+    java_double_bits: Vec<u64>,
+}
+
+impl EncodedJsonPreflight {
+    pub(crate) fn java_double_bits(&self) -> &[u64] {
+        &self.java_double_bits
+    }
+
+    pub(crate) fn complete(self, values: Vec<Vec<u8>>) -> io::Result<EncodedJsonPlan> {
+        if values.len() != self.java_double_bits.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Java returned {} DOUBLE strings for {} requested values",
+                    values.len(),
+                    self.java_double_bits.len()
+                ),
+            ));
+        }
+        for (&bits, value) in self.java_double_bits.iter().zip(&values) {
+            let rendered = std::str::from_utf8(value).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Java returned non-UTF-8 DOUBLE text: {}", error),
+                )
+            })?;
+            let parsed = rendered.parse::<f64>().map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Java returned invalid DOUBLE text '{}': {}",
+                        rendered, error
+                    ),
+                )
+            })?;
+            if parsed.to_bits() != bits {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Java DOUBLE text '{}' does not round-trip to 0x{:016x}",
+                        rendered, bits
+                    ),
+                ));
+            }
+        }
+        Ok(EncodedJsonPlan {
+            java_double_values: self.java_double_bits.into_iter().zip(values).collect(),
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct EncodedJsonPlan {
+    java_double_values: Vec<(u64, Vec<u8>)>,
+}
+
+impl EncodedJsonPlan {
+    fn java_double_value(&self, bits: u64) -> Option<&[u8]> {
+        let index = self
+            .java_double_values
+            .binary_search_by_key(&bits, |(stored_bits, _)| *stored_bits)
+            .ok()?;
+        Some(self.java_double_values[index].1.as_slice())
+    }
+}
+
+fn text_size_overflow() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "columnar JSON size calculation overflowed",
+    )
+}
+
+fn has_supported_structure(data_type: &DataType, encoding: Encoding) -> bool {
+    if encoding == Encoding::AllNull {
+        return true;
+    }
+    matches!(
+        data_type,
+        DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Float64
+            | DataType::Decimal128(_, _)
+            | DataType::Utf8
+    ) && matches!(encoding, Encoding::Const | Encoding::Dict | Encoding::Plain)
+}
+
+/// Checks format support and prepares JVM-compatible DOUBLE text before emitting any bytes.
+/// Other values are validated as they are written, without a second full decoding pass.
+pub(crate) fn prepare_encoded(
+    row_group: &RowGroupReader,
+) -> io::Result<Option<EncodedJsonPreflight>> {
+    let mut columns = 0usize;
+    let mut fallback_required = false;
+    let mut java_double_bits = BTreeSet::new();
+    let result = row_group.visit_encoded_columns(|_name, data_type, _, column| {
+        columns += 1;
+        if column.num_rows() != row_group.num_rows() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "column row count {} does not match row group row count {}",
+                    column.num_rows(),
+                    row_group.num_rows()
+                ),
+            ));
+        }
+        if !has_supported_structure(data_type, column.encoding()) {
+            fallback_required = true;
+            return Ok(());
+        }
+        if matches!(data_type, DataType::Float64) && column.encoding() != Encoding::AllNull {
+            match validate_float64_column(column, &mut java_double_bits) {
+                Ok(true) => {}
+                Ok(false) => fallback_required = true,
+                Err(error) if error.kind() == io::ErrorKind::Unsupported => {
+                    fallback_required = true;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    });
+    match result {
+        Ok(()) if columns == 0 || fallback_required => {
+            // Preserve errors in supported columns rather than hide them behind another column's
+            // fallback decision. This extra pass is not needed on the supported streaming path.
+            validate_fallback_columns(row_group)?;
+            Ok(None)
+        }
+        Ok(()) => Ok(Some(EncodedJsonPreflight {
+            java_double_bits: java_double_bits.into_iter().collect(),
+        })),
+        Err(error) if error.kind() == io::ErrorKind::Unsupported => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn validate_fallback_columns(row_group: &RowGroupReader) -> io::Result<()> {
+    row_group.visit_encoded_columns(|_, data_type, _, column| {
+        if column.encoding() == Encoding::AllNull
+            || !has_supported_structure(data_type, column.encoding())
+        {
+            return Ok(());
+        }
+        match data_type {
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {
+                validate_integer_column(column)?;
+            }
+            DataType::Decimal128(_, _) => {
+                validate_decimal_column(column)?;
+            }
+            DataType::Utf8 => {
+                validate_utf8_column(column)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    })
+}
+
+pub(crate) fn write_encoded_supported<W: Write>(
+    row_group: &RowGroupReader,
+    plan: &EncodedJsonPlan,
+    output: &mut W,
+) -> io::Result<()> {
+    let mut writer = EncodedJsonWriter {
+        output,
+        plan,
+        value_buffer: Vec::with_capacity(64),
+        repeated_buffer: Vec::with_capacity(REPEATED_VALUE_BUFFER_BYTES),
+        nullable_block_cache: (0..NULLABLE_CONST_PATTERN_COUNT).map(|_| None).collect(),
+        nullable_cache_bytes: 0,
+        column_index: 0,
+    };
+    writer.output.write_all(b"{")?;
+    row_group.visit_encoded_columns(|name, data_type, _, column| {
+        writer.write_column(name, data_type, column)
+    })?;
+    writer.output.write_all(b"}")
+}
+
+fn validate_integer_column(column: EncodedColumn<'_>) -> io::Result<bool> {
+    match column.encoding() {
+        Encoding::AllNull => Ok(true),
+        Encoding::Const => {
+            if !has_non_null(&column) {
+                return Ok(true);
+            }
+            match column.constant()? {
+                Some(value) if integer_value_matches(column.data_type(), value) => Ok(true),
+                _ => Err(encoded_type_mismatch(column.data_type())),
+            }
+        }
+        Encoding::Dict | Encoding::Plain => {
+            for value in column.values() {
+                let value = value?;
+                if !matches!(value, EncodedValueRef::Null)
+                    && !integer_value_matches(column.data_type(), value)
+                {
+                    return Err(encoded_type_mismatch(column.data_type()));
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn integer_value_matches(data_type: &DataType, value: EncodedValueRef<'_>) -> bool {
+    matches!(
+        (data_type, value),
+        (DataType::Int8, EncodedValueRef::Int8(_))
+            | (DataType::Int16, EncodedValueRef::Int16(_))
+            | (DataType::Int32, EncodedValueRef::Int32(_))
+            | (DataType::Int64, EncodedValueRef::Int64(_))
+    )
+}
+
+fn validate_float64_column(
+    column: EncodedColumn<'_>,
+    java_double_bits: &mut BTreeSet<u64>,
+) -> io::Result<bool> {
+    match column.encoding() {
+        Encoding::AllNull => Ok(true),
+        Encoding::Const => {
+            if !has_non_null(&column) {
+                return Ok(true);
+            }
+            match column.constant()? {
+                Some(EncodedValueRef::Float64(value)) => {
+                    prepare_double_value(value, java_double_bits)
+                }
+                _ => Err(encoded_type_mismatch(column.data_type())),
+            }
+        }
+        Encoding::Dict | Encoding::Plain => {
+            let mut supported = true;
+            for value in column.values() {
+                match value? {
+                    EncodedValueRef::Null => {}
+                    EncodedValueRef::Float64(value) => {
+                        match prepare_double_value(value, java_double_bits) {
+                            Ok(value_supported) => supported &= value_supported,
+                            Err(error) if error.kind() == io::ErrorKind::Unsupported => {
+                                supported = false;
+                            }
+                            Err(error) => return Err(error),
+                        }
+                    }
+                    _ => return Err(encoded_type_mismatch(column.data_type())),
+                }
+            }
+            Ok(supported)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn prepare_double_value(value: f64, java_double_bits: &mut BTreeSet<u64>) -> io::Result<bool> {
+    if !value.is_finite() {
+        return Ok(false);
+    }
+    if !can_format_double_in_rust(value) {
+        let bits = value.to_bits();
+        if !java_double_bits.contains(&bits)
+            && java_double_bits.len() >= MAX_DISTINCT_JAVA_DOUBLE_VALUES
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "columnar JSON requires more than {} distinct Java-formatted DOUBLE values",
+                    MAX_DISTINCT_JAVA_DOUBLE_VALUES
+                ),
+            ));
+        }
+        java_double_bits.insert(bits);
+    }
+    Ok(true)
+}
+
+fn validate_decimal_column(column: EncodedColumn<'_>) -> io::Result<bool> {
+    match column.encoding() {
+        Encoding::AllNull => Ok(true),
+        Encoding::Const => {
+            if !has_non_null(&column) {
+                return Ok(true);
+            }
+            match column.constant()? {
+                Some(value) => {
+                    decode_decimal_value(column.data_type(), value)?;
+                    Ok(true)
+                }
+                None => Err(encoded_type_mismatch(column.data_type())),
+            }
+        }
+        Encoding::Dict | Encoding::Plain => {
+            for value in column.values() {
+                let value = value?;
+                if !matches!(value, EncodedValueRef::Null) {
+                    decode_decimal_value(column.data_type(), value)?;
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn decode_decimal_value(data_type: &DataType, value: EncodedValueRef<'_>) -> io::Result<i128> {
+    match (data_type, value) {
+        (DataType::Decimal128(precision, _), EncodedValueRef::DecimalCompact(value))
+            if *precision <= 18 =>
+        {
+            Ok(value as i128)
+        }
+        (DataType::Decimal128(precision, _), EncodedValueRef::DecimalLarge(bytes))
+            if *precision > 18 =>
+        {
+            decode_signed_i128(bytes)
+        }
+        _ => Err(encoded_type_mismatch(data_type)),
+    }
+}
+
+fn decode_signed_i128(bytes: &[u8]) -> io::Result<i128> {
+    if bytes.is_empty() || bytes.len() > 16 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Decimal128 byte width {}", bytes.len()),
+        ));
+    }
+    let negative = bytes[0] & 0x80 != 0;
+    let mut decoded = [if negative { 0xff } else { 0x00 }; 16];
+    decoded[16 - bytes.len()..].copy_from_slice(bytes);
+    Ok(i128::from_be_bytes(decoded))
+}
+
+fn validate_utf8_column(column: EncodedColumn<'_>) -> io::Result<bool> {
+    validate_utf8_column_with(column, |value| {
+        std::str::from_utf8(value).map_err(invalid_utf8)?;
+        Ok(())
+    })
+}
+
+fn validate_utf8_column_with<F>(
+    column: EncodedColumn<'_>,
+    mut validate_value: F,
+) -> io::Result<bool>
+where
+    F: FnMut(&[u8]) -> io::Result<()>,
+{
+    match column.encoding() {
+        Encoding::AllNull => Ok(true),
+        Encoding::Const => {
+            if !has_non_null(&column) {
+                return Ok(true);
+            }
+            match column.constant()? {
+                Some(EncodedValueRef::Utf8(value)) => {
+                    validate_value(value)?;
+                    Ok(true)
+                }
+                _ => Err(encoded_type_mismatch(column.data_type())),
+            }
+        }
+        Encoding::Dict => column.visit_dictionary(|value| match value {
+            EncodedValueRef::Utf8(value) => validate_value(value),
+            _ => Err(encoded_type_mismatch(column.data_type())),
+        }),
+        Encoding::Plain => {
+            for value in column.values() {
+                match value? {
+                    EncodedValueRef::Null => {}
+                    EncodedValueRef::Utf8(value) => {
+                        validate_value(value)?;
+                    }
+                    _ => return Err(encoded_type_mismatch(column.data_type())),
+                }
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn invalid_utf8(error: std::str::Utf8Error) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("invalid UTF-8 column value: {}", error),
+    )
+}
+
+fn has_non_null(column: &EncodedColumn<'_>) -> bool {
+    non_null_count(column) > 0
+}
+
+fn non_null_count(column: &EncodedColumn<'_>) -> usize {
+    if column.num_rows() == 0 || column.encoding() == Encoding::AllNull {
+        return 0;
+    }
+    let Some(bitmap) = column.null_bitmap() else {
+        return column.num_rows();
+    };
+
+    let full_bytes = column.num_rows() / 8;
+    let full_nulls: usize = bitmap[..full_bytes]
+        .iter()
+        .map(|byte| byte.count_ones() as usize)
+        .sum();
+    let remaining = column.num_rows() % 8;
+    let tail_nulls = if remaining == 0 {
+        0
+    } else {
+        (bitmap[full_bytes] & ((1u8 << remaining) - 1)).count_ones() as usize
+    };
+    column
+        .num_rows()
+        .saturating_sub(full_nulls.saturating_add(tail_nulls))
+}
+
+struct EncodedJsonWriter<'a, W> {
+    output: &'a mut W,
+    plan: &'a EncodedJsonPlan,
+    value_buffer: Vec<u8>,
+    repeated_buffer: Vec<u8>,
+    nullable_block_cache: Vec<Option<Vec<u8>>>,
+    nullable_cache_bytes: usize,
+    column_index: usize,
+}
+
+impl<W: Write> EncodedJsonWriter<'_, W> {
+    fn write_column(
+        &mut self,
+        name: &str,
+        data_type: &DataType,
+        column: EncodedColumn<'_>,
+    ) -> io::Result<()> {
+        if self.column_index > 0 {
+            self.output.write_all(b",")?;
+        }
+        self.column_index += 1;
+        self.output.write_all(b"\"")?;
+        write_escaped_utf8_chunked(self.output, name.as_bytes())?;
+        self.output.write_all(b"\":\"")?;
+        self.write_column_values(data_type, column)?;
+        self.output.write_all(b"\"")
+    }
+
+    fn write_column_values(
+        &mut self,
+        data_type: &DataType,
+        column: EncodedColumn<'_>,
+    ) -> io::Result<()> {
+        match column.encoding() {
+            Encoding::AllNull => write_null_entries(self.output, column.num_rows()),
+            Encoding::Const => self.write_constant(data_type, column),
+            Encoding::Dict | Encoding::Plain => {
+                for (row, value) in column.values().enumerate() {
+                    write_encoded_value(self.output, data_type, value?, row > 0, self.plan)?;
+                }
+                Ok(())
+            }
+            encoding => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported column encoding {:?}", encoding),
+            )),
+        }
+    }
+
+    fn write_constant(
+        &mut self,
+        data_type: &DataType,
+        column: EncodedColumn<'_>,
+    ) -> io::Result<()> {
+        if !has_non_null(&column) {
+            return write_null_entries(self.output, column.num_rows());
+        }
+        let value = column
+            .constant()?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing CONST value"))?;
+        if column.has_nulls() {
+            for block in &mut self.nullable_block_cache {
+                *block = None;
+            }
+            self.nullable_cache_bytes = 0;
+        }
+        if let (DataType::Utf8, EncodedValueRef::Utf8(value)) = (data_type, value) {
+            return write_utf8_constant(
+                self.output,
+                value,
+                column.num_rows(),
+                column.null_bitmap(),
+                &mut self.value_buffer,
+                &mut self.repeated_buffer,
+                &mut self.nullable_block_cache,
+                &mut self.nullable_cache_bytes,
+            );
+        }
+        self.value_buffer.clear();
+        write_encoded_value(&mut self.value_buffer, data_type, value, false, self.plan)?;
+        if column.has_nulls() {
+            return write_nullable_repeated_value(
+                self.output,
+                &self.value_buffer,
+                column,
+                &mut self.nullable_block_cache,
+                &mut self.nullable_cache_bytes,
+                &mut self.repeated_buffer,
+            );
+        }
+        write_repeated_value(
+            self.output,
+            &self.value_buffer,
+            column.num_rows(),
+            &mut self.repeated_buffer,
+        )
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_utf8_constant<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    row_count: usize,
+    null_bitmap: Option<&[u8]>,
+    value_buffer: &mut Vec<u8>,
+    repeated_buffer: &mut Vec<u8>,
+    block_cache: &mut [Option<Vec<u8>>],
+    cache_bytes: &mut usize,
+) -> io::Result<()> {
+    std::str::from_utf8(value).map_err(invalid_utf8)?;
+    if let Some(null_bitmap) = null_bitmap {
+        validate_null_bitmap(row_count, null_bitmap)?;
+    }
+    if is_oversized_escaped_utf8(value)? {
+        return write_utf8_rows_streamed(output, value, row_count, null_bitmap);
+    }
+
+    value_buffer.clear();
+    write_escaped_utf8(value_buffer, value)?;
+    match null_bitmap {
+        Some(null_bitmap) => write_nullable_repeated_rows(
+            output,
+            value_buffer,
+            row_count,
+            null_bitmap,
+            block_cache,
+            cache_bytes,
+            repeated_buffer,
+        ),
+        None => write_repeated_value(output, value_buffer, row_count, repeated_buffer),
+    }
+}
+
+fn is_oversized_escaped_utf8(value: &[u8]) -> io::Result<bool> {
+    Ok(escaped_utf8_len(value)? >= REPEATED_VALUE_BUFFER_BYTES)
+}
+
+fn write_utf8_rows_streamed<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    row_count: usize,
+    null_bitmap: Option<&[u8]>,
+) -> io::Result<()> {
+    for row in 0..row_count {
+        if row > 0 {
+            output.write_all(b",")?;
+        }
+        let is_null = null_bitmap
+            .map(|bitmap| bitmap[row / 8] & (1 << (row % 8)) != 0)
+            .unwrap_or(false);
+        if !is_null {
+            write_escaped_utf8_chunked(output, value)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_escaped_utf8_chunked<W: Write>(output: &mut W, value: &[u8]) -> io::Result<()> {
+    for chunk in value.chunks(REPEATED_VALUE_BUFFER_BYTES) {
+        write_escaped_utf8(output, chunk)?;
+    }
+    Ok(())
+}
+
+fn write_encoded_value<W: Write>(
+    output: &mut W,
+    data_type: &DataType,
+    value: EncodedValueRef<'_>,
+    separator: bool,
+    plan: &EncodedJsonPlan,
+) -> io::Result<()> {
+    if matches!(value, EncodedValueRef::Null) {
+        return if separator {
+            output.write_all(b",")
+        } else {
+            Ok(())
+        };
+    }
+
+    match (data_type, value) {
+        (DataType::Int8, EncodedValueRef::Int8(value)) => {
+            write_i64_value(output, value as i64, separator)
+        }
+        (DataType::Int16, EncodedValueRef::Int16(value)) => {
+            write_i64_value(output, value as i64, separator)
+        }
+        (DataType::Int32, EncodedValueRef::Int32(value)) => {
+            write_i64_value(output, value as i64, separator)
+        }
+        (DataType::Int64, EncodedValueRef::Int64(value)) => {
+            write_i64_value(output, value, separator)
+        }
+        (DataType::Float64, EncodedValueRef::Float64(value)) => {
+            write_exact_double(output, value, separator, plan)
+        }
+        (data_type @ DataType::Decimal128(_, scale), value) => write_decimal(
+            output,
+            decode_decimal_value(data_type, value)?,
+            *scale,
+            separator,
+        ),
+        (DataType::Utf8, EncodedValueRef::Utf8(value)) => {
+            std::str::from_utf8(value).map_err(invalid_utf8)?;
+            if separator {
+                output.write_all(b",")?;
+            }
+            write_escaped_utf8_chunked(output, value)
+        }
+        _ => Err(encoded_type_mismatch(data_type)),
+    }
+}
+
+fn write_repeated_value<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    row_count: usize,
+    repeated_buffer: &mut Vec<u8>,
+) -> io::Result<()> {
+    if row_count == 0 {
+        return Ok(());
+    }
+    if value.len() >= REPEATED_VALUE_BUFFER_BYTES {
+        repeated_buffer.clear();
+        write_bytes_chunked(output, value)?;
+        for _ in 1..row_count {
+            output.write_all(b",")?;
+            write_bytes_chunked(output, value)?;
+        }
+        return Ok(());
+    }
+    output.write_all(value)?;
+    let mut remaining = row_count - 1;
+    if remaining == 0 {
+        return Ok(());
+    }
+
+    let pattern_size = value.len().saturating_add(1);
+    let repeats_per_buffer = (REPEATED_VALUE_BUFFER_BYTES / pattern_size.max(1))
+        .max(1)
+        .min(remaining);
+    repeated_buffer.clear();
+    repeated_buffer.push(b',');
+    repeated_buffer.extend_from_slice(value);
+    let target_size = repeats_per_buffer * pattern_size;
+    while repeated_buffer.len() < target_size {
+        let current_size = repeated_buffer.len();
+        let copy_size = current_size.min(target_size - current_size);
+        repeated_buffer.extend_from_within(..copy_size);
+    }
+    while remaining >= repeats_per_buffer {
+        output.write_all(repeated_buffer)?;
+        remaining -= repeats_per_buffer;
+    }
+    if remaining > 0 {
+        output.write_all(&repeated_buffer[..remaining * pattern_size])?;
+    }
+    Ok(())
+}
+
+fn write_bytes_chunked<W: Write>(output: &mut W, value: &[u8]) -> io::Result<()> {
+    for chunk in value.chunks(REPEATED_VALUE_BUFFER_BYTES) {
+        output.write_all(chunk)?;
+    }
+    Ok(())
+}
+
+fn write_nullable_repeated_value<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    column: EncodedColumn<'_>,
+    block_cache: &mut [Option<Vec<u8>>],
+    cache_bytes: &mut usize,
+    scratch: &mut Vec<u8>,
+) -> io::Result<()> {
+    let null_bitmap = column.null_bitmap().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "nullable CONST column is missing its null bitmap",
+        )
+    })?;
+    write_nullable_repeated_rows(
+        output,
+        value,
+        column.num_rows(),
+        null_bitmap,
+        block_cache,
+        cache_bytes,
+        scratch,
+    )
+}
+
+fn write_nullable_repeated_rows<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    row_count: usize,
+    null_bitmap: &[u8],
+    block_cache: &mut [Option<Vec<u8>>],
+    cache_bytes: &mut usize,
+    scratch: &mut Vec<u8>,
+) -> io::Result<()> {
+    if block_cache.len() != NULLABLE_CONST_PATTERN_COUNT {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "nullable CONST block cache must contain 256 entries",
+        ));
+    }
+    validate_null_bitmap(row_count, null_bitmap)?;
+
+    if value.len().saturating_add(1).saturating_mul(8) > REPEATED_VALUE_BUFFER_BYTES {
+        return write_nullable_rows_bounded(output, value, row_count, null_bitmap, scratch);
+    }
+
+    let mut row = 0usize;
+    if row + 8 <= row_count {
+        scratch.clear();
+        append_nullable_const_block(scratch, value, !null_bitmap[0], 8, true);
+        output.write_all(scratch)?;
+        row += 8;
+    }
+
+    while row + 8 <= row_count {
+        let validity = !null_bitmap[row / 8];
+        let cache_index = validity as usize;
+        match &block_cache[cache_index] {
+            Some(block) => output.write_all(block)?,
+            None => {
+                scratch.clear();
+                append_nullable_const_block(scratch, value, validity, 8, false);
+                if cache_bytes.saturating_add(scratch.len()) <= NULLABLE_CONST_CACHE_BYTES {
+                    *cache_bytes += scratch.len();
+                    block_cache[cache_index] = Some(scratch.clone());
+                    output.write_all(block_cache[cache_index].as_ref().unwrap())?;
+                } else {
+                    output.write_all(scratch)?;
+                }
+            }
+        }
+        row += 8;
+    }
+
+    if row < row_count {
+        scratch.clear();
+        append_nullable_const_block(
+            scratch,
+            value,
+            !null_bitmap[row / 8],
+            row_count - row,
+            row == 0,
+        );
+        output.write_all(scratch)?;
+    }
+
+    Ok(())
+}
+
+fn validate_null_bitmap(row_count: usize, null_bitmap: &[u8]) -> io::Result<()> {
+    let required_bitmap_bytes = row_count.div_ceil(8);
+    if null_bitmap.len() < required_bitmap_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "nullable CONST null bitmap is truncated",
+        ));
+    }
+    Ok(())
+}
+
+fn write_nullable_rows_bounded<W: Write>(
+    output: &mut W,
+    value: &[u8],
+    row_count: usize,
+    null_bitmap: &[u8],
+    scratch: &mut Vec<u8>,
+) -> io::Result<()> {
+    scratch.clear();
+    for row in 0..row_count {
+        let is_null = null_bitmap[row / 8] & (1 << (row % 8)) != 0;
+        let row_size = usize::from(row > 0)
+            .checked_add(if is_null { 0 } else { value.len() })
+            .ok_or_else(text_size_overflow)?;
+        if !scratch.is_empty()
+            && scratch.len().saturating_add(row_size) > REPEATED_VALUE_BUFFER_BYTES
+        {
+            output.write_all(scratch)?;
+            scratch.clear();
+        }
+        if row_size > REPEATED_VALUE_BUFFER_BYTES {
+            if row > 0 {
+                output.write_all(b",")?;
+            }
+            if !is_null {
+                write_bytes_chunked(output, value)?;
+            }
+            continue;
+        }
+        if row > 0 {
+            scratch.push(b',');
+        }
+        if !is_null {
+            scratch.extend_from_slice(value);
+        }
+    }
+    if !scratch.is_empty() {
+        output.write_all(scratch)?;
+    }
+    Ok(())
+}
+
+fn append_nullable_const_block(
+    output: &mut Vec<u8>,
+    value: &[u8],
+    validity: u8,
+    rows: usize,
+    first_block: bool,
+) {
+    for row in 0..rows {
+        if !first_block || row > 0 {
+            output.push(b',');
+        }
+        if validity & (1 << row) != 0 {
+            output.extend_from_slice(value);
+        }
+    }
+}
+
+fn encoded_type_mismatch(data_type: &DataType) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("encoded value does not match column type {:?}", data_type),
+    )
+}
+
+fn write_null_entries<W: Write>(output: &mut W, row_count: usize) -> io::Result<()> {
+    let mut remaining = row_count.saturating_sub(1);
+    while remaining > 0 {
+        let written = remaining.min(COMMA_BLOCK.len());
+        output.write_all(&COMMA_BLOCK[..written])?;
+        remaining -= written;
+    }
+    Ok(())
+}
+
+fn write_i64<W: Write>(output: &mut W, value: i64) -> io::Result<()> {
+    write_i64_value(output, value, false)
+}
+
+fn write_i64_value<W: Write>(output: &mut W, value: i64, separator: bool) -> io::Result<()> {
+    let mut buffer = [0u8; 21];
+    let mut position = buffer.len();
+    let mut magnitude = value.unsigned_abs();
+    loop {
+        position -= 1;
+        buffer[position] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+        if magnitude == 0 {
+            break;
+        }
+    }
+    if value < 0 {
+        position -= 1;
+        buffer[position] = b'-';
+    }
+    if separator {
+        position -= 1;
+        buffer[position] = b',';
+    }
+    output.write_all(&buffer[position..])
+}
+
+fn write_decimal<W: Write>(
+    output: &mut W,
+    value: i128,
+    scale: i8,
+    separator: bool,
+) -> io::Result<()> {
+    if separator {
+        output.write_all(b",")?;
+    }
+    if value < 0 {
+        output.write_all(b"-")?;
+    }
+
+    let mut buffer = [0u8; 39];
+    let mut position = buffer.len();
+    let mut magnitude = value.unsigned_abs();
+    loop {
+        position -= 1;
+        buffer[position] = b'0' + (magnitude % 10) as u8;
+        magnitude /= 10;
+        if magnitude == 0 {
+            break;
+        }
+    }
+    let digits = &buffer[position..];
+
+    match scale.cmp(&0) {
+        std::cmp::Ordering::Equal => output.write_all(digits),
+        std::cmp::Ordering::Less => {
+            output.write_all(digits)?;
+            // BigDecimal.toPlainString() renders zero with a negative scale as "0".
+            if value == 0 {
+                Ok(())
+            } else {
+                write_zeroes(output, scale.unsigned_abs() as usize)
+            }
+        }
+        std::cmp::Ordering::Greater => {
+            let scale = scale as usize;
+            if digits.len() > scale {
+                let decimal_position = digits.len() - scale;
+                output.write_all(&digits[..decimal_position])?;
+                output.write_all(b".")?;
+                output.write_all(&digits[decimal_position..])
+            } else {
+                output.write_all(b"0.")?;
+                write_zeroes(output, scale - digits.len())?;
+                output.write_all(digits)
+            }
+        }
+    }
+}
+
+fn can_format_double_in_rust(value: f64) -> bool {
+    let bits = value.to_bits();
+    if bits == 0 || bits == (1u64 << 63) {
+        return true;
+    }
+
+    value.is_finite() && value.abs() >= MIN_EXACT_DOUBLE_ABS && value.abs() <= MAX_EXACT_DOUBLE_ABS
+}
+
+fn write_exact_double<W: Write>(
+    output: &mut W,
+    value: f64,
+    separator: bool,
+    plan: &EncodedJsonPlan,
+) -> io::Result<()> {
+    if can_format_double_in_rust(value) {
+        return write_double(output, value, separator);
+    }
+    if !value.is_finite() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "non-finite DOUBLE reached the columnar JSON writer",
+        ));
+    }
+    let rendered = plan.java_double_value(value.to_bits()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "missing Java DOUBLE rendering for 0x{:016x}",
+                value.to_bits()
+            ),
+        )
+    })?;
+    if separator {
+        output.write_all(b",")?;
+    }
+    output.write_all(rendered)
+}
+
+fn write_double<W: Write>(output: &mut W, value: f64, separator: bool) -> io::Result<()> {
+    let bits = value.to_bits();
+    if bits == 0 {
+        return output.write_all(if separator { b",0.0" } else { b"0.0" });
+    }
+    if bits == (1u64 << 63) {
+        return output.write_all(if separator { b",-0.0" } else { b"-0.0" });
+    }
+
+    let integer = value as i64;
+    if (-9_999_999..=9_999_999).contains(&integer) && value == integer as f64 {
+        write_i64_value(output, integer, separator)?;
+        return output.write_all(b".0");
+    }
+
+    let scaled = value * 10.0;
+    let unscaled = scaled as i64;
+    if value > -10_000_000.0
+        && value < 10_000_000.0
+        && scaled == unscaled as f64
+        && unscaled % 10 != 0
+        && unscaled as f64 / 10.0 == value
+    {
+        if separator {
+            output.write_all(b",")?;
+        }
+        if unscaled < 0 {
+            output.write_all(b"-")?;
+        }
+        let magnitude = unscaled.unsigned_abs();
+        write_i64(output, (magnitude / 10) as i64)?;
+        output.write_all(&[b'.', b'0' + (magnitude % 10) as u8])?;
+        return Ok(());
+    }
+
+    if separator {
+        output.write_all(b",")?;
+    }
+    let mut buffer = ryu::Buffer::new();
+    write_java_style_double(output, buffer.format_finite(value))
+}
+
+fn write_java_style_double<W: Write>(output: &mut W, raw: &str) -> io::Result<()> {
+    let bytes = raw.as_bytes();
+    let (sign, unsigned) = if bytes.first() == Some(&b'-') {
+        (Some(b'-'), &bytes[1..])
+    } else {
+        (None, bytes)
+    };
+    let exponent_index = unsigned
+        .iter()
+        .position(|value| *value == b'e' || *value == b'E');
+    let mantissa_end = exponent_index.unwrap_or(unsigned.len());
+    let exponent = match exponent_index {
+        Some(index) => parse_exponent(&unsigned[index + 1..])?,
+        None => 0,
+    };
+    let mantissa = &unsigned[..mantissa_end];
+    let dot_position = mantissa
+        .iter()
+        .position(|value| *value == b'.')
+        .unwrap_or(mantissa.len());
+
+    let mut digits = [0u8; 24];
+    let mut digits_len = 0;
+    let mut leading_zeroes = 0;
+    let mut significant = false;
+    for &value in mantissa {
+        if value == b'.' {
+            continue;
+        }
+        if !significant && value == b'0' {
+            leading_zeroes += 1;
+            continue;
+        }
+        significant = true;
+        digits[digits_len] = value;
+        digits_len += 1;
+    }
+    while digits_len > 1 && digits[digits_len - 1] == b'0' {
+        digits_len -= 1;
+    }
+    if digits_len == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid finite double rendering '{}'", raw),
+        ));
+    }
+
+    let decimal_position = dot_position as i32 + exponent - leading_zeroes;
+    if let Some(sign) = sign {
+        output.write_all(&[sign])?;
+    }
+    if decimal_position > 0 && decimal_position <= 7 {
+        let decimal_position = decimal_position as usize;
+        if digits_len <= decimal_position {
+            output.write_all(&digits[..digits_len])?;
+            write_zeroes(output, decimal_position - digits_len)?;
+            output.write_all(b".0")
+        } else {
+            output.write_all(&digits[..decimal_position])?;
+            output.write_all(b".")?;
+            output.write_all(&digits[decimal_position..digits_len])
+        }
+    } else if decimal_position > -3 && decimal_position <= 0 {
+        output.write_all(b"0.")?;
+        write_zeroes(output, (-decimal_position) as usize)?;
+        output.write_all(&digits[..digits_len])
+    } else {
+        output.write_all(&digits[..1])?;
+        output.write_all(b".")?;
+        if digits_len == 1 {
+            output.write_all(b"0")?;
+        } else {
+            output.write_all(&digits[1..digits_len])?;
+        }
+        output.write_all(b"E")?;
+        write_i64(output, (decimal_position - 1) as i64)
+    }
+}
+
+fn parse_exponent(value: &[u8]) -> io::Result<i32> {
+    let (negative, digits) = if value.first() == Some(&b'-') {
+        (true, &value[1..])
+    } else if value.first() == Some(&b'+') {
+        (false, &value[1..])
+    } else {
+        (false, value)
+    };
+    if digits.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "missing floating-point exponent",
+        ));
+    }
+    let mut exponent = 0i32;
+    for &digit in digits {
+        if !digit.is_ascii_digit() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid floating-point exponent",
+            ));
+        }
+        exponent = exponent
+            .checked_mul(10)
+            .and_then(|current| current.checked_add((digit - b'0') as i32))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "floating-point exponent overflow",
+                )
+            })?;
+    }
+    Ok(if negative { -exponent } else { exponent })
+}
+
+fn write_zeroes<W: Write>(output: &mut W, count: usize) -> io::Result<()> {
+    const ZEROES: &[u8; 32] = b"00000000000000000000000000000000";
+    let mut remaining = count;
+    while remaining > 0 {
+        let written = remaining.min(ZEROES.len());
+        output.write_all(&ZEROES[..written])?;
+        remaining -= written;
+    }
+    Ok(())
+}
+
+fn write_escaped_utf8<W: Write>(output: &mut W, value: &[u8]) -> io::Result<()> {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut safe_start = 0;
+    for (index, &current) in value.iter().enumerate() {
+        if current >= 0x20 && current != b'"' && current != b'\\' {
+            continue;
+        }
+        if safe_start < index {
+            output.write_all(&value[safe_start..index])?;
+        }
+        match current {
+            b'"' => output.write_all(b"\\\"")?,
+            b'\\' => output.write_all(b"\\\\")?,
+            b'\x08' => output.write_all(b"\\b")?,
+            b'\x0c' => output.write_all(b"\\f")?,
+            b'\n' => output.write_all(b"\\n")?,
+            b'\r' => output.write_all(b"\\r")?,
+            b'\t' => output.write_all(b"\\t")?,
+            value => {
+                output.write_all(&[
+                    b'\\',
+                    b'u',
+                    b'0',
+                    b'0',
+                    HEX[(value >> 4) as usize],
+                    HEX[(value & 0x0f) as usize],
+                ])?;
+            }
+        }
+        safe_start = index + 1;
+    }
+    if safe_start < value.len() {
+        output.write_all(&value[safe_start..])?;
+    }
+    Ok(())
+}
+
+fn escaped_utf8_len(value: &[u8]) -> io::Result<usize> {
+    let mut length = 0usize;
+    for current in value {
+        let bytes = match current {
+            b'"' | b'\\' | b'\x08' | b'\x0c' | b'\n' | b'\r' | b'\t' => 2,
+            0x00..=0x1f => 6,
+            _ => 1,
+        };
+        length = length.checked_add(bytes).ok_or_else(text_size_overflow)?;
+    }
+    Ok(length)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::io::{self, Write};
+    use std::mem::size_of;
+    use std::sync::Arc;
+
+    use arrow_array::{BooleanArray, Float64Array, Int32Array, RecordBatch};
+    use arrow_schema::DataType;
+    use arrow_schema::{Field, Schema};
+    use mosaic_core::bucket_reader::EncodedValueRef;
+    use mosaic_core::reader::{Encoding, InputFile, MosaicReader, ReaderAccess};
+    use mosaic_core::spec::{COMPRESSION_NONE, ENCODING_DICT};
+    use mosaic_core::writer::{MosaicWriter, OutputFile, WriterOptions};
+
+    use super::{
+        append_nullable_const_block, can_format_double_in_rust, decode_signed_i128,
+        escaped_utf8_len, has_supported_structure, integer_value_matches,
+        is_oversized_escaped_utf8, prepare_double_value, prepare_encoded,
+        validate_utf8_column_with, write_decimal, write_double, write_encoded_supported,
+        write_encoded_value, write_escaped_utf8, write_exact_double, write_nullable_repeated_rows,
+        write_repeated_value, write_utf8_constant, EncodedJsonPlan, EncodedJsonPreflight,
+        MAX_DISTINCT_JAVA_DOUBLE_VALUES, NULLABLE_CONST_CACHE_BYTES, NULLABLE_CONST_PATTERN_COUNT,
+        REPEATED_VALUE_BUFFER_BYTES,
+    };
+
+    #[derive(Default)]
+    struct MemoryOutput {
+        data: Vec<u8>,
+    }
+
+    impl OutputFile for MemoryOutput {
+        fn write(&mut self, data: &[u8]) -> io::Result<()> {
+            self.data.extend_from_slice(data);
+            Ok(())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn pos(&self) -> u64 {
+            self.data.len() as u64
+        }
+    }
+
+    struct MemoryInput {
+        data: Vec<u8>,
+    }
+
+    impl InputFile for MemoryInput {
+        fn read_at(&self, offset: u64, buffer: &mut [u8]) -> io::Result<()> {
+            let start = offset as usize;
+            let end = start
+                .checked_add(buffer.len())
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "read range overflow"))?;
+            let source = self
+                .data
+                .get(start..end)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "read past end"))?;
+            buffer.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct TrackingWriter {
+        output: Vec<u8>,
+        max_write: usize,
+    }
+
+    impl Write for TrackingWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.output.extend_from_slice(buffer);
+            self.max_write = self.max_write.max(buffer.len());
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn validates_integer_value_type_exactly() {
+        assert!(integer_value_matches(
+            &DataType::Int16,
+            EncodedValueRef::Int16(0)
+        ));
+        assert!(!integer_value_matches(
+            &DataType::Int16,
+            EncodedValueRef::Int32(0)
+        ));
+        assert!(!integer_value_matches(
+            &DataType::Int32,
+            EncodedValueRef::Int16(0)
+        ));
+    }
+
+    #[test]
+    fn checks_column_support_without_scanning_values() {
+        assert!(has_supported_structure(&DataType::Int32, Encoding::Plain));
+        assert!(has_supported_structure(
+            &DataType::Boolean,
+            Encoding::AllNull
+        ));
+        assert!(!has_supported_structure(&DataType::Boolean, Encoding::Dict));
+        assert!(!has_supported_structure(
+            &DataType::Utf8,
+            Encoding::Other(99)
+        ));
+    }
+
+    #[test]
+    fn reports_corrupt_supported_column_before_later_unsupported_column() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("z", DataType::Boolean, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 1, 2, 3, 1, 2])),
+                Arc::new(BooleanArray::from(vec![
+                    true, false, true, false, true, false, true, false,
+                ])),
+            ],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut data = writer.output().data.clone();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+        assert_eq!(data[2], 3);
+        // Header bytes: encoding/null flags, both dictionaries, then the first column's indexes.
+        // A two-bit dictionary index of 3 is outside the valid 0..3 range.
+        data[18] = (data[18] & !0x03) | 0x03;
+
+        let file_len = data.len() as u64;
+        let reader = MosaicReader::new(MemoryInput { data }, file_len).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let error = match prepare_encoded(&row_group) {
+            Ok(_) => panic!("corrupt dictionary index was accepted as normal fallback"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("corrupt dict index"));
+    }
+
+    #[test]
+    fn validates_each_utf8_dictionary_entry_once_while_scanning_all_indexes() {
+        let schema = Schema::new(vec![Field::new("text", DataType::Utf8, true)]);
+        let row_count = 4096;
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(arrow_array::StringArray::from_iter(
+                (0..row_count).map(|row| match row % 5 {
+                    0 => None,
+                    1 | 3 => Some("alpha"),
+                    _ => Some("beta"),
+                }),
+            ))],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let data = writer.output().data.clone();
+        let reader =
+            MosaicReader::new(MemoryInput { data }, writer.output().data.len() as u64).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let mut scans = 0usize;
+        let mut scanned_bytes = 0usize;
+        row_group
+            .visit_encoded_columns(|_name, _data_type, _nullable, column| {
+                assert_eq!(column.encoding(), Encoding::Dict);
+                assert!(validate_utf8_column_with(column, |value| {
+                    scans += 1;
+                    scanned_bytes += value.len();
+                    std::str::from_utf8(value)
+                        .map(|_| ())
+                        .map_err(super::invalid_utf8)
+                })?);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(scans, 2);
+        assert_eq!(scanned_bytes, "alpha".len() + "beta".len());
+    }
+
+    #[test]
+    fn rejects_invalid_utf8_dictionary_entry() {
+        let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(arrow_array::StringArray::from(vec![
+                "alpha", "beta", "alpha", "beta",
+            ]))],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut data = writer.output().data.clone();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+        assert_eq!(data[2], 2);
+        assert_eq!(data[3], 5);
+        data[4] = 0xff;
+
+        let file_len = data.len() as u64;
+        let reader = MosaicReader::new(MemoryInput { data }, file_len).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let plan = prepare_encoded(&row_group)
+            .unwrap()
+            .unwrap()
+            .complete(Vec::new())
+            .unwrap();
+        let error = write_encoded_supported(&row_group, &plan, &mut Vec::new()).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("invalid UTF-8 column value"));
+    }
+
+    #[test]
+    fn writer_validates_utf8_during_streaming_write() {
+        let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![Arc::new(arrow_array::StringArray::from(vec![
+                "alpha", "beta", "alpha", "beta",
+            ]))],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut data = writer.output().data.clone();
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+        data[4] = 0xff;
+
+        let file_len = data.len() as u64;
+        let reader = MosaicReader::new(MemoryInput { data }, file_len).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let preflight = prepare_encoded(&row_group)
+            .unwrap()
+            .expect("supported structure");
+        let plan = preflight.complete(Vec::new()).unwrap();
+        let mut output = Vec::new();
+        let error = write_encoded_supported(&row_group, &plan, &mut output).unwrap_err();
+
+        assert!(!output.is_empty());
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("invalid UTF-8 column value"));
+    }
+
+    #[test]
+    fn reports_corrupt_supported_column_after_earlier_unsupported_column() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("z", DataType::Boolean, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 1, 2, 3, 1, 2])),
+                Arc::new(BooleanArray::from(vec![
+                    true, false, true, false, true, false, true, false,
+                ])),
+            ],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut data = writer.output().data.clone();
+        let mut baseline =
+            MosaicReader::new(MemoryInput { data: data.clone() }, data.len() as u64).unwrap();
+        baseline.project(&["z", "a"]).unwrap();
+        let baseline_row_group = baseline.row_group_reader(0).unwrap();
+        assert!(prepare_encoded(&baseline_row_group).unwrap().is_none());
+
+        assert_eq!(data[0] & 0x03, ENCODING_DICT);
+        assert_eq!(data[2], 3);
+        data[18] = (data[18] & !0x03) | 0x03;
+
+        let file_len = data.len() as u64;
+        let mut reader = MosaicReader::new(MemoryInput { data }, file_len).unwrap();
+        reader.project(&["z", "a"]).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let error = match prepare_encoded(&row_group) {
+            Ok(_) => panic!("corrupt dictionary index was accepted as normal fallback"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("corrupt dict index"));
+    }
+
+    #[test]
+    fn reports_corrupt_column_after_double_cardinality_fallback() {
+        let row_count = MAX_DISTINCT_JAVA_DOUBLE_VALUES + 1;
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Float64, false),
+            Field::new("z", DataType::Int32, false),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Float64Array::from_iter_values(
+                    (1..=row_count as u64).map(f64::from_bits),
+                )),
+                Arc::new(Int32Array::from_iter_values(
+                    (0..row_count).map(|row| (row % 3 + 1) as i32),
+                )),
+            ],
+        )
+        .unwrap();
+        let mut writer = MosaicWriter::new(
+            MemoryOutput::default(),
+            &schema,
+            WriterOptions {
+                compression: COMPRESSION_NONE,
+                num_buckets: 2,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        writer.write_batch(&batch).unwrap();
+        writer.close().unwrap();
+
+        let mut data = writer.output().data.clone();
+        let reader =
+            MosaicReader::new(MemoryInput { data: data.clone() }, data.len() as u64).unwrap();
+        let buckets = reader.bucket_infos(0).unwrap();
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0].columns, vec![0]);
+        assert_eq!(buckets[1].columns, vec![1]);
+        let baseline_row_group = reader.row_group_reader(0).unwrap();
+        assert!(prepare_encoded(&baseline_row_group).unwrap().is_none());
+
+        let int_bucket_start = buckets[0].size;
+        assert_eq!(data[int_bucket_start] & 0x03, ENCODING_DICT);
+        assert_eq!(data[int_bucket_start + 2], 3);
+        // Single-column bucket: two header bytes, one-byte dictionary size, three i32 values.
+        let int_indexes_start = int_bucket_start + 2 + 1 + 3 * size_of::<i32>();
+        data[int_indexes_start] = (data[int_indexes_start] & !0x03) | 0x03;
+
+        let file_len = data.len() as u64;
+        let reader = MosaicReader::new(MemoryInput { data }, file_len).unwrap();
+        let row_group = reader.row_group_reader(0).unwrap();
+        let error = match prepare_encoded(&row_group) {
+            Ok(_) => panic!("corrupt dictionary index was accepted after DOUBLE fallback"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("corrupt dict index"));
+    }
+
+    #[test]
+    fn writes_nullable_const_bitmap_block() {
+        let mut output = Vec::new();
+        append_nullable_const_block(&mut output, b"-7", 0b1001_1010, 8, true);
+        assert_eq!(output, b",-7,,-7,-7,,,-7");
+
+        output.clear();
+        append_nullable_const_block(&mut output, b"x", 0b0000_0101, 3, false);
+        assert_eq!(output, b",x,,x");
+    }
+
+    #[test]
+    fn oversized_repeated_values_use_bounded_writes_and_buffer() {
+        let value = vec![b'x'; REPEATED_VALUE_BUFFER_BYTES + 17];
+        let mut output = TrackingWriter::default();
+        let mut repeated_buffer = Vec::new();
+
+        write_repeated_value(&mut output, &value, 3, &mut repeated_buffer).unwrap();
+
+        let mut expected = value.clone();
+        expected.push(b',');
+        expected.extend_from_slice(&value);
+        expected.push(b',');
+        expected.extend_from_slice(&value);
+        assert_eq!(output.output, expected);
+        assert!(output.max_write <= REPEATED_VALUE_BUFFER_BYTES);
+        assert!(repeated_buffer.len() <= REPEATED_VALUE_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn large_nullable_constants_use_bounded_writes_and_scratch() {
+        let value = vec![b'x'; REPEATED_VALUE_BUFFER_BYTES / 4 + 17];
+        let null_bitmap = [0b0001_0010];
+        let mut output = TrackingWriter::default();
+        let mut block_cache = (0..NULLABLE_CONST_PATTERN_COUNT)
+            .map(|_| None)
+            .collect::<Vec<_>>();
+        let mut cache_bytes = 0;
+        let mut scratch = Vec::new();
+
+        write_nullable_repeated_rows(
+            &mut output,
+            &value,
+            8,
+            &null_bitmap,
+            &mut block_cache,
+            &mut cache_bytes,
+            &mut scratch,
+        )
+        .unwrap();
+
+        let mut expected = Vec::new();
+        for row in 0..8 {
+            if row > 0 {
+                expected.push(b',');
+            }
+            if null_bitmap[0] & (1 << row) == 0 {
+                expected.extend_from_slice(&value);
+            }
+        }
+        assert_eq!(output.output, expected);
+        assert!(output.max_write <= REPEATED_VALUE_BUFFER_BYTES);
+        assert!(scratch.len() <= REPEATED_VALUE_BUFFER_BYTES);
+        assert_eq!(cache_bytes, 0);
+    }
+
+    #[test]
+    fn nullable_const_cache_stays_within_its_total_budget() {
+        let value = vec![b'x'; 511];
+        let null_bitmap = (0u8..=u8::MAX).collect::<Vec<_>>();
+        let row_count = null_bitmap.len() * 8;
+        let mut output = TrackingWriter::default();
+        let mut block_cache = (0..NULLABLE_CONST_PATTERN_COUNT)
+            .map(|_| None)
+            .collect::<Vec<_>>();
+        let mut cache_bytes = 0;
+        let mut scratch = Vec::new();
+
+        write_nullable_repeated_rows(
+            &mut output,
+            &value,
+            row_count,
+            &null_bitmap,
+            &mut block_cache,
+            &mut cache_bytes,
+            &mut scratch,
+        )
+        .unwrap();
+
+        let mut expected = Vec::new();
+        for row in 0..row_count {
+            if row > 0 {
+                expected.push(b',');
+            }
+            if null_bitmap[row / 8] & (1 << (row % 8)) == 0 {
+                expected.extend_from_slice(&value);
+            }
+        }
+        let retained_cache_bytes: usize = block_cache
+            .iter()
+            .filter_map(|block| block.as_ref())
+            .map(Vec::len)
+            .sum();
+        assert_eq!(output.output, expected);
+        assert_eq!(cache_bytes, retained_cache_bytes);
+        assert!(cache_bytes <= NULLABLE_CONST_CACHE_BYTES);
+        assert!(scratch.len() <= REPEATED_VALUE_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn oversized_utf8_constants_stream_without_staging() {
+        let mut value = vec![b'x'; REPEATED_VALUE_BUFFER_BYTES + 17];
+        value[1] = b'"';
+        value[2] = b'\\';
+        value[3] = b'\n';
+        value[4] = 0x01;
+        let null_bitmap = [0b0000_0010];
+        let mut output = TrackingWriter::default();
+        let mut value_buffer = b"value sentinel".to_vec();
+        let mut repeated_buffer = b"repeated sentinel".to_vec();
+        let mut block_cache = (0..NULLABLE_CONST_PATTERN_COUNT)
+            .map(|_| None)
+            .collect::<Vec<_>>();
+        let mut cache_bytes = 0;
+
+        write_utf8_constant(
+            &mut output,
+            &value,
+            3,
+            Some(&null_bitmap),
+            &mut value_buffer,
+            &mut repeated_buffer,
+            &mut block_cache,
+            &mut cache_bytes,
+        )
+        .unwrap();
+
+        let mut escaped = Vec::new();
+        write_escaped_utf8(&mut escaped, &value).unwrap();
+        let mut expected = escaped.clone();
+        expected.extend_from_slice(b",,");
+        expected.extend_from_slice(&escaped);
+        assert_eq!(output.output, expected);
+        assert!(output.max_write <= REPEATED_VALUE_BUFFER_BYTES);
+        assert_eq!(value_buffer, b"value sentinel");
+        assert_eq!(repeated_buffer, b"repeated sentinel");
+    }
+
+    #[test]
+    fn oversized_plain_or_dict_utf8_values_use_bounded_writes() {
+        let mut value = vec![b'x'; REPEATED_VALUE_BUFFER_BYTES + 17];
+        value[1] = b'"';
+        value[2] = b'\\';
+        value[3] = b'\n';
+        value[4] = 0x01;
+        let mut output = TrackingWriter::default();
+
+        write_encoded_value(
+            &mut output,
+            &DataType::Utf8,
+            EncodedValueRef::Utf8(&value),
+            false,
+            &EncodedJsonPlan::default(),
+        )
+        .unwrap();
+
+        let mut expected = Vec::new();
+        write_escaped_utf8(&mut expected, &value).unwrap();
+        assert_eq!(output.output, expected);
+        assert!(output.max_write <= REPEATED_VALUE_BUFFER_BYTES);
+    }
+
+    #[test]
+    fn escaped_size_selects_streaming_at_the_buffer_limit() {
+        let safe = vec![b'x'; REPEATED_VALUE_BUFFER_BYTES - 1];
+        assert!(!is_oversized_escaped_utf8(&safe).unwrap());
+
+        let mut escaped_to_limit = safe;
+        escaped_to_limit[0] = b'"';
+        assert!(is_oversized_escaped_utf8(&escaped_to_limit).unwrap());
+    }
+
+    #[test]
+    fn writes_java_style_fallback_doubles() {
+        let values = [
+            1.25,
+            0.0001,
+            10_000_000.0,
+            429_496_729.5,
+            1_812_576.4000000001,
+        ];
+        let mut output = Vec::new();
+        for (index, value) in values.into_iter().enumerate() {
+            write_double(&mut output, value, index > 0).unwrap();
+        }
+        assert_eq!(
+            output,
+            b"1.25,1.0E-4,1.0E7,4.294967295E8,1812576.4000000001"
+        );
+    }
+
+    #[test]
+    fn writes_integer_and_one_decimal_double_fast_paths() {
+        let values = [
+            1.0,
+            -1.0,
+            1_234_567.0,
+            -1_234_567.0,
+            9_999_999.0,
+            -9_999_999.0,
+            1.2,
+            -1.2,
+            1_234_567.8,
+            -1_234_567.8,
+        ];
+        let mut output = Vec::new();
+        for (index, value) in values.into_iter().enumerate() {
+            write_double(&mut output, value, index > 0).unwrap();
+        }
+        assert_eq!(
+            output,
+            b"1.0,-1.0,1234567.0,-1234567.0,9999999.0,-9999999.0,\
+1.2,-1.2,1234567.8,-1234567.8"
+        );
+    }
+
+    #[test]
+    fn identifies_doubles_formatted_in_rust() {
+        let minimum = 1.0e-6_f64;
+        let below_minimum = f64::from_bits(minimum.to_bits() - 1);
+        let above_minimum = f64::from_bits(minimum.to_bits() + 1);
+        let maximum = 1.0e9_f64;
+        let below_maximum = f64::from_bits(maximum.to_bits() - 1);
+        let above_maximum = f64::from_bits(maximum.to_bits() + 1);
+
+        for value in [
+            0.0,
+            -0.0,
+            minimum,
+            above_minimum,
+            -minimum,
+            -above_minimum,
+            below_maximum,
+            maximum,
+            -below_maximum,
+            -maximum,
+            1_234_567.0,
+            -1_234_567.0,
+            1_234_567.8,
+            -1_234_567.8,
+        ] {
+            assert!(can_format_double_in_rust(value), "{value}");
+        }
+        for value in [below_minimum, -below_minimum, above_maximum, -above_maximum] {
+            assert!(!can_format_double_in_rust(value), "{value}");
+        }
+        assert!(!can_format_double_in_rust(f64::MIN_POSITIVE));
+        assert!(!can_format_double_in_rust(f64::INFINITY));
+        assert!(!can_format_double_in_rust(f64::NAN));
+    }
+
+    #[test]
+    fn routes_double_boundary_neighbors_to_rust_or_java() {
+        let minimum = 1.0e-6_f64;
+        let below_minimum = f64::from_bits(minimum.to_bits() - 1);
+        let above_minimum = f64::from_bits(minimum.to_bits() + 1);
+        let maximum = 1.0e9_f64;
+        let below_maximum = f64::from_bits(maximum.to_bits() - 1);
+        let above_maximum = f64::from_bits(maximum.to_bits() + 1);
+        let mut java_double_bits = BTreeSet::new();
+
+        for value in [
+            minimum,
+            above_minimum,
+            -minimum,
+            -above_minimum,
+            below_maximum,
+            maximum,
+            -below_maximum,
+            -maximum,
+        ] {
+            assert!(prepare_double_value(value, &mut java_double_bits).unwrap());
+        }
+        assert!(java_double_bits.is_empty());
+
+        for value in [below_minimum, -below_minimum, above_maximum, -above_maximum] {
+            assert!(prepare_double_value(value, &mut java_double_bits).unwrap());
+        }
+        assert_eq!(
+            java_double_bits,
+            [
+                below_minimum.to_bits(),
+                (-below_minimum).to_bits(),
+                above_maximum.to_bits(),
+                (-above_maximum).to_bits(),
+            ]
+            .into_iter()
+            .collect()
+        );
+    }
+
+    #[test]
+    fn writes_java_supplied_double_text_exactly() {
+        let value = f64::from_bits(0x3d20_0000_0000_0000);
+        let plan = EncodedJsonPreflight {
+            java_double_bits: vec![value.to_bits()],
+        }
+        .complete(vec![b"2.8421709430404007E-14".to_vec()])
+        .unwrap();
+
+        let mut output = Vec::new();
+        write_exact_double(&mut output, value, true, &plan).unwrap();
+        assert_eq!(output, b",2.8421709430404007E-14");
+    }
+
+    #[test]
+    fn rejects_java_double_text_for_a_different_value() {
+        let value = f64::from_bits(0x3d20_0000_0000_0000);
+        let preflight = EncodedJsonPreflight {
+            java_double_bits: vec![value.to_bits()],
+        };
+        let error = match preflight.complete(vec![b"1.0".to_vec()]) {
+            Ok(_) => panic!("mismatched Java DOUBLE text was accepted"),
+            Err(error) => error,
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("does not round-trip"));
+    }
+
+    #[test]
+    fn bounds_java_formatted_double_cardinality() {
+        let mut values = BTreeSet::new();
+        for bits in 1..=MAX_DISTINCT_JAVA_DOUBLE_VALUES as u64 {
+            assert!(prepare_double_value(f64::from_bits(bits), &mut values).unwrap());
+        }
+        let error = prepare_double_value(
+            f64::from_bits(MAX_DISTINCT_JAVA_DOUBLE_VALUES as u64 + 1),
+            &mut values,
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Unsupported);
+        assert!(error.to_string().contains("Java-formatted DOUBLE"));
+    }
+
+    #[test]
+    fn writes_decimal_plain_strings_for_all_scales() {
+        let mut output = Vec::new();
+        write_decimal(&mut output, 12_340, 3, false).unwrap();
+        write_decimal(&mut output, -5, 3, true).unwrap();
+        write_decimal(&mut output, 123, -2, true).unwrap();
+        write_decimal(&mut output, 0, -2, true).unwrap();
+        write_decimal(&mut output, 0, 3, true).unwrap();
+        assert_eq!(output, b"12.340,-0.005,12300,0,0.000");
+    }
+
+    #[test]
+    fn decodes_signed_big_endian_decimal_values() {
+        assert_eq!(decode_signed_i128(&[0xff]).unwrap(), -1);
+        assert_eq!(decode_signed_i128(&[0x00, 0x80]).unwrap(), 128);
+        assert_eq!(
+            decode_signed_i128(&i128::MIN.to_be_bytes()).unwrap(),
+            i128::MIN
+        );
+        assert!(decode_signed_i128(&[]).is_err());
+        assert!(decode_signed_i128(&[0; 17]).is_err());
+    }
+
+    #[test]
+    fn escaped_length_matches_written_bytes() {
+        let value = b"a\"\\\n\t\x01z";
+        let mut output = Vec::new();
+        write_escaped_utf8(&mut output, value).unwrap();
+        assert_eq!(escaped_utf8_len(value).unwrap(), output.len());
+        assert_eq!(output, br#"a\"\\\n\t\u0001z"#);
+    }
+}

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -17,7 +17,7 @@
 
 use std::error::Error;
 use std::fmt;
-use std::io;
+use std::io::{self, BufWriter, Write};
 use std::panic::{self, AssertUnwindSafe};
 use std::ptr;
 use std::sync::Arc;
@@ -26,7 +26,7 @@ use jni::errors::Error as JniError;
 use jni::objects::{
     GlobalRef, JByteArray, JClass, JMethodID, JObject, JObjectArray, JString, JThrowable, JValue,
 };
-use jni::sys::{jint, jlong, jlongArray};
+use jni::sys::{jboolean, jint, jlong, jlongArray};
 use jni::JNIEnv;
 use jni::JavaVM;
 
@@ -37,6 +37,8 @@ use arrow_schema::Schema;
 use mosaic_core::reader::{InputFile, MosaicReader, ReaderAccess, RowGroupReader};
 use mosaic_core::spec::*;
 use mosaic_core::writer::{MosaicWriter, OutputFile, WriterOptions};
+
+mod columnar_text_json;
 
 fn panic_message(e: &Box<dyn std::any::Any + Send>) -> String {
     if let Some(s) = e.downcast_ref::<String>() {
@@ -196,6 +198,57 @@ impl OutputFile for JniOutputFile {
     fn pos(&self) -> u64 {
         self.pos
     }
+}
+
+impl Write for JniOutputFile {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        OutputFile::write(self, data)?;
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        OutputFile::flush(self)
+    }
+}
+
+fn new_jni_output_file(
+    env: &mut JNIEnv<'_>,
+    stream: &JObject<'_>,
+) -> Result<JniOutputFile, String> {
+    let stream_ref = env
+        .new_global_ref(stream)
+        .map_err(|error| format!("failed to create output global ref: {}", error))?;
+    if env
+        .exception_check()
+        .map_err(|error| format!("failed to check output global ref exception: {}", error))?
+    {
+        return Err("failed to create output global ref: Java exception was thrown".to_string());
+    }
+    if stream_ref.as_obj().is_null() {
+        return Err("failed to create output global ref: NewGlobalRef returned null".to_string());
+    }
+
+    let write_mid = env
+        .get_method_id("java/io/OutputStream", "write", "([BII)V")
+        .map_err(|error| format!("cannot find OutputStream.write: {}", error))?;
+    let flush_mid = env
+        .get_method_id("java/io/OutputStream", "flush", "()V")
+        .map_err(|error| format!("cannot find OutputStream.flush: {}", error))?;
+    let jvm = env
+        .get_java_vm()
+        .map(Arc::new)
+        .map_err(|error| format!("cannot get JavaVM: {}", error))?;
+
+    Ok(JniOutputFile {
+        jvm,
+        stream_ref,
+        write_mid,
+        flush_mid,
+        pos: 0,
+        cached_array: None,
+        cached_array_len: 0,
+        pending_exception: None,
+    })
 }
 
 // ======================== JniInputFile ========================
@@ -777,6 +830,18 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeWriterWrite
 
 struct RowGroupReaderHandle {
     inner: RowGroupReader,
+    #[cfg(test)]
+    _drop_probe: Option<RowGroupReaderDropProbe>,
+}
+
+#[cfg(test)]
+struct RowGroupReaderDropProbe(Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(test)]
+impl Drop for RowGroupReaderDropProbe {
+    fn drop(&mut self) {
+        self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 #[no_mangle]
@@ -913,7 +978,11 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeReaderOpenR
         let rh = unsafe { &*(handle as *const ReaderHandle) };
         match rh.reader.row_group_reader(rg_index as usize) {
             Ok(rg) => {
-                let rg_handle = Box::new(RowGroupReaderHandle { inner: rg });
+                let rg_handle = Box::new(RowGroupReaderHandle {
+                    inner: rg,
+                    #[cfg(test)]
+                    _drop_probe: None,
+                });
                 Box::into_raw(rg_handle) as jlong
             }
             Err(e) => {
@@ -999,8 +1068,8 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupRea
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderFree(
-    _env: JNIEnv,
-    _class: JClass,
+    _env: *mut jni::sys::JNIEnv,
+    _class: jni::sys::jclass,
     handle: jlong,
 ) {
     if handle != 0 {
@@ -1203,5 +1272,230 @@ pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupRea
             throw(&mut env, &panic_message(&e));
             -1
         }
+    }
+}
+
+// ======================== Columnar Text JSON ========================
+
+fn format_columnar_json_doubles(
+    env: &mut JNIEnv<'_>,
+    class: &JClass<'_>,
+    bits: &[u64],
+) -> Result<Vec<Vec<u8>>, String> {
+    if bits.is_empty() {
+        return Ok(Vec::new());
+    }
+    let bits_array = env
+        .new_long_array(bits.len() as i32)
+        .map_err(|error| format!("failed to allocate DOUBLE bits array: {}", error))?;
+    let java_bits: Vec<jlong> = bits.iter().map(|bits| *bits as jlong).collect();
+    env.set_long_array_region(&bits_array, 0, &java_bits)
+        .map_err(|error| format!("failed to populate DOUBLE bits array: {}", error))?;
+
+    let result = env
+        .call_static_method(
+            class,
+            "formatColumnarTextJsonDoubles",
+            "([J)[Ljava/lang/String;",
+            &[JValue::Object(bits_array.as_ref())],
+        )
+        .map_err(|error| format!("failed to format DOUBLE values in Java: {}", error))?
+        .l()
+        .map_err(|error| format!("Java DOUBLE formatter returned a non-object: {}", error))?;
+    if result.is_null() {
+        return Err("Java DOUBLE formatter returned null".to_string());
+    }
+    let values_array = JObjectArray::from(result);
+    let length = env
+        .get_array_length(&values_array)
+        .map_err(|error| format!("failed to read Java DOUBLE strings length: {}", error))?;
+    if length as usize != bits.len() {
+        return Err(format!(
+            "Java DOUBLE formatter returned {} strings for {} values",
+            length,
+            bits.len()
+        ));
+    }
+
+    let mut values = Vec::with_capacity(bits.len());
+    for index in 0..length {
+        let object = env
+            .get_object_array_element(&values_array, index)
+            .map_err(|error| format!("failed to read Java DOUBLE string: {}", error))?;
+        if object.is_null() {
+            return Err(format!(
+                "Java DOUBLE formatter returned null at index {}",
+                index
+            ));
+        }
+        let string = JString::from(object);
+        // SAFETY: formatColumnarTextJsonDoubles has the JNI return type String[], and the element was
+        // checked for null above. Avoid get_string's per-element class local references.
+        let value: String = unsafe { env.get_string_unchecked(&string) }
+            .map_err(|error| format!("failed to copy Java DOUBLE string: {}", error))?
+            .into();
+        env.delete_local_ref(string)
+            .map_err(|error| format!("failed to release Java DOUBLE string: {}", error))?;
+        values.push(value.into_bytes());
+    }
+    Ok(values)
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderWriteColumnarTextJson(
+    mut env: JNIEnv,
+    class: JClass,
+    handle: jlong,
+    output: JObject,
+) -> jboolean {
+    const JSON_BUFFER_BYTES: usize = 1024 * 1024;
+
+    let raw_env = env.get_raw();
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        if handle == 0 {
+            throw(&mut env, "null row group handle");
+            return 0;
+        }
+
+        let row_group = unsafe { &*(handle as *const RowGroupReaderHandle) };
+        let preflight_result = columnar_text_json::prepare_encoded(&row_group.inner);
+        let preflight = match preflight_result {
+            Ok(None) => return 0,
+            Ok(Some(preflight)) => preflight,
+            Err(error) => {
+                throw_io_error(
+                    &mut env,
+                    &error,
+                    &format!("columnar text JSON compatibility check failed: {}", error),
+                );
+                return 0;
+            }
+        };
+        let double_values =
+            match format_columnar_json_doubles(&mut env, &class, preflight.java_double_bits()) {
+                Ok(values) => values,
+                Err(error) => {
+                    throw(
+                        &mut env,
+                        &format!("columnar text JSON DOUBLE formatting failed: {}", error),
+                    );
+                    return 0;
+                }
+            };
+        let plan_result = preflight.complete(double_values);
+        let plan = match plan_result {
+            Ok(plan) => plan,
+            Err(error) => {
+                throw(
+                    &mut env,
+                    &format!("columnar text JSON DOUBLE validation failed: {}", error),
+                );
+                return 0;
+            }
+        };
+
+        let output = match new_jni_output_file(&mut env, &output) {
+            Ok(output) => output,
+            Err(error) => {
+                throw(&mut env, &error);
+                return 0;
+            }
+        };
+        let mut buffered = BufWriter::with_capacity(JSON_BUFFER_BYTES, output);
+        if let Err(error) =
+            columnar_text_json::write_encoded_supported(&row_group.inner, &plan, &mut buffered)
+        {
+            let (mut output, _) = buffered.into_parts();
+            let pending = output.take_pending_exception();
+            match pending {
+                Some(exception) => rethrow(&mut env, &exception),
+                None => throw(
+                    &mut env,
+                    &format!("columnar text JSON write failed: {}", error),
+                ),
+            }
+            return 0;
+        }
+
+        match buffered.into_inner() {
+            Ok(_) => 1,
+            Err(error) => {
+                let message = error.error().to_string();
+                let (mut output, _) = error.into_inner().into_parts();
+                let pending = output.take_pending_exception();
+                match pending {
+                    Some(exception) => rethrow(&mut env, &exception),
+                    None => throw(
+                        &mut env,
+                        &format!("columnar text JSON output failed: {}", message),
+                    ),
+                }
+                0
+            }
+        }
+    }));
+    match result {
+        Ok(value) => value,
+        Err(error) => {
+            let mut env = unsafe { JNIEnv::from_raw(raw_env).unwrap() };
+            throw(&mut env, &panic_message(&error));
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    struct MemoryInput {
+        data: &'static [u8],
+    }
+
+    impl InputFile for MemoryInput {
+        fn read_at(&self, offset: u64, buffer: &mut [u8]) -> io::Result<()> {
+            let start = offset as usize;
+            let end = start
+                .checked_add(buffer.len())
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "read overflow"))?;
+            let source = self
+                .data
+                .get(start..end)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "read past end"))?;
+            buffer.copy_from_slice(source);
+            Ok(())
+        }
+    }
+
+    fn test_row_group_reader() -> RowGroupReader {
+        let data = include_bytes!("../../core/tests/testdata/v1_no_array.mosaic");
+        let length = data.len() as u64;
+        let reader = MosaicReader::new(MemoryInput { data }, length).unwrap();
+        reader.row_group_reader(0).unwrap()
+    }
+
+    #[test]
+    fn native_row_group_reader_free_drops_handle() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let handle = Box::into_raw(Box::new(RowGroupReaderHandle {
+            inner: test_row_group_reader(),
+            _drop_probe: Some(RowGroupReaderDropProbe(Arc::clone(&dropped))),
+        })) as jlong;
+
+        Java_org_apache_paimon_mosaic_NativeLib_nativeRowGroupReaderFree(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            handle,
+        );
+
+        let was_dropped = dropped.load(Ordering::SeqCst);
+        if !was_dropped {
+            // Reclaim the handle before failing if the function under test did not free it.
+            unsafe { drop(Box::from_raw(handle as *mut RowGroupReaderHandle)) };
+        }
+        assert!(was_dropped, "JNI free did not drop the row-group handle");
     }
 }


### PR DESCRIPTION
## What

Add a Java API for streaming a prepared Mosaic row group as a JSON object whose values are comma-separated text columns, directly from Mosaic's native encodings and without materializing intermediate Arrow arrays.

## Example

Given a prepared Mosaic row group with these logical rows:

| Row | `timestamp` | `speed` | `state` |
| ---: | ----------: | ------: | ------- |
| 0 | 1 | 10 | `on` |
| 1 | 2 | `null` | `off` |
| 2 | 3 | 12 | `null` |

`ColumnarTextJsonWriter.write(rowGroup, output)` streams one JSON object:

```json
{"timestamp":"1,2,3","speed":"10,,12","state":"on,off,"}
```

Each JSON key is a projected column. Its string contains that column's values in logical row order, separated by commas. In other words, the three input rows above become one column-oriented text object rather than three row-oriented JSON objects.

This format is intentionally a text aggregation format, not a lossless typed serialization: `null` and an empty string both produce an empty entry, and commas inside string values remain literal.

The fast path changes the execution flow from:

```text
Mosaic encodings -> Arrow vectors -> Java serialization
```

to:

```text
Mosaic encodings -> native text writer -> OutputStream
```

The implementation:

- supports signed integers, `DOUBLE`, `Decimal128`, and UTF-8 values in `ALL_NULL`, `CONST`, `DICT`, and `PLAIN` encodings;
- preserves JVM-compatible `Double.toString` and `BigDecimal.toPlainString` output;
- returns `UNSUPPORTED` before touching the output when the row group requires fallback;
- keeps ownership of the caller's `OutputStream` with the caller;
- exposes a reusable `MosaicRowGroupReader` for fast-path attempts followed by Arrow fallback; and
- prevents concurrent or reentrant row-group operations while safely deferring native release when `close()` races an active operation.

The format, supported types, fallback behavior, and ownership rules are documented in `docs/columnar-text-json.md`.

## Why

Wide Mosaic files often contain many `CONST` and `ALL_NULL` columns. Reading those encodings directly avoids expanding every logical cell into Arrow vectors when a downstream interface only needs column-oriented text.

## Validation

Tests cover:

- primitive, dictionary, constant, all-null, and projected output;
- JVM-exact double formatting and decimal scales;
- unsupported and malformed encodings;
- partial-output and `OutputStream` exception behavior;
- output ownership; and
- reentrant use, concurrent close, idempotent close, and use-after-close lifecycle cases.

The source branch's identical tree passed the repository's `check`, `rust-test`, `cpp-test`, `java-test`, and `python-test` CI jobs.
